### PR TITLE
修复 docker compose 启动时保存密码失效

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       CODEXMANAGER_WEB_ADDR: 0.0.0.0:48761
       CODEXMANAGER_WEB_NO_SPAWN_SERVICE: "1"
       CODEXMANAGER_SERVICE_ADDR: codexmanager-service:48760
+      CODEXMANAGER_DB_PATH: /data/codexmanager.db
       CODEXMANAGER_RPC_TOKEN_FILE: /data/codexmanager.rpc-token
       CODEXMANAGER_WEB_NO_OPEN: "1"
     volumes:


### PR DESCRIPTION
## 变更摘要

- 修需 docker compose 保存密码失效问题

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- 

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [ ] 其他本地验证已说明

已执行的实际验证：

```text

```

未执行的验证与原因：

```text

```

## 风险与影响面

- 

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
