### PR TITLE
Fix web startup with axum 0.8

### DIFF
--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -677,7 +677,7 @@ async fn main() {
     let app = Router::new()
         .route("/__login", get(login_page).post(login_submit))
         .route("/__logout", get(logout))
-        .nest("/", protected_app)
+        .merge(protected_app)
         .with_state(state);
 
     println!("codexmanager-web listening on {web_addr} (service={service_addr})");


### PR DESCRIPTION
## Summary
- replace root `nest("/")` with `merge(...)` in the web router
- keep the route structure unchanged while matching axum 0.8 behavior

## Why
Running `codexmanager-web` currently panics at startup with:

```text
Nesting at the root is no longer supported. Use merge instead.
```

Using `merge` fixes startup without changing the protected route layout.

## Verification
- `cargo build -p codexmanager-web --release`
- verified the web binary starts past the previous panic point locally