### PR TITLE
feat: add lightweight close-to-tray mode

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -573,6 +573,46 @@
                                 </div>
 
                                 <div
+                                    class="settings-top-item settings-top-item-window-memory"
+                                >
+                                    <label
+                                        class="hint settings-field-label settings-top-label"
+                                        for="lightweightModeOnCloseToTray"
+                                    >
+                                        <span>轻量模式</span>
+                                    </label>
+                                    <div
+                                        class="settings-top-main settings-row-actions"
+                                    >
+                                        <label
+                                            class="update-auto-check switch-control"
+                                            for="lightweightModeOnCloseToTray"
+                                        >
+                                            <input
+                                                id="lightweightModeOnCloseToTray"
+                                                type="checkbox"
+                                            />
+                                            <span
+                                                class="switch-track"
+                                                aria-hidden="true"
+                                            >
+                                                <span
+                                                    class="switch-thumb"
+                                                ></span>
+                                            </span>
+                                            <span>托盘隐藏时释放 WebView 内存</span>
+                                        </label>
+                                    </div>
+                                    <div
+                                        class="settings-top-aside settings-row-actions"
+                                    >
+                                        <div class="hint">
+                                            仅在“关闭时最小化到托盘”开启后生效；再次打开界面会更慢。
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div
                                     id="settingsLowTransparencyCard"
                                     class="settings-top-item settings-top-item-visual"
                                 >

--- a/apps/src-tauri/src/lib.rs
+++ b/apps/src-tauri/src/lib.rs
@@ -10,17 +10,20 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::thread;
 use std::time::Duration;
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::Manager;
 
 mod updater;
 
 const TRAY_MENU_SHOW_MAIN: &str = "tray_show_main";
 const TRAY_MENU_QUIT_APP: &str = "tray_quit_app";
+const MAIN_WINDOW_LABEL: &str = "main";
 static APP_EXIT_REQUESTED: AtomicBool = AtomicBool::new(false);
 static TRAY_AVAILABLE: AtomicBool = AtomicBool::new(false);
 static CLOSE_TO_TRAY_ON_CLOSE: AtomicBool = AtomicBool::new(false);
+static LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY: AtomicBool = AtomicBool::new(false);
+static KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE: AtomicBool = AtomicBool::new(false);
 
 #[tauri::command]
 async fn service_initialize(addr: Option<String>) -> Result<serde_json::Value, String> {
@@ -675,6 +678,17 @@ fn app_close_to_tray_on_close_set(app: tauri::AppHandle, enabled: bool) -> bool 
 }
 
 #[tauri::command]
+fn app_lightweight_mode_on_close_to_tray_get() -> bool {
+    LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY.load(Ordering::Relaxed)
+}
+
+#[tauri::command]
+fn app_lightweight_mode_on_close_to_tray_set(enabled: bool) -> bool {
+    LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY.store(enabled, Ordering::Relaxed);
+    enabled
+}
+
+#[tauri::command]
 async fn app_settings_get(app: tauri::AppHandle) -> Result<serde_json::Value, String> {
     apply_runtime_storage_env(&app);
     let mut settings = tauri::async_runtime::spawn_blocking(move || {
@@ -773,6 +787,9 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| {
+            if window.label() != MAIN_WINDOW_LABEL {
+                return;
+            }
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 if APP_EXIT_REQUESTED.load(Ordering::Relaxed) {
                     return;
@@ -784,6 +801,13 @@ pub fn run() {
                     CLOSE_TO_TRAY_ON_CLOSE.store(false, Ordering::Relaxed);
                     return;
                 }
+                if LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY.load(Ordering::Relaxed) {
+                    KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(true, Ordering::Relaxed);
+                    log::info!(
+                        "window close intercepted; lightweight mode enabled, closing main window to release webview"
+                    );
+                    return;
+                }
                 api.prevent_close();
                 if let Err(err) = window.hide() {
                     log::warn!("hide window to tray failed: {}", err);
@@ -793,6 +817,10 @@ pub fn run() {
                 return;
             }
             if let tauri::WindowEvent::Destroyed = event {
+                if should_keep_alive_for_lightweight_close() {
+                    log::info!("main window destroyed for lightweight tray mode");
+                    return;
+                }
                 stop_service();
             }
         })
@@ -845,6 +873,8 @@ pub fn run() {
             app_settings_set,
             app_close_to_tray_on_close_get,
             app_close_to_tray_on_close_set,
+            app_lightweight_mode_on_close_to_tray_get,
+            app_lightweight_mode_on_close_to_tray_set,
             updater::app_update_check,
             updater::app_update_prepare,
             updater::app_update_apply_portable,
@@ -855,8 +885,14 @@ pub fn run() {
         .expect("error while building tauri application");
 
     app.run(|_app_handle, event| match event {
-        tauri::RunEvent::ExitRequested { .. } => {
+        tauri::RunEvent::ExitRequested { api, .. } => {
+            if should_keep_alive_for_lightweight_close() {
+                api.prevent_exit();
+                log::info!("prevented app exit for lightweight tray mode");
+                return;
+            }
             APP_EXIT_REQUESTED.store(true, Ordering::Relaxed);
+            KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(false, Ordering::Relaxed);
             stop_service();
         }
         #[cfg(target_os = "macos")]
@@ -881,6 +917,7 @@ fn setup_tray(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
             }
             TRAY_MENU_QUIT_APP => {
                 APP_EXIT_REQUESTED.store(true, Ordering::Relaxed);
+                KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(false, Ordering::Relaxed);
                 stop_service();
                 app.exit(0);
             }
@@ -905,7 +942,8 @@ fn setup_tray(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
 }
 
 fn show_main_window(app: &tauri::AppHandle) {
-    let Some(window) = app.get_webview_window("main") else {
+    KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(false, Ordering::Relaxed);
+    let Some(window) = ensure_main_window(app) else {
         return;
     };
     if let Err(err) = window.show() {
@@ -914,6 +952,32 @@ fn show_main_window(app: &tauri::AppHandle) {
     }
     let _ = window.unminimize();
     let _ = window.set_focus();
+}
+
+fn ensure_main_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        return Some(window);
+    }
+    match WebviewWindowBuilder::new(app, MAIN_WINDOW_LABEL, WebviewUrl::default())
+        .title("CodexManager")
+        .inner_size(1100.0, 720.0)
+        .resizable(true)
+        .build()
+    {
+        Ok(window) => Some(window),
+        Err(err) => {
+            if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+                return Some(window);
+            }
+            log::warn!("create main window failed: {}", err);
+            None
+        }
+    }
+}
+
+fn should_keep_alive_for_lightweight_close() -> bool {
+    !APP_EXIT_REQUESTED.load(Ordering::Relaxed)
+        && KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.load(Ordering::Relaxed)
 }
 
 fn load_env_from_exe_dir() {

--- a/apps/src/api.js
+++ b/apps/src/api.js
@@ -668,6 +668,22 @@ export async function appCloseToTrayOnCloseSet(enabled) {
   return value === true;
 }
 
+export async function appLightweightModeOnCloseToTrayGet() {
+  if (!isTauriRuntime()) {
+    return false;
+  }
+  const value = await invoke("app_lightweight_mode_on_close_to_tray_get", {});
+  return value === true;
+}
+
+export async function appLightweightModeOnCloseToTraySet(enabled) {
+  if (!isTauriRuntime()) {
+    return false;
+  }
+  const value = await invoke("app_lightweight_mode_on_close_to_tray_set", { enabled: Boolean(enabled) });
+  return value === true;
+}
+
 export async function appSettingsGet() {
   if (!isTauriRuntime()) {
     return rpcInvoke("appSettings/get");

--- a/apps/src/main.js
+++ b/apps/src/main.js
@@ -5,6 +5,8 @@ import "./styles/responsive.css";
 import "./styles/performance.css";
 
 import {
+  appLightweightModeOnCloseToTrayGet,
+  appLightweightModeOnCloseToTraySet,
   appSettingsGet,
   appSettingsSet,
   serviceGatewayBackgroundTasksSet,
@@ -165,6 +167,7 @@ const BACKGROUND_TASKS_RESTART_KEY_LABELS = {
 const API_MODELS_REMOTE_REFRESH_STORAGE_KEY = "codexmanager.apikey.models.last_remote_refresh_at";
 const API_MODELS_REMOTE_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const UPDATE_CHECK_DELAY_MS = 1200;
+const LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY_STORAGE_KEY = "codexmanager.app.lightweight_mode_on_close_to_tray";
 let refreshAllInFlight = null;
 let refreshAllProgressClearTimer = null;
 let updateCheckInFlight = null;
@@ -327,6 +330,12 @@ function applyBrowserModeUi() {
   if (closeToTrayCard) {
     closeToTrayCard.style.display = "none";
   }
+  const lightweightCard = dom.lightweightModeOnCloseToTray
+    ? dom.lightweightModeOnCloseToTray.closest(".settings-top-item, .settings-card")
+    : null;
+  if (lightweightCard) {
+    lightweightCard.style.display = "none";
+  }
 
   return true;
 }
@@ -395,6 +404,82 @@ function initCloseToTrayOnCloseSetting() {
   if (dom.closeToTrayOnClose) {
     dom.closeToTrayOnClose.disabled = !Boolean(appSettingsSnapshot.closeToTraySupported);
   }
+}
+
+function readLightweightModeOnCloseToTraySetting() {
+  if (typeof localStorage === "undefined") {
+    return false;
+  }
+  const raw = localStorage.getItem(LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY_STORAGE_KEY);
+  if (raw == null) {
+    return false;
+  }
+  const normalized = String(raw).trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(normalized);
+}
+
+function saveLightweightModeOnCloseToTraySetting(enabled) {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+  localStorage.setItem(LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY_STORAGE_KEY, enabled ? "1" : "0");
+}
+
+function setLightweightModeOnCloseToTrayToggle(enabled) {
+  if (dom.lightweightModeOnCloseToTray) {
+    dom.lightweightModeOnCloseToTray.checked = Boolean(enabled);
+  }
+}
+
+async function applyLightweightModeOnCloseToTraySetting(enabled, { silent = true } = {}) {
+  const normalized = Boolean(enabled);
+  if (!isTauriRuntime()) {
+    return normalized;
+  }
+  try {
+    const applied = await appLightweightModeOnCloseToTraySet(normalized);
+    if (!silent) {
+      showToast(
+        applied
+          ? "已开启：关闭到托盘时会释放 WebView 内存（再次打开可能更慢）"
+          : "已关闭：托盘隐藏时保留 WebView（再次打开更快）",
+      );
+    }
+    return Boolean(applied);
+  } catch (err) {
+    if (!silent) {
+      showToast(`设置失败：${normalizeErrorMessage(err)}`, "error");
+    }
+    throw err;
+  }
+}
+
+async function initLightweightModeOnCloseToTraySetting() {
+  const hasLocalSetting = typeof localStorage !== "undefined"
+    && localStorage.getItem(LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY_STORAGE_KEY) != null;
+  let enabled = readLightweightModeOnCloseToTraySetting();
+  if (!hasLocalSetting) {
+    saveLightweightModeOnCloseToTraySetting(enabled);
+  }
+  if (isTauriRuntime()) {
+    try {
+      const serviceValue = await appLightweightModeOnCloseToTrayGet();
+      if (!hasLocalSetting) {
+        enabled = serviceValue === true;
+      }
+    } catch {
+      // ignore and fallback to local value
+    }
+  }
+  setLightweightModeOnCloseToTrayToggle(enabled);
+  let applied = enabled;
+  try {
+    applied = await applyLightweightModeOnCloseToTraySetting(enabled, { silent: true });
+  } catch {
+    applied = enabled;
+  }
+  saveLightweightModeOnCloseToTraySetting(applied);
+  setLightweightModeOnCloseToTrayToggle(applied);
 }
 
 function readLowTransparencySetting() {
@@ -2254,6 +2339,20 @@ function bindEvents() {
       });
     });
   }
+  if (dom.lightweightModeOnCloseToTray && dom.lightweightModeOnCloseToTray.dataset.bound !== "1") {
+    dom.lightweightModeOnCloseToTray.dataset.bound = "1";
+    dom.lightweightModeOnCloseToTray.addEventListener("change", () => {
+      const previousEnabled = readLightweightModeOnCloseToTraySetting();
+      const enabled = Boolean(dom.lightweightModeOnCloseToTray.checked);
+      void applyLightweightModeOnCloseToTraySetting(enabled, { silent: false }).then((applied) => {
+        saveLightweightModeOnCloseToTraySetting(applied);
+        setLightweightModeOnCloseToTrayToggle(applied);
+      }).catch(() => {
+        saveLightweightModeOnCloseToTraySetting(previousEnabled);
+        setLightweightModeOnCloseToTrayToggle(previousEnabled);
+      });
+    });
+  }
   if (dom.routeStrategySelect && dom.routeStrategySelect.dataset.bound !== "1") {
     dom.routeStrategySelect.dataset.bound = "1";
     dom.routeStrategySelect.addEventListener("change", () => {
@@ -2543,6 +2642,7 @@ async function bootstrap() {
   initLowTransparencySetting();
   initUpdateAutoCheckSetting();
   initCloseToTrayOnCloseSetting();
+  void initLightweightModeOnCloseToTraySetting();
   initServiceListenModeSetting();
   initRouteStrategySetting();
   initCpaNoCookieHeaderModeSetting();

--- a/apps/src/ui/dom.js
+++ b/apps/src/ui/dom.js
@@ -13,6 +13,7 @@ export const dom = {
   autoCheckUpdate: byId("autoCheckUpdate"),
   checkUpdate: byId("checkUpdate"),
   closeToTrayOnClose: byId("closeToTrayOnClose"),
+  lightweightModeOnCloseToTray: byId("lightweightModeOnCloseToTray"),
   updateCurrentVersion: byId("updateCurrentVersion"),
   updateStatusText: byId("updateStatusText"),
   routeStrategySelect: byId("routeStrategySelect"),


### PR DESCRIPTION
应用隐藏到托盘之后，webview依然占用很多内存，但实际上只保留核心服务即可
为此添加了轻量级模式，此功能可在设置界面打开，隐藏到托盘后关闭webview，可节省内存，缺点是再次打开主窗口会有一定延迟

主窗口显示时：
<img width="1406" height="362" alt="image" src="https://github.com/user-attachments/assets/9cbfd2cf-458d-4520-a315-90834859e4d0" />

隐藏到托盘时：
<img width="1430" height="327" alt="image" src="https://github.com/user-attachments/assets/38f0da22-0a5c-4d01-93e2-9a9506f24fe8" />
