### PR TITLE
fix(security): 收敛前端注入面并启用 Tauri CSP

### DIFF
--- a/apps/src-tauri/tauri.conf.json
+++ b/apps/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:* http://127.0.0.1:*; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     }
   },
   "bundle": {

--- a/apps/src/views/accounts.js
+++ b/apps/src/views/accounts.js
@@ -68,7 +68,12 @@ export function renderAccounts({ onUpdateSort, onOpenUsage, onDelete }) {
     const secondaryRemain = remainingPercent(
       usage ? usage.secondaryUsedPercent : null,
     );
-    accountWrap.innerHTML = `<strong>${account.label}</strong><small>${account.id}${workspaceLabel}</small>`;
+    const accountTitle = document.createElement("strong");
+    accountTitle.textContent = account.label || "-";
+    const accountMeta = document.createElement("small");
+    accountMeta.textContent = `${account.id || "-"}${workspaceLabel}`;
+    accountWrap.appendChild(accountTitle);
+    accountWrap.appendChild(accountMeta);
     const mini = document.createElement("div");
     mini.className = "mini-usage";
     mini.appendChild(
@@ -108,7 +113,9 @@ export function renderAccounts({ onUpdateSort, onOpenUsage, onDelete }) {
     cellStatus.appendChild(statusTag);
 
     const cellUpdated = document.createElement("td");
-    cellUpdated.innerHTML = `<strong>${usage && usage.capturedAt ? formatTs(usage.capturedAt) : "未知"}</strong>`;
+    const updatedText = document.createElement("strong");
+    updatedText.textContent = usage && usage.capturedAt ? formatTs(usage.capturedAt) : "未知";
+    cellUpdated.appendChild(updatedText);
 
     const cellActions = document.createElement("td");
     const actionsWrap = document.createElement("div");

--- a/apps/src/views/dashboard.js
+++ b/apps/src/views/dashboard.js
@@ -40,7 +40,10 @@ function renderCurrentAccount(accounts, usageMap) {
   if (!dom.currentAccountCard) return;
   dom.currentAccountCard.innerHTML = "";
   if (!accounts.length) {
-    dom.currentAccountCard.innerHTML = "<div class=\"hint\">暂无账号</div>";
+    const empty = document.createElement("div");
+    empty.className = "hint";
+    empty.textContent = "暂无账号";
+    dom.currentAccountCard.appendChild(empty);
     return;
   }
   const account = accounts[0];
@@ -49,7 +52,9 @@ function renderCurrentAccount(accounts, usageMap) {
 
   const header = document.createElement("div");
   header.className = "panel-header";
-  header.innerHTML = "<h3>当前账号</h3>";
+  const title = document.createElement("h3");
+  title.textContent = "当前账号";
+  header.appendChild(title);
   const statusTag = document.createElement("span");
   statusTag.className = "status-tag";
   statusTag.textContent = status.text;
@@ -63,7 +68,12 @@ function renderCurrentAccount(accounts, usageMap) {
   const summary = document.createElement("div");
   summary.className = "cell";
   const workspaceLabel = account.workspaceName ? ` · ${account.workspaceName}` : "";
-  summary.innerHTML = `<strong>${account.label}</strong><small>${account.id}${workspaceLabel}</small>`;
+  const summaryTitle = document.createElement("strong");
+  summaryTitle.textContent = account.label || "-";
+  const summaryMeta = document.createElement("small");
+  summaryMeta.textContent = `${account.id || "-"}${workspaceLabel}`;
+  summary.appendChild(summaryTitle);
+  summary.appendChild(summaryMeta);
   dom.currentAccountCard.appendChild(summary);
 
   const usageWrap = document.createElement("div");
@@ -94,7 +104,13 @@ function renderRecommendations(accounts, usageMap) {
   dom.recommendations.innerHTML = "";
   const header = document.createElement("div");
   header.className = "panel-header";
-  header.innerHTML = "<h3>最佳账号推荐</h3><span class=\"hint\">按剩余额度</span>";
+  const title = document.createElement("h3");
+  title.textContent = "最佳账号推荐";
+  const hint = document.createElement("span");
+  hint.className = "hint";
+  hint.textContent = "按剩余额度";
+  header.appendChild(title);
+  header.appendChild(hint);
   dom.recommendations.appendChild(header);
 
   if (!accounts.length) {
@@ -164,11 +180,21 @@ function buildProgressLine(label, usedPercent, resetsAt, secondary) {
 function renderRecommendationItem(label, account, remain) {
   const item = document.createElement("div");
   item.className = "cell";
+  const itemLabel = document.createElement("small");
+  itemLabel.textContent = label;
+  item.appendChild(itemLabel);
   if (!account) {
-    item.innerHTML = `<small>${label}</small><strong>暂无账号</strong>`;
+    const empty = document.createElement("strong");
+    empty.textContent = "暂无账号";
+    item.appendChild(empty);
     return item;
   }
-  item.innerHTML = `<small>${label}</small><strong>${account.label}</strong><small>${account.id}</small>`;
+  const accountLabel = document.createElement("strong");
+  accountLabel.textContent = account.label || "-";
+  const accountId = document.createElement("small");
+  accountId.textContent = account.id || "-";
+  item.appendChild(accountLabel);
+  item.appendChild(accountId);
   const badge = document.createElement("span");
   badge.className = "status-tag status-ok";
   badge.textContent = remain == null ? "--" : `${remain}%`;

--- a/apps/src/views/usage.js
+++ b/apps/src/views/usage.js
@@ -81,7 +81,12 @@ function renderProgressRow(label, percent, resetsAt, level) {
   row.className = "progress-row";
   const rowLabel = document.createElement("div");
   rowLabel.className = "progress-label";
-  rowLabel.innerHTML = `<span>${label}</span><span>${percent == null ? "n/a" : `${percent}% left`}</span>`;
+  const left = document.createElement("span");
+  left.textContent = label;
+  const right = document.createElement("span");
+  right.textContent = percent == null ? "n/a" : `${percent}% left`;
+  rowLabel.appendChild(left);
+  rowLabel.appendChild(right);
   const track = document.createElement("div");
   track.className = "progress-track";
   const fill = document.createElement("div");


### PR DESCRIPTION
## 背景与问题
在本地桌面场景中，前端页面会渲染来自本地数据库/上游返回的账号与用量字段。当前实现中存在多处 `innerHTML` 直接拼接动态字符串，同时 Tauri 配置中 `csp` 为 `null`。

这在 Tauri 应用中会放大风险：一旦有恶意内容进入这些字段，可能在渲染时触发脚本执行，影响账号管理、API Key 管理等高敏感操作。

## 修复目标
1. 收敛动态 HTML 注入面，避免把不可信字符串当作 HTML 执行。
2. 增加平台级防护（CSP），即使后续有遗漏点也能降低执行风险。

## 主要改动
### 1) 替换危险渲染路径（`innerHTML` -> 安全 DOM API）
- `apps/src/views/accounts.js`
  - 账号标题/元信息改为 `createElement + textContent`
  - 更新时间单元格改为安全节点渲染
- `apps/src/views/dashboard.js`
  - “暂无账号”“当前账号标题”“推荐标题”改为节点构造
  - 推荐项中账号标签/ID/空状态改为安全节点构造
- `apps/src/views/usage.js`
  - 进度行 label 区域改为两个 `span` + `textContent`

说明：保留的 `innerHTML = ""` 仅用于清空容器，不涉及注入执行。

### 2) 启用 Tauri CSP
- `apps/src-tauri/tauri.conf.json`
  - 将 `csp: null` 改为显式策略：
    - 允许 `self` 脚本
    - 允许本地样式与内联样式
    - 允许本地/loopback 连接（`localhost` / `127.0.0.1`）
    - 限制 `frame-ancestors`、`base-uri`、`form-action`

## 改动原因
- 动态 `innerHTML` 是最直接的脚本注入入口。
- 在桌面壳中，注入后果通常比普通网页更大（可间接影响本地服务调用链）。
- CSP 是必要的 defense-in-depth，可降低未来回归风险。

## 影响范围
- 仅涉及渲染方式与安全配置，不改变业务数据结构和接口契约。
- 页面行为与视觉预期保持一致。

## 验证
- 已完成本地构建与打包（macOS DMG）通过。
- 关键页面（账号列表/仪表盘/用量）渲染逻辑可正常工作。