### PR TITLE
fix(web): preserve container env overrides

### DIFF
--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -43,6 +43,37 @@ fn read_env_trim(name: &str) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
+fn capture_explicit_env(keys: &[&str]) -> Vec<(String, String)> {
+    keys.iter()
+        .filter_map(|key| read_env_trim(key).map(|value| (key.to_string(), value)))
+        .collect()
+}
+
+fn restore_env(items: Vec<(String, String)>) {
+    for (key, value) in items {
+        std::env::set_var(key, value);
+    }
+}
+
+fn is_running_in_container() -> bool {
+    if cfg!(target_os = "linux") {
+        if Path::new("/.dockerenv").is_file() || Path::new("/run/.containerenv").is_file() {
+            return true;
+        }
+        if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
+            let cgroup = cgroup.to_lowercase();
+            if cgroup.contains("docker")
+                || cgroup.contains("containerd")
+                || cgroup.contains("kubepods")
+                || cgroup.contains("podman")
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 fn normalize_addr(raw: &str) -> Option<String> {
     let mut value = raw.trim();
     if value.is_empty() {
@@ -73,7 +104,13 @@ fn resolve_service_addr() -> String {
 fn resolve_web_addr() -> String {
     read_env_trim("CODEXMANAGER_WEB_ADDR")
         .and_then(|v| normalize_addr(&v))
-        .unwrap_or_else(|| DEFAULT_WEB_ADDR.to_string())
+        .unwrap_or_else(|| {
+            if is_running_in_container() {
+                "0.0.0.0:48761".to_string()
+            } else {
+                DEFAULT_WEB_ADDR.to_string()
+            }
+        })
 }
 
 fn resolve_web_root() -> PathBuf {
@@ -251,9 +288,24 @@ async fn async_main() {
 }
 
 fn main() {
+    let preserved_env = if is_running_in_container() {
+        capture_explicit_env(&[
+            "CODEXMANAGER_WEB_ADDR",
+            "CODEXMANAGER_WEB_ROOT",
+            "CODEXMANAGER_WEB_NO_OPEN",
+            "CODEXMANAGER_WEB_NO_SPAWN_SERVICE",
+            "CODEXMANAGER_SERVICE_ADDR",
+        ])
+    } else {
+        Vec::new()
+    };
+
     codexmanager_service::portable::bootstrap_current_process();
     let _ = codexmanager_service::initialize_storage_if_needed();
     codexmanager_service::sync_runtime_settings_from_storage();
+    if !preserved_env.is_empty() {
+        restore_env(preserved_env);
+    }
 
     let runtime = tokio::runtime::Runtime::new().expect("create tokio runtime");
     runtime.block_on(async_main());


### PR DESCRIPTION
## 概述

**PS：尝试Docker部署在Linux VPS上的时候发现Web无法访问，就丢给AI分析解决，以下内容和修改的代码都是使用Claude输出的**

在容器环境（Docker/Podman/K8s）下，通过 `docker run -e` 显式设置的环境变量
会被 `bootstrap_current_process()` 和 `sync_runtime_settings_from_storage()` 静默覆盖。

本 PR 在 bootstrap 阶段前后增加了环境变量的捕获与恢复机制，确保用户的显式容器配置
始终优先于持久化存储中的设置。

## 问题描述

在容器化部署中，用户通常通过环境变量配置应用（如 `CODEXMANAGER_WEB_ADDR`、
`CODEXMANAGER_SERVICE_ADDR`）。然而当前 `main()` 的初始化流程会依次调用：

1. `bootstrap_current_process()` — 可能从打包默认值重置环境变量
2. `sync_runtime_settings_from_storage()` — 从持久化存储覆盖环境变量

这导致用户通过 `-e` 指定的值被丢失，进而引发：
- Web 服务绑定到 `localhost` 而非 `0.0.0`（容器外部无法访问）
- 服务地址不匹配
- 难以排查的异常行为

## 解决方案

1. **检测容器环境**：通过 `/.dockerenv`、`/run/.containerenv` 文件及
   `/proc/1/cgroup` 关键字启发式判断（覆盖 Docker、Podman、containerd、K8s）
2. **捕获环境变量**：在 bootstrap 前保存用户显式设置的环境变量
3. **恢复环境变量**：在 bootstrap 和存储同步完成后恢复
4. **容器默认绑定 `0.0.0.0`**：未显式设置 `CODEXMANAGER_WEB_ADDR` 时，
   容器内默认绑定 `0.0.0.0:48761`（localhost 从容器外部不可达）

### 涉及的环境变量

- `CODEXMANAGER_WEB_ADDR`
- `CODEXMANAGER_WEB_ROOT`
- `CODEXMANAGER_WEB_NO_OPEN`
- `CODEXMANAGER_WEB_NO_SPAWN_SERVICE`
- `CODEXMANAGER_SERVICE_ADDR`## 变更内容

- **`crates/web/src/main.rs`**（+53/-1）：
  - 新增 `is_running_in_container()` — 多方法容器检测
  - 新增 `capture_explicit_env()` / `restore_env()` — 环境变量保存与恢复
  - 修改 `resolve_web_addr()` — 容器内默认绑定 `0.0.0:48761`
  - 修改 `main()` — 实现 捕获→初始化→恢复 流程## 已知限制

- **cgroup v2**：在纯 cgroup v2 系统上，`/proc/1/cgroup` 可能不包含运行时关键字。
  文件检测（`/.dockerenv`、`/run/.containerenv`）仍可覆盖 Docker 和 Podman 场景。
  Kubernetes 检测可在后续通过 `KUBERNETES_SERVICE_HOST` 环境变量增强。
- **`std::env::set_var` 安全性**：Rust 1.83+ 中 `set_var` 被标记为 `unsafe`。
  当前调用位于 `main()` Tokio runtime 启动前的单线程阶段，实际安全。
  若项目 MSRV 升至 1.83+，可添加 `unsafe` 块及 SAFETY 注释。

## 测试情况

- ✅ 非容器环境：无行为变化（零成本路径）
- ✅ Docker 指定环境变量：`docker run -e CODEXMANAGER_WEB_ADDR=0.0.0.0:999 ...`
  正确保留自定义地址
- ✅ Docker 未指定环境变量：默认绑定 `0.0.0:48761`（宿主机可访问）