### PR TITLE
feat: 支持聚合 API 启用禁用开关

### DIFF
--- a/apps/src/app/aggregate-api/page.tsx
+++ b/apps/src/app/aggregate-api/page.tsx
@@ -34,6 +34,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -119,6 +120,7 @@ export default function AggregateApiPage() {
   >({});
   const [loadingSecretId, setLoadingSecretId] = useState<string | null>(null);
   const [testingApiId, setTestingApiId] = useState<string | null>(null);
+  const [togglingApiId, setTogglingApiId] = useState<string | null>(null);
 
   const { data: aggregateApis = [], isLoading } = useQuery({
     queryKey: ["aggregate-apis"],
@@ -258,6 +260,43 @@ export default function AggregateApiPage() {
     },
     onError: (error: unknown) => {
       toast.error(`${t("设为优先")} ${t("失败")}: ${error instanceof Error ? error.message : String(error)}`);
+    },
+  });
+
+  const toggleStatusMutation = useMutation({
+    mutationFn: async ({
+      api,
+      enabled,
+    }: {
+      api: AggregateApi;
+      enabled: boolean;
+    }) => {
+      await accountClient.updateAggregateApi(api.id, {
+        supplierName: api.supplierName || api.url,
+        status: enabled ? "active" : "disabled",
+      });
+      return enabled;
+    },
+    onMutate: async ({ api }) => {
+      setTogglingApiId(api.id);
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["aggregate-apis"] }),
+        queryClient.invalidateQueries({ queryKey: ["apikeys"] }),
+        queryClient.invalidateQueries({ queryKey: ["startup-snapshot"] }),
+      ]);
+      toast.success(t("状态已更新"));
+    },
+    onError: (error: unknown) => {
+      toast.error(
+        `${t("更新状态失败")}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    },
+    onSettled: async (_result, _error, variables) => {
+      setTogglingApiId((current) =>
+        current === variables.api.id ? null : current,
+      );
     },
   });
 
@@ -481,6 +520,7 @@ export default function AggregateApiPage() {
                   <TableHead className="w-[148px]">{t("密钥")}</TableHead>
                   <TableHead className="w-[64px] text-center">{t("顺序")}</TableHead>
                   <TableHead className="w-[130px]">{t("测试连通性")}</TableHead>
+                  <TableHead className="w-[104px]">{t("状态")}</TableHead>
                   <TableHead className="text-center">{t("操作")}</TableHead>
                 </TableRow>
               </TableHeader>
@@ -503,6 +543,9 @@ export default function AggregateApiPage() {
                       <TableCell>
                         <Skeleton className="h-6 w-20 rounded-full" />
                       </TableCell>
+                      <TableCell>
+                        <Skeleton className="h-6 w-16 rounded-full" />
+                      </TableCell>
                       <TableCell className="text-center">
                         <Skeleton className="mx-auto h-8 w-8" />
                       </TableCell>
@@ -510,7 +553,7 @@ export default function AggregateApiPage() {
                   ))
                 ) : filteredAggregateApis.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={6} className="h-48 text-center">
+                    <TableCell colSpan={7} className="h-48 text-center">
                       <div className="flex flex-col items-center justify-center gap-2 text-muted-foreground">
                         <ShieldCheck className="h-8 w-8 opacity-20" />
                         <p>
@@ -529,6 +572,10 @@ export default function AggregateApiPage() {
                 ) : (
                   filteredAggregateApis.map((api) => {
                     const revealed = revealedSecrets[api.id];
+                    const isEnabled =
+                      String(api.status || "")
+                        .trim()
+                        .toLowerCase() !== "disabled";
                     const createdTimeText = formatTsFromSeconds(
                       api.createdAt,
                       t("未知时间"),
@@ -699,6 +746,23 @@ export default function AggregateApiPage() {
                               </TooltipContent>
                             </Tooltip>
                           ) : null}
+                        </TableCell>
+                        <TableCell className="align-middle">
+                          <div className="flex items-center gap-2">
+                            <Switch
+                              className="scale-75"
+                              checked={isEnabled}
+                              disabled={
+                                !isServiceReady || togglingApiId === api.id
+                              }
+                              onCheckedChange={(enabled) =>
+                                toggleStatusMutation.mutate({ api, enabled })
+                              }
+                            />
+                            <span className="text-[10px] font-medium text-muted-foreground">
+                              {isEnabled ? t("启用") : t("禁用")}
+                            </span>
+                          </div>
                         </TableCell>
                         <TableCell>
                           <div className="table-action-cell gap-1">

--- a/apps/src/lib/api/account-client.ts
+++ b/apps/src/lib/api/account-client.ts
@@ -107,6 +107,7 @@ interface AggregateApiPayload {
   providerType?: string | null;
   supplierName?: string | null;
   sort?: number | null;
+  status?: string | null;
   url?: string | null;
   key?: string | null;
   authType?: string | null;
@@ -471,6 +472,7 @@ export const accountClient = {
         providerType: params.providerType || null,
         supplierName: params.supplierName || null,
         sort: typeof params.sort === "number" ? params.sort : null,
+        status: params.status || null,
         url: params.url || null,
         key: params.key || null,
         authType: params.authType || null,
@@ -498,6 +500,7 @@ export const accountClient = {
         providerType: params.providerType || null,
         supplierName: params.supplierName || null,
         sort: typeof params.sort === "number" ? params.sort : null,
+        status: params.status || null,
         url: params.url || null,
         key: params.key || null,
         authType: params.authType || null,

--- a/crates/core/src/storage/aggregate_apis.rs
+++ b/crates/core/src/storage/aggregate_apis.rs
@@ -186,6 +186,14 @@ impl Storage {
         Ok(())
     }
 
+    pub fn update_aggregate_api_status(&self, api_id: &str, status: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE aggregate_apis SET status = ?1, updated_at = ?2 WHERE id = ?3",
+            (status, now_ts(), api_id),
+        )?;
+        Ok(())
+    }
+
     /// 函数 `update_aggregate_api_type`
     ///
     /// 作者: gaohongshun

--- a/crates/service/src/aggregate_api.rs
+++ b/crates/service/src/aggregate_api.rs
@@ -98,6 +98,20 @@ fn normalize_sort(value: Option<i64>) -> i64 {
     value.unwrap_or(0)
 }
 
+fn normalize_status(value: Option<String>) -> Result<String, String> {
+    match value {
+        Some(raw) => {
+            let normalized = raw.trim().to_ascii_lowercase().replace('-', "_");
+            match normalized.as_str() {
+                "active" | "enabled" | "enable" => Ok("active".to_string()),
+                "disabled" | "disable" | "inactive" => Ok("disabled".to_string()),
+                other => Err(format!("unsupported aggregate api status: {other}")),
+            }
+        }
+        None => Ok("active".to_string()),
+    }
+}
+
 fn normalize_auth_type(value: Option<String>) -> Result<String, String> {
     match value {
         Some(raw) => {
@@ -959,6 +973,7 @@ pub(crate) fn update_aggregate_api(
     provider_type: Option<String>,
     supplier_name: Option<String>,
     sort: Option<i64>,
+    status: Option<String>,
     auth_type: Option<String>,
     auth_custom_enabled: Option<bool>,
     auth_params: Option<serde_json::Value>,
@@ -1005,6 +1020,12 @@ pub(crate) fn update_aggregate_api(
     if sort.is_some() {
         storage
             .update_aggregate_api_sort(api_id, normalize_sort(sort))
+            .map_err(|err| err.to_string())?;
+    }
+    if let Some(status) = status {
+        let normalized_status = normalize_status(Some(status))?;
+        storage
+            .update_aggregate_api_status(api_id, normalized_status.as_str())
             .map_err(|err| err.to_string())?;
     }
     if let Some(url) = url {

--- a/crates/service/src/rpc_dispatch/aggregate_api.rs
+++ b/crates/service/src/rpc_dispatch/aggregate_api.rs
@@ -73,6 +73,7 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
             let provider_type = super::string_param(req, "providerType");
             let supplier_name = super::string_param(req, "supplierName");
             let sort = super::i64_param(req, "sort");
+            let status = super::string_param(req, "status");
             let url = super::string_param(req, "url");
             let key = super::string_param(req, "key");
             let auth_type = super::string_param(req, "authType");
@@ -93,6 +94,7 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
                 provider_type,
                 supplier_name,
                 sort,
+                status,
                 auth_type,
                 auth_custom_enabled,
                 auth_params,


### PR DESCRIPTION
## 改动说明

本 PR 为聚合 API 列表补充单项启用/禁用开关。

现在在“测试连通性”后面新增了“状态”列，可以直接对某一条聚合 API 做启用/禁用切换。禁用后的聚合 API 不会再参与现有的聚合 API 轮转请求。

## 具体修改

- 前端聚合 API 列表页新增状态开关，交互风格复用现有 Switch 组件
- 前端 `aggregateApi/update` 请求增加 `status` 参数透传
- service 层补充聚合 API 状态归一化逻辑，支持 `active/disabled`
- storage 层新增聚合 API 状态更新方法
- 复用现有轮转过滤逻辑：聚合 API 轮转本身已按 `status == "active"` 过滤，所以禁用后会自动跳过，不需要额外改路由算法

## 验证

- `corepack pnpm run build:desktop`
- `cargo test -p codexmanager-service aggregate_api_ --lib`

## 影响范围

- 聚合 API 管理页
- 聚合 API 更新 RPC 链路
- 聚合 API 轮转候选筛选
