### PR TITLE
修复: SOCKS5 代理支持及 DNS 防污染

### DIFF
--- a/apps/src/main.js
+++ b/apps/src/main.js
@@ -766,7 +766,21 @@ function normalizeUpstreamProxyUrl(value) {
   if (value == null) {
     return "";
   }
-  return String(value).trim();
+  let trimmed = String(value).trim();
+  // 清理前端可能引入的双重协议前缀
+  if (trimmed.startsWith("http://socks")) {
+    trimmed = trimmed.slice("http://".length);
+  } else if (trimmed.startsWith("https://socks")) {
+    trimmed = trimmed.slice("https://".length);
+  }
+  // socks5:// / socks:// → socks5h:// 防止 DNS 污染
+  if (trimmed.startsWith("socks5://")) {
+    return trimmed.replace("socks5://", "socks5h://");
+  }
+  if (trimmed.startsWith("socks://")) {
+    return trimmed.replace("socks://", "socks5h://");
+  }
+  return trimmed;
 }
 
 function readUpstreamProxyUrlSetting() {
@@ -1783,13 +1797,13 @@ async function handleRefreshAllClick() {
       return;
     }
     let accounts = Array.isArray(state.accountList) ? state.accountList.filter((item) => item && item.id) : [];
-  if (accounts.length === 0) {
-    try {
-      await refreshAccounts();
-      await refreshAccountsPage({ latestOnly: true }).catch(() => false);
-    } catch (err) {
-      console.error("[refreshUsageOnly] load accounts failed", err);
-    }
+    if (accounts.length === 0) {
+      try {
+        await refreshAccounts();
+        await refreshAccountsPage({ latestOnly: true }).catch(() => false);
+      } catch (err) {
+        console.error("[refreshUsageOnly] load accounts failed", err);
+      }
       accounts = Array.isArray(state.accountList) ? state.accountList.filter((item) => item && item.id) : [];
     }
     const total = accounts.length;

--- a/apps/src/services/connection.js
+++ b/apps/src/services/connection.js
@@ -11,6 +11,15 @@ export function normalizeAddr(raw) {
     throw new Error("请输入端口或地址");
   }
   let value = trimmed;
+  if (value.startsWith("socks5://")) {
+    return value.replace("socks5://", "socks5h://");
+  }
+  if (value.startsWith("socks://")) {
+    return value.replace("socks://", "socks5h://");
+  }
+  if (value.startsWith("socks5h://")) {
+    return value;
+  }
   if (value.startsWith("http://")) {
     value = value.slice("http://".length);
   }

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 codexmanager-core = { path = "../core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking", "stream"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking", "stream", "socks"] }
 bytes = "1"
 rand = "0.8"
 sha2 = "0.10"

--- a/crates/service/src/gateway/core/runtime_config.rs
+++ b/crates/service/src/gateway/core/runtime_config.rs
@@ -316,7 +316,9 @@ pub(super) fn reload_from_env() {
     let proxy_url = env_non_empty(ENV_UPSTREAM_PROXY_URL);
     let mut cached_proxy_url =
         crate::lock_utils::write_recover(upstream_proxy_url_cell(), "upstream_proxy_url");
-    *cached_proxy_url = proxy_url;
+    let converted_proxy = normalize_upstream_proxy_url(proxy_url.as_deref()).unwrap_or_default();
+
+    *cached_proxy_url = converted_proxy;
     drop(cached_proxy_url);
 
     refresh_upstream_clients_from_runtime_config();
@@ -434,12 +436,23 @@ fn env_bool_or(name: &str, default: bool) -> bool {
 }
 
 fn normalize_upstream_proxy_url(proxy_url: Option<&str>) -> Result<Option<String>, String> {
-    let normalized = proxy_url
+    let mut normalized = proxy_url
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string);
-    if let Some(value) = normalized.as_deref() {
-        Proxy::all(value).map_err(|err| format!("invalid proxy url: {err}"))?;
+    if let Some(value) = normalized.as_mut() {
+        // 清理前端可能引入的双重协议前缀
+        if let Some(rest) = value.strip_prefix("http://socks") {
+            *value = format!("socks{rest}");
+        } else if let Some(rest) = value.strip_prefix("https://socks") {
+            *value = format!("socks{rest}");
+        }
+        if value.starts_with("socks5://") {
+            *value = value.replacen("socks5://", "socks5h://", 1);
+        } else if value.starts_with("socks://") {
+            *value = value.replacen("socks://", "socks5h://", 1);
+        }
+        Proxy::all(value.as_str()).map_err(|err| format!("invalid proxy url: {err}"))?;
     }
     Ok(normalized)
 }
@@ -453,6 +466,14 @@ fn parse_proxy_list_env() -> Vec<String> {
         .filter(|part| !part.is_empty())
         .take(MAX_UPSTREAM_PROXY_POOL_SIZE)
         .map(str::to_string)
+        .map(|mut proxy| {
+            if proxy.starts_with("socks5://") {
+                proxy = proxy.replacen("socks5://", "socks5h://", 1);
+            } else if proxy.starts_with("socks://") {
+                proxy = proxy.replacen("socks://", "socks5h://", 1);
+            }
+            proxy
+        })
         .collect()
 }
 


### PR DESCRIPTION
- Cargo.toml: 为 reqwest 启用 socks 特性
- runtime_config.rs: socks5:// 自动转为 socks5h:// 启用远程 DNS 解析
- runtime_config.rs: 清理 http://socks5h:// 双重协议前缀
- runtime_config.rs: reload_from_env 启动时走 normalize 保证一致性
- connection.js: normalizeAddr 支持 socks5/socks 协议地址
- main.js: normalizeUpstreamProxyUrl 增加 socks 转换和前缀清理