### PR TITLE
fix: 补齐工具 JSON Schema 缺失字段，修复 Claude Code 请求上游 400

### DIFF
--- a/crates/service/src/gateway/protocol_adapter/request_mapping.rs
+++ b/crates/service/src/gateway/protocol_adapter/request_mapping.rs
@@ -549,6 +549,7 @@ fn map_anthropic_tool_definition(
         .get("input_schema")
         .cloned()
         .unwrap_or_else(|| json!({ "type": "object", "properties": {} }));
+    let parameters = fix_array_items_in_schema(parameters);
     let mapped_name = shorten_openai_tool_name_with_map(name, tool_name_map);
 
     let mut tool_obj = serde_json::Map::new();
@@ -600,4 +601,35 @@ fn resolve_anthropic_parallel_tool_calls(source: &serde_json::Map<String, Value>
         .and_then(|tool_choice| tool_choice.get("disable_parallel_tool_use"))
         .and_then(Value::as_bool)
         .unwrap_or(false)
+}
+
+/// OpenAI/Codex 后端对 JSON Schema 的要求比 Anthropic 更严格：
+/// - `"type":"array"` 必须携带 `"items"` 定义
+/// - `"type":"object"` 必须携带 `"properties"` 定义
+/// 此函数递归补齐缺失的字段。
+fn fix_array_items_in_schema(mut value: Value) -> Value {
+    match &mut value {
+        Value::Object(obj) => {
+            let schema_type = obj
+                .get("type")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            if schema_type.as_deref() == Some("array") && !obj.contains_key("items") {
+                obj.insert("items".to_string(), json!({}));
+            }
+            if schema_type.as_deref() == Some("object") && !obj.contains_key("properties") {
+                obj.insert("properties".to_string(), json!({}));
+            }
+            for (_, v) in obj.iter_mut() {
+                *v = fix_array_items_in_schema(v.clone());
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                *v = fix_array_items_in_schema(v.clone());
+            }
+        }
+        _ => {}
+    }
+    value
 }

--- a/crates/service/src/gateway/protocol_adapter/request_mapping/openai.rs
+++ b/crates/service/src/gateway/protocol_adapter/request_mapping/openai.rs
@@ -143,6 +143,7 @@ fn map_dynamic_tool_to_responses_tool(
         .or_else(|| tool_obj.get("parameters"))
         .cloned()
         .unwrap_or_else(|| json!({ "type": "object", "properties": {} }));
+    let parameters = super::fix_array_items_in_schema(parameters);
 
     let mut mapped = serde_json::Map::new();
     mapped.insert("type".to_string(), Value::String("function".to_string()));
@@ -345,7 +346,10 @@ fn map_openai_chat_tools_to_responses(
                 mapped.insert("description".to_string(), description.clone());
             }
             if let Some(parameters) = function.get("parameters") {
-                mapped.insert("parameters".to_string(), parameters.clone());
+                mapped.insert(
+                    "parameters".to_string(),
+                    super::fix_array_items_in_schema(parameters.clone()),
+                );
             }
             if let Some(strict) = function.get("strict") {
                 mapped.insert("strict".to_string(), strict.clone());


### PR DESCRIPTION
OpenAI/Codex 后端对 JSON Schema 要求比 Anthropic 更严格：
- type:array 必须包含 items
- type:object 必须包含 properties

Claude Code + MCP 工具的 schema 中存在省略这些字段的情况，
导致转换后的请求被上游拒绝（400 Bad Request）。

## 变更摘要

- 

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- 

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [ ] 其他本地验证已说明

已执行的实际验证：

```text

```

未执行的验证与原因：

```text

```

## 风险与影响面

- 

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
