### PR TITLE
fix(service): prefer process env over persisted env overrides

### DIFF
--- a/crates/service/src/app_settings/env_overrides/mod.rs
+++ b/crates/service/src/app_settings/env_overrides/mod.rs
@@ -13,5 +13,6 @@ pub(crate) use catalog::{
 pub(crate) use manager::set_env_overrides;
 pub(crate) use process::{apply_env_overrides_to_process, reload_runtime_after_env_override_apply};
 pub(crate) use snapshot::{
-    current_env_overrides, persisted_env_overrides_only, save_env_overrides_value,
+    current_env_overrides, persisted_env_overrides_missing_process_env,
+    persisted_env_overrides_only, save_env_overrides_value,
 };

--- a/crates/service/src/app_settings/env_overrides/snapshot.rs
+++ b/crates/service/src/app_settings/env_overrides/snapshot.rs
@@ -49,8 +49,21 @@ pub(crate) fn persisted_env_overrides_only() -> BTreeMap<String, String> {
     persisted_env_overrides(BTreeMap::new())
 }
 
+pub(crate) fn persisted_env_overrides_missing_process_env() -> BTreeMap<String, String> {
+    persisted_env_overrides_only()
+        .into_iter()
+        .filter(|(key, _)| std::env::var_os(key).is_none())
+        .collect()
+}
+
 pub(crate) fn current_env_overrides() -> BTreeMap<String, String> {
-    persisted_env_overrides(env_override_default_snapshot())
+    let mut current = env_override_default_snapshot();
+    for (key, value) in persisted_env_overrides_only() {
+        if std::env::var_os(&key).is_none() {
+            current.insert(key, value);
+        }
+    }
+    current
 }
 
 pub(crate) fn save_env_overrides_value(overrides: &BTreeMap<String, String>) -> Result<(), String> {

--- a/crates/service/src/app_settings/mod.rs
+++ b/crates/service/src/app_settings/mod.rs
@@ -9,7 +9,7 @@ mod ui;
 
 pub use api::{app_settings_get, app_settings_get_with_overrides, app_settings_set};
 pub(crate) use env_overrides::{
-    apply_env_overrides_to_process, persisted_env_overrides_only,
+    apply_env_overrides_to_process, persisted_env_overrides_missing_process_env,
     reload_runtime_after_env_override_apply,
 };
 pub use gateway::{

--- a/crates/service/src/app_settings/runtime_sync.rs
+++ b/crates/service/src/app_settings/runtime_sync.rs
@@ -3,16 +3,17 @@ use crate::usage_refresh;
 
 use super::{
     apply_env_overrides_to_process, list_app_settings_map, normalize_optional_text,
-    parse_bool_with_default, persisted_env_overrides_only, reload_runtime_after_env_override_apply,
-    set_service_bind_mode, BackgroundTasksInput, APP_SETTING_GATEWAY_BACKGROUND_TASKS_KEY,
-    APP_SETTING_GATEWAY_CPA_NO_COOKIE_HEADER_MODE_KEY, APP_SETTING_GATEWAY_ROUTE_STRATEGY_KEY,
-    APP_SETTING_GATEWAY_SSE_KEEPALIVE_INTERVAL_MS_KEY, APP_SETTING_GATEWAY_UPSTREAM_PROXY_URL_KEY,
-    APP_SETTING_GATEWAY_UPSTREAM_STREAM_TIMEOUT_MS_KEY, SERVICE_BIND_MODE_SETTING_KEY,
+    parse_bool_with_default, persisted_env_overrides_missing_process_env,
+    reload_runtime_after_env_override_apply, set_service_bind_mode, BackgroundTasksInput,
+    APP_SETTING_GATEWAY_BACKGROUND_TASKS_KEY, APP_SETTING_GATEWAY_CPA_NO_COOKIE_HEADER_MODE_KEY,
+    APP_SETTING_GATEWAY_ROUTE_STRATEGY_KEY, APP_SETTING_GATEWAY_SSE_KEEPALIVE_INTERVAL_MS_KEY,
+    APP_SETTING_GATEWAY_UPSTREAM_PROXY_URL_KEY, APP_SETTING_GATEWAY_UPSTREAM_STREAM_TIMEOUT_MS_KEY,
+    SERVICE_BIND_MODE_SETTING_KEY,
 };
 
 pub fn sync_runtime_settings_from_storage() {
     let settings = list_app_settings_map();
-    let env_overrides = persisted_env_overrides_only();
+    let env_overrides = persisted_env_overrides_missing_process_env();
     if !env_overrides.is_empty() {
         apply_env_overrides_to_process(&env_overrides, &env_overrides);
     }

--- a/crates/service/tests/app_settings.rs
+++ b/crates/service/tests/app_settings.rs
@@ -133,6 +133,33 @@ fn sync_runtime_settings_from_storage_preserves_process_env_when_override_not_pe
 }
 
 #[test]
+fn sync_runtime_settings_from_storage_preserves_explicit_process_env_over_persisted_override() {
+    with_temp_db(|db_path| {
+        let storage = Storage::open(db_path).expect("open storage");
+        storage
+            .set_app_setting(
+                codexmanager_service::APP_SETTING_ENV_OVERRIDES_KEY,
+                &serde_json::to_string(&json!({
+                    "CODEXMANAGER_WEB_ADDR": "localhost:48761"
+                }))
+                .expect("serialize env overrides"),
+                now_ts(),
+            )
+            .expect("save env overrides");
+        drop(storage);
+
+        let _env = override_env_vars(&[("CODEXMANAGER_WEB_ADDR", Some("0.0.0.0:48761"))]);
+
+        codexmanager_service::sync_runtime_settings_from_storage();
+
+        assert_eq!(
+            std::env::var("CODEXMANAGER_WEB_ADDR").ok().as_deref(),
+            Some("0.0.0.0:48761")
+        );
+    });
+}
+
+#[test]
 fn app_settings_set_persists_snapshot_and_password_hash() {
     with_temp_db(|db_path| {
         let snapshot = codexmanager_service::app_settings_set(Some(&json!({


### PR DESCRIPTION
## 变更摘要

- 修复 Docker 场景下 `codexmanager-web` 重启后监听地址从 `0.0.0.0:48761` 退回 `localhost:48761`，导致宿主机无法访问 Web UI 的问题。
- 根因是启动时会从数据库中的 `app.env_overrides` 恢复环境变量，旧逻辑会覆盖容器显式传入的 `CODEXMANAGER_WEB_ADDR`。
- 调整 env override 优先级为“当前进程环境变量优先，持久化 override 仅补充缺失值”，避免 Docker 部署配置被历史持久化值反向覆盖。
- 同步修正当前 `envOverrides` 快照读取逻辑，避免数据库旧值再次显示或写回。
- 本次修改内容均由`gpt-5.4`生成

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/app_settings/runtime_sync.rs`
- `crates/service/src/app_settings/env_overrides/snapshot.rs`
- `crates/service/src/app_settings/env_overrides/mod.rs`
- `crates/service/tests/app_settings.rs`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
1. 检查 docker-compose 与 Dockerfile，确认 compose 中显式设置了 CODEXMANAGER_WEB_ADDR=0.0.0.0:48761。
2. 检查 web 启动链路，确认 codexmanager-web 会在启动时先调用 sync_runtime_settings_from_storage()，随后读取 CODEXMANAGER_WEB_ADDR 并开始监听。
3. 检查 app_settings / env_overrides 相关代码，确认持久化 app.env_overrides 会在启动时写回进程环境变量。
4. 读取持久化数据库内容，确认 app.env_overrides 中存在 CODEXMANAGER_WEB_ADDR=localhost:48761。
5. 检查容器日志，确认实际日志为 codexmanager-web listening on localhost:48761。
6. 完成代码修改，使持久化 env override 仅在当前进程缺失对应变量时才生效，并补充针对 CODEXMANAGER_WEB_ADDR 的回归测试代码。
7. 已完成docker-compose部署测试：测试后不再出现 0.0.0.0 回退到 localhost 的情况
```

未执行的验证与原因：

```text
1. 未执行 pnpm 相关测试或构建：本次修改仅涉及 Rust service 配置同步逻辑，且当前约定由 Docker 镜像构建阶段完成编译验证。
2. 未执行 cargo test / cargo test --workspace：编译与验证放在 Docker 镜像构建中完成。
```

## 风险与影响面

- 本次改动调整了 env override 的优先级语义：显式进程环境变量现在高于数据库中的持久化 override。
- 影响面主要在 Service 启动时的运行时配置同步，以及 app settings 当前快照中 envOverrides 的展示与持久化。
- 对 Docker / 容器部署是预期修复；对依赖“启动时用数据库覆盖已有进程环境变量”的场景，行为会改变，需要注意。
- 未改动 env override 的保存机制本身，只调整读取和启动应用时的合并优先级，整体风险可控。

## 备注

- 提交前已确认未包含敏感 token、cookie、API key。