### PR TITLE
fix: 修正更新后仓库的 Docker 构建链路

### DIFF
--- a/crates/docker/Dockerfile.web
+++ b/crates/docker/Dockerfile.web
@@ -4,13 +4,13 @@ WORKDIR /src/apps
 
 RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
 
-COPY apps/package.json apps/pnpm-lock.yaml apps/vite.config.js apps/index.html ./
-COPY apps/src ./src
-COPY apps/tests ./tests
-COPY apps/scripts ./scripts
+COPY apps/package.json apps/pnpm-lock.yaml ./
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm run build
+
+COPY apps ./
+
+RUN pnpm run build:desktop
 
 FROM rust:1-bookworm AS builder
 
@@ -19,7 +19,7 @@ WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 
-COPY --from=ui /src/apps/dist ./apps/dist
+COPY --from=ui /src/apps/out ./apps/out
 
 RUN cargo build -p codexmanager-web --release --features embedded-ui
 

--- a/crates/docker/docker-compose.yml
+++ b/crates/docker/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   codexmanager-service:
     build:
-      context: ..
-      dockerfile: docker/Dockerfile.service
+      context: ../..
+      dockerfile: crates/docker/Dockerfile.service
     environment:
       CODEXMANAGER_SERVICE_ADDR: 0.0.0.0:48760
       CODEXMANAGER_DB_PATH: /data/codexmanager.db
@@ -14,8 +14,8 @@ services:
 
   codexmanager-web:
     build:
-      context: ..
-      dockerfile: docker/Dockerfile.web
+      context: ../..
+      dockerfile: crates/docker/Dockerfile.web
     depends_on:
       - codexmanager-service
     environment:

--- a/docs/report/20260310122606850_运行与部署指南.md
+++ b/docs/report/20260310122606850_运行与部署指南.md
@@ -29,7 +29,7 @@
 
 ### 方式 1：docker compose
 ```bash
-docker compose -f docker/docker-compose.yml up --build
+docker compose -f crates/docker/docker-compose.yml up --build
 ```
 
 浏览器打开：`http://localhost:48761/`
@@ -37,13 +37,13 @@ docker compose -f docker/docker-compose.yml up --build
 ### 方式 2：分别构建和运行
 ```bash
 # service
-docker build -f docker/Dockerfile.service -t codexmanager-service .
+docker build -f crates/docker/Dockerfile.service -t codexmanager-service .
 docker run --rm -p 48760:48760 -v codexmanager-data:/data \
   -e CODEXMANAGER_RPC_TOKEN=replace_with_your_token \
   codexmanager-service
 
 # web（需要能访问到 service）
-docker build -f docker/Dockerfile.web -t codexmanager-web .
+docker build -f crates/docker/Dockerfile.web -t codexmanager-web .
 docker run --rm -p 48761:48761 \
   -v codexmanager-data:/data \
   -e CODEXMANAGER_WEB_NO_SPAWN_SERVICE=1 \


### PR DESCRIPTION
## Summary
- fix docker compose build context and Dockerfile paths for the current repo layout
- update web image build to use the current Next.js frontend export output
- align Docker usage docs with the new crates/docker entry path

## Verification
- pnpm -C apps run build:desktop
- docker compose -f crates/docker/docker-compose.yml config
- docker compose -f crates/docker/docker-compose.yml up --build