### PR TITLE
fix: support request log filtering by account label

### DIFF
--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -734,6 +734,16 @@ impl Storage {
         Ok(false)
     }
 
+    fn has_table(&self, table: &str) -> Result<bool> {
+        self.conn
+            .query_row(
+                "SELECT COUNT(1) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                [table],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|count| count > 0)
+    }
+
     /// 函数 `ensure_migrations_table`
     ///
     /// 作者: gaohongshun

--- a/crates/core/src/storage/request_log_query.rs
+++ b/crates/core/src/storage/request_log_query.rs
@@ -2,6 +2,8 @@
 pub(super) enum RequestLogQuery {
     All,
     GlobalLike(String),
+    AccountLike(String),
+    AccountExact(String),
     FieldLike {
         column: &'static str,
         pattern: String,
@@ -59,7 +61,7 @@ fn parse_prefixed_request_log_query(raw: &str) -> Option<RequestLogQuery> {
     let (is_exact, needle) = parse_match_mode(normalized_value)?;
 
     match normalized_prefix.as_str() {
-        "account" | "account_id" => Some(parse_field_query("account_id", is_exact, needle)),
+        "account" | "account_id" => Some(parse_account_query(is_exact, needle)),
         "path" | "request_path" => Some(parse_field_query("request_path", is_exact, needle)),
         "original" | "original_path" => Some(parse_field_query("original_path", is_exact, needle)),
         "adapted" | "adapted_path" => Some(parse_field_query("adapted_path", is_exact, needle)),
@@ -133,6 +135,13 @@ fn parse_field_query(column: &'static str, is_exact: bool, value: &str) -> Reque
         column,
         pattern: format!("%{}%", value),
     }
+}
+
+fn parse_account_query(is_exact: bool, value: &str) -> RequestLogQuery {
+    if is_exact {
+        return RequestLogQuery::AccountExact(value.to_string());
+    }
+    RequestLogQuery::AccountLike(format!("%{}%", value))
 }
 
 /// 函数 `parse_status_query`

--- a/crates/core/src/storage/request_logs.rs
+++ b/crates/core/src/storage/request_logs.rs
@@ -223,7 +223,8 @@ impl Storage {
     ) -> Result<Vec<RequestLog>> {
         let normalized_limit = normalize_request_log_limit(limit);
         let normalized_offset = offset.max(0);
-        let filters = build_request_log_filters(query, status_filter);
+        let include_account_lookup = self.has_table("accounts")?;
+        let filters = build_request_log_filters(query, status_filter, include_account_lookup);
         let sql = format!(
             "SELECT
                 r.trace_id, r.key_id, r.account_id, r.initial_account_id, r.attempted_account_ids_json, r.initial_aggregate_api_id, r.attempted_aggregate_api_ids_json,
@@ -232,10 +233,12 @@ impl Storage {
                 t.input_tokens, t.cached_input_tokens, t.output_tokens, t.total_tokens, t.reasoning_output_tokens, t.estimated_cost_usd,
                 r.error, r.created_at
              FROM request_logs r
+             {account_join}
              LEFT JOIN request_token_stats t ON t.request_log_id = r.id
              {where_clause}
              ORDER BY r.created_at DESC, r.id DESC
              LIMIT ? OFFSET ?",
+            account_join = account_join_clause(include_account_lookup),
             where_clause = filters.where_clause
         );
         let mut params = filters.params;
@@ -269,12 +272,15 @@ impl Storage {
         query: Option<&str>,
         status_filter: Option<&str>,
     ) -> Result<i64> {
-        let filters = build_request_log_filters(query, status_filter);
+        let include_account_lookup = self.has_table("accounts")?;
+        let filters = build_request_log_filters(query, status_filter, include_account_lookup);
         let sql = format!(
             "SELECT COUNT(1)
              FROM request_logs r
+             {account_join}
              LEFT JOIN request_token_stats t ON t.request_log_id = r.id
              {where_clause}",
+            account_join = account_join_clause(include_account_lookup),
             where_clause = filters.where_clause
         );
         self.conn
@@ -301,7 +307,8 @@ impl Storage {
         query: Option<&str>,
         status_filter: Option<&str>,
     ) -> Result<RequestLogQuerySummary> {
-        let filters = build_request_log_filters(query, status_filter);
+        let include_account_lookup = self.has_table("accounts")?;
+        let filters = build_request_log_filters(query, status_filter, include_account_lookup);
         let sql = format!(
             "SELECT
                 COUNT(1),
@@ -321,8 +328,10 @@ impl Storage {
                 ), 0),
                 IFNULL(SUM(IFNULL(t.estimated_cost_usd, 0.0)), 0.0)
              FROM request_logs r
+             {account_join}
              LEFT JOIN request_token_stats t ON t.request_log_id = r.id
              {where_clause}",
+            account_join = account_join_clause(include_account_lookup),
             where_clause = filters.where_clause
         );
         self.conn
@@ -745,12 +754,14 @@ fn normalize_request_log_limit(value: i64) -> i64 {
 fn build_request_log_filters(
     query: Option<&str>,
     status_filter: Option<&str>,
+    include_account_lookup: bool,
 ) -> RequestLogSqlFilters {
     let mut clauses = Vec::new();
     let mut params = Vec::new();
 
     append_request_log_query_clause(
         request_log_query::parse_request_log_query(query),
+        include_account_lookup,
         &mut clauses,
         &mut params,
     );
@@ -781,11 +792,18 @@ fn build_request_log_filters(
 /// 无
 fn append_request_log_query_clause(
     query: request_log_query::RequestLogQuery,
+    include_account_lookup: bool,
     clauses: &mut Vec<String>,
     params: &mut Vec<Value>,
 ) {
     match query {
         request_log_query::RequestLogQuery::All => {}
+        request_log_query::RequestLogQuery::AccountLike(pattern) => {
+            append_account_query_clause(pattern, false, include_account_lookup, clauses, params);
+        }
+        request_log_query::RequestLogQuery::AccountExact(value) => {
+            append_account_query_clause(value, true, include_account_lookup, clauses, params);
+        }
         request_log_query::RequestLogQuery::FieldLike { column, pattern } => {
             clauses.push(format!("IFNULL(r.{column}, '') LIKE ?"));
             params.push(Value::Text(pattern));
@@ -804,42 +822,86 @@ fn append_request_log_query_clause(
             params.push(Value::Integer(end));
         }
         request_log_query::RequestLogQuery::GlobalLike(pattern) => {
-            clauses.push(
-                "(r.request_path LIKE ?
-                    OR IFNULL(r.initial_account_id,'') LIKE ?
-                    OR IFNULL(r.attempted_account_ids_json,'') LIKE ?
-                    OR IFNULL(r.initial_aggregate_api_id,'') LIKE ?
-                    OR IFNULL(r.attempted_aggregate_api_ids_json,'') LIKE ?
-                    OR IFNULL(r.aggregate_api_supplier_name,'') LIKE ?
-                    OR IFNULL(r.aggregate_api_url,'') LIKE ?
-                    OR IFNULL(r.original_path,'') LIKE ?
-                    OR IFNULL(r.adapted_path,'') LIKE ?
-                    OR r.method LIKE ?
-                    OR IFNULL(r.request_type,'') LIKE ?
-                    OR IFNULL(r.account_id,'') LIKE ?
-                    OR IFNULL(r.model,'') LIKE ?
-                    OR IFNULL(r.reasoning_effort,'') LIKE ?
-                    OR IFNULL(r.service_tier,'') LIKE ?
-                    OR IFNULL(r.effective_service_tier,'') LIKE ?
-                    OR IFNULL(r.response_adapter,'') LIKE ?
-                    OR IFNULL(r.error,'') LIKE ?
-                    OR IFNULL(r.key_id,'') LIKE ?
-                    OR IFNULL(r.trace_id,'') LIKE ?
-                    OR IFNULL(r.upstream_url,'') LIKE ?
-                    OR IFNULL(CAST(r.status_code AS TEXT),'') LIKE ?
-                    OR IFNULL(CAST(t.input_tokens AS TEXT),'') LIKE ?
-                    OR IFNULL(CAST(t.cached_input_tokens AS TEXT),'') LIKE ?
-                    OR IFNULL(CAST(t.output_tokens AS TEXT),'') LIKE ?
-                    OR IFNULL(CAST(t.total_tokens AS TEXT),'') LIKE ?
-                    OR IFNULL(CAST(t.reasoning_output_tokens AS TEXT),'') LIKE ?
-                    OR IFNULL(CAST(t.estimated_cost_usd AS TEXT),'') LIKE ?)"
-                    .to_string(),
-            );
-            for _ in 0..28 {
+            let mut global_fields = vec![
+                "r.request_path LIKE ?",
+                "IFNULL(r.initial_account_id,'') LIKE ?",
+                "IFNULL(r.attempted_account_ids_json,'') LIKE ?",
+                "IFNULL(r.initial_aggregate_api_id,'') LIKE ?",
+                "IFNULL(r.attempted_aggregate_api_ids_json,'') LIKE ?",
+                "IFNULL(r.aggregate_api_supplier_name,'') LIKE ?",
+                "IFNULL(r.aggregate_api_url,'') LIKE ?",
+                "IFNULL(r.original_path,'') LIKE ?",
+                "IFNULL(r.adapted_path,'') LIKE ?",
+                "r.method LIKE ?",
+                "IFNULL(r.request_type,'') LIKE ?",
+                "IFNULL(r.account_id,'') LIKE ?",
+                "IFNULL(r.model,'') LIKE ?",
+                "IFNULL(r.reasoning_effort,'') LIKE ?",
+                "IFNULL(r.service_tier,'') LIKE ?",
+                "IFNULL(r.effective_service_tier,'') LIKE ?",
+                "IFNULL(r.response_adapter,'') LIKE ?",
+                "IFNULL(r.error,'') LIKE ?",
+                "IFNULL(r.key_id,'') LIKE ?",
+                "IFNULL(r.trace_id,'') LIKE ?",
+                "IFNULL(r.upstream_url,'') LIKE ?",
+                "IFNULL(CAST(r.status_code AS TEXT),'') LIKE ?",
+                "IFNULL(CAST(t.input_tokens AS TEXT),'') LIKE ?",
+                "IFNULL(CAST(t.cached_input_tokens AS TEXT),'') LIKE ?",
+                "IFNULL(CAST(t.output_tokens AS TEXT),'') LIKE ?",
+                "IFNULL(CAST(t.total_tokens AS TEXT),'') LIKE ?",
+                "IFNULL(CAST(t.reasoning_output_tokens AS TEXT),'') LIKE ?",
+                "IFNULL(CAST(t.estimated_cost_usd AS TEXT),'') LIKE ?",
+            ];
+            if include_account_lookup {
+                global_fields.extend([
+                    "IFNULL(a.label,'') LIKE ?",
+                    "IFNULL(a.chatgpt_account_id,'') LIKE ?",
+                    "IFNULL(a.workspace_id,'') LIKE ?",
+                ]);
+            }
+            clauses.push(format!(
+                "({})",
+                global_fields.join("\n                    OR ")
+            ));
+            for _ in 0..global_fields.len() {
                 params.push(Value::Text(pattern.clone()));
             }
         }
     }
+}
+
+fn account_join_clause(include_account_lookup: bool) -> &'static str {
+    if include_account_lookup {
+        "LEFT JOIN accounts a ON a.id = r.account_id"
+    } else {
+        ""
+    }
+}
+
+fn append_account_query_clause(
+    value: String,
+    is_exact: bool,
+    include_account_lookup: bool,
+    clauses: &mut Vec<String>,
+    params: &mut Vec<Value>,
+) {
+    if include_account_lookup {
+        let comparator = if is_exact { "=" } else { "LIKE" };
+        clauses.push(format!(
+            "(IFNULL(r.account_id, '') {comparator} ?
+                OR IFNULL(a.label, '') {comparator} ?
+                OR IFNULL(a.chatgpt_account_id, '') {comparator} ?
+                OR IFNULL(a.workspace_id, '') {comparator} ?)"
+        ));
+        for _ in 0..4 {
+            params.push(Value::Text(value.clone()));
+        }
+        return;
+    }
+
+    let comparator = if is_exact { "=" } else { "LIKE" };
+    clauses.push(format!("IFNULL(r.account_id, '') {comparator} ?"));
+    params.push(Value::Text(value));
 }
 
 /// 函数 `append_status_filter_clause`

--- a/crates/core/src/storage/tests/request_log_query_tests.rs
+++ b/crates/core/src/storage/tests/request_log_query_tests.rs
@@ -62,10 +62,7 @@ fn prefixed_account_query_supports_alias() {
     let query = parse_request_log_query(Some("account:acc-1"));
     assert!(matches!(
         query,
-        RequestLogQuery::FieldLike {
-            column: "account_id",
-            pattern
-        } if pattern == "%acc-1%"
+        RequestLogQuery::AccountLike(pattern) if pattern == "%acc-1%"
     ));
 }
 

--- a/crates/core/tests/storage.rs
+++ b/crates/core/tests/storage.rs
@@ -735,6 +735,26 @@ fn request_logs_support_prefixed_query_filters() {
     let storage = Storage::open_in_memory().expect("open in memory");
     storage.init().expect("init schema");
 
+    for (id, label) in [
+        ("acc-1", "owner-alpha@example.com"),
+        ("acc-2", "owner-beta@example.com"),
+    ] {
+        storage
+            .insert_account(&Account {
+                id: id.to_string(),
+                label: label.to_string(),
+                issuer: "https://auth.openai.com".to_string(),
+                chatgpt_account_id: None,
+                workspace_id: None,
+                group_name: None,
+                sort: 0,
+                status: "active".to_string(),
+                created_at: now_ts(),
+                updated_at: now_ts(),
+            })
+            .expect("insert account");
+    }
+
     storage
         .insert_request_log(&RequestLog {
             trace_id: Some("trc-alpha-extra".to_string()),
@@ -893,6 +913,22 @@ fn request_logs_support_prefixed_query_filters() {
         fallback_filtered[0].error.as_deref(),
         Some("upstream timeout")
     );
+
+    let account_label_filtered = storage
+        .list_request_logs(Some("owner-alpha@example.com"), 100)
+        .expect("filter by account label");
+    assert_eq!(account_label_filtered.len(), 2);
+    assert!(account_label_filtered
+        .iter()
+        .all(|log| log.account_id.as_deref() == Some("acc-1")));
+
+    let account_prefixed_filtered = storage
+        .list_request_logs(Some("account:=owner-alpha@example.com"), 100)
+        .expect("filter by account label with account prefix");
+    assert_eq!(account_prefixed_filtered.len(), 2);
+    assert!(account_prefixed_filtered
+        .iter()
+        .all(|log| log.account_id.as_deref() == Some("acc-1")));
 }
 
 /// 函数 `request_log_today_summary_reads_from_token_stats_table`


### PR DESCRIPTION
## Summary
- support request log search by account label, ChatGPT account ID, and workspace ID
- make `account:` / `account:=` queries resolve against account identity fields instead of only `request_logs.account_id`
- add regression coverage for account-label filtering while preserving lightweight request-log query scenarios without an `accounts` table

## Verification
- `cargo test -p codexmanager-core prefixed_account_query_supports_alias`
- `cargo test -p codexmanager-core request_logs_support_prefixed_query_filters`
- `cargo test -p codexmanager-core token_stat_failure_still_commits_request_log`