### PR TITLE
fix: use local day range across time zones

### DIFF
--- a/apps/src/app/logs/page.tsx
+++ b/apps/src/app/logs/page.tsx
@@ -50,6 +50,7 @@ import {
 import { serviceClient } from "@/lib/api/service-client";
 import { useDesktopPageActive } from "@/hooks/useDesktopPageActive";
 import { useDeferredDesktopActivation } from "@/hooks/useDeferredDesktopActivation";
+import { useLocalDayRange } from "@/hooks/useLocalDayRange";
 import { usePageTransitionReady } from "@/hooks/usePageTransitionReady";
 import { useI18n } from "@/lib/i18n/provider";
 import { useAppStore } from "@/lib/store/useAppStore";
@@ -1190,6 +1191,7 @@ function buildSummaryPlaceholder(logs: RequestLog[]): RequestLogFilterSummary {
  */
 function LogsPageContent() {
   const { t } = useI18n();
+  const localDayRange = useLocalDayRange();
   const searchParams = useSearchParams();
   const { serviceStatus } = useAppStore();
   const isPageActive = useDesktopPageActive("/logs/");
@@ -1211,7 +1213,8 @@ function LogsPageContent() {
   const startupSnapshot = queryClient.getQueryData<StartupSnapshot>(
     buildStartupSnapshotQueryKey(
       serviceStatus.addr,
-      STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT
+      STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
+      localDayRange.dayStartTs,
     )
   );
   const startupAccounts = startupSnapshot?.accounts || [];

--- a/apps/src/app/plugins/page.tsx
+++ b/apps/src/app/plugins/page.tsx
@@ -43,6 +43,7 @@ import { pluginClient } from "@/lib/api/plugin-client";
 import { useI18n } from "@/lib/i18n/provider";
 import { useAppStore } from "@/lib/store/useAppStore";
 import { cn } from "@/lib/utils";
+import { formatLocalDateTimeFromSeconds } from "@/lib/utils/time";
 import {
   InstalledPluginSummary,
   PluginCatalogEntry,
@@ -302,18 +303,7 @@ function formatDuration(value: number | null): string {
  * 返回函数执行结果
  */
 function formatTimestamp(value: number | null): string {
-  if (value == null) return "-";
-  const date = new Date(value * 1000);
-  if (Number.isNaN(date.getTime())) return "-";
-  return new Intl.DateTimeFormat("zh-CN", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  }).format(date);
+  return formatLocalDateTimeFromSeconds(value, "-");
 }
 
 /**

--- a/apps/src/components/layout/app-bootstrap.tsx
+++ b/apps/src/components/layout/app-bootstrap.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { CodexCliOnboardingDialog } from "@/components/layout/codex-cli-onboarding-dialog";
 import { applyAppearancePreset } from "@/lib/appearance";
 import { useRuntimeCapabilities } from "@/hooks/useRuntimeCapabilities";
+import { useLocalDayRange } from "@/hooks/useLocalDayRange";
 import {
   formatServiceError,
   isExpectedInitializeResult,
@@ -73,6 +74,7 @@ export function AppBootstrap({ children }: { children: React.ReactNode }) {
   } = useAppStore();
   const { setTheme } = useTheme();
   const { t } = useI18n();
+  const localDayRange = useLocalDayRange();
   const queryClient = useQueryClient();
   const pathname = usePathname();
   const { canManageService, isDesktopRuntime, isUnsupportedWebRuntime } =
@@ -149,16 +151,19 @@ export function AppBootstrap({ children }: { children: React.ReactNode }) {
       await queryClient.prefetchQuery({
         queryKey: buildStartupSnapshotQueryKey(
           addr,
-          STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT
+          STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
+          localDayRange.dayStartTs,
         ),
         queryFn: () =>
           serviceClient.getStartupSnapshot({
             requestLogLimit: STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
+            dayStartTs: localDayRange.dayStartTs,
+            dayEndTs: localDayRange.dayEndTs,
           }),
         staleTime: STARTUP_SNAPSHOT_STALE_TIME,
       });
     },
-    [queryClient]
+    [localDayRange.dayEndTs, localDayRange.dayStartTs, queryClient]
   );
 
   const shouldBlockOnInitialDashboardSnapshot = useCallback(

--- a/apps/src/hooks/useAccounts.ts
+++ b/apps/src/hooks/useAccounts.ts
@@ -12,6 +12,7 @@ import {
 import { getAppErrorMessage } from "@/lib/api/transport";
 import { useDesktopPageActive } from "@/hooks/useDesktopPageActive";
 import { useDeferredDesktopActivation } from "@/hooks/useDeferredDesktopActivation";
+import { useLocalDayRange } from "@/hooks/useLocalDayRange";
 import { useRuntimeCapabilities } from "@/hooks/useRuntimeCapabilities";
 import { useI18n } from "@/lib/i18n/provider";
 import { useAppStore } from "@/lib/store/useAppStore";
@@ -107,6 +108,7 @@ function formatUsageRefreshErrorMessage(
 export function useAccounts() {
   const queryClient = useQueryClient();
   const { t } = useI18n();
+  const localDayRange = useLocalDayRange();
   const serviceStatus = useAppStore((state) => state.serviceStatus);
   const { canAccessManagementRpc } = useRuntimeCapabilities();
   const isServiceReady = canAccessManagementRpc && serviceStatus.connected;
@@ -117,7 +119,8 @@ export function useAccounts() {
   const startupSnapshot = queryClient.getQueryData<StartupSnapshot>(
     buildStartupSnapshotQueryKey(
       serviceStatus.addr,
-      STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT
+      STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
+      localDayRange.dayStartTs,
     )
   );
   const startupAccounts = startupSnapshot?.accounts || [];

--- a/apps/src/hooks/useApiKeys.ts
+++ b/apps/src/hooks/useApiKeys.ts
@@ -10,6 +10,7 @@ import {
 import { getAppErrorMessage } from "@/lib/api/transport";
 import { useDesktopPageActive } from "@/hooks/useDesktopPageActive";
 import { useDeferredDesktopActivation } from "@/hooks/useDeferredDesktopActivation";
+import { useLocalDayRange } from "@/hooks/useLocalDayRange";
 import { useRuntimeCapabilities } from "@/hooks/useRuntimeCapabilities";
 import { useI18n } from "@/lib/i18n/provider";
 import { useAppStore } from "@/lib/store/useAppStore";
@@ -33,6 +34,7 @@ type ApiKeyPayload = Parameters<typeof accountClient.createApiKey>[0];
 export function useApiKeys() {
   const queryClient = useQueryClient();
   const { t } = useI18n();
+  const localDayRange = useLocalDayRange();
   const serviceStatus = useAppStore((state) => state.serviceStatus);
   const { canAccessManagementRpc } = useRuntimeCapabilities();
   const isServiceReady = canAccessManagementRpc && serviceStatus.connected;
@@ -43,7 +45,8 @@ export function useApiKeys() {
   const startupSnapshot = queryClient.getQueryData<StartupSnapshot>(
     buildStartupSnapshotQueryKey(
       serviceStatus.addr,
-      STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT
+      STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
+      localDayRange.dayStartTs,
     )
   );
   const startupApiKeys = startupSnapshot?.apiKeys || [];

--- a/apps/src/hooks/useDashboardStats.ts
+++ b/apps/src/hooks/useDashboardStats.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useDeferredDesktopActivation } from "@/hooks/useDeferredDesktopActivation";
 import { useDesktopPageActive } from "@/hooks/useDesktopPageActive";
+import { useLocalDayRange } from "@/hooks/useLocalDayRange";
 import {
   buildStartupSnapshotQueryKey,
   hasStartupSnapshotSignal,
@@ -31,6 +32,7 @@ import { pickBestRecommendations, pickCurrentAccount } from "@/lib/utils/usage";
  */
 export function useDashboardStats() {
   const serviceStatus = useAppStore((state) => state.serviceStatus);
+  const localDayRange = useLocalDayRange();
   const isServiceReady = serviceStatus.connected;
   const isPageActive = useDesktopPageActive("/");
   const isSnapshotQueryEnabled = useDeferredDesktopActivation(
@@ -49,11 +51,14 @@ export function useDashboardStats() {
   const snapshotQuery = useQuery({
     queryKey: buildStartupSnapshotQueryKey(
       serviceStatus.addr,
-      STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT
+      STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
+      localDayRange.dayStartTs,
     ),
     queryFn: () =>
       serviceClient.getStartupSnapshot({
         requestLogLimit: STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
+        dayStartTs: localDayRange.dayStartTs,
+        dayEndTs: localDayRange.dayEndTs,
       }),
     enabled: isSnapshotQueryEnabled,
     retry: 1,

--- a/apps/src/hooks/useLocalDayRange.ts
+++ b/apps/src/hooks/useLocalDayRange.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getLocalDayRange, type LocalDayRange } from "@/lib/utils/time";
+
+/**
+ * 函数 `useLocalDayRange`
+ *
+ * 作者: gaohongshun
+ *
+ * 时间: 2026-04-13
+ *
+ * # 参数
+ * 无
+ *
+ * # 返回
+ * 返回当前浏览器本地时区对应的当天时间范围
+ */
+export function useLocalDayRange(): LocalDayRange {
+  const [dayRange, setDayRange] = useState<LocalDayRange>(() => getLocalDayRange());
+
+  useEffect(() => {
+    const refresh = () => {
+      setDayRange((current) => {
+        const next = getLocalDayRange();
+        if (
+          current.dayStartTs === next.dayStartTs &&
+          current.dayEndTs === next.dayEndTs &&
+          current.timeZone === next.timeZone
+        ) {
+          return current;
+        }
+        return next;
+      });
+    };
+
+    refresh();
+    const intervalId = window.setInterval(refresh, 60_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  return dayRange;
+}

--- a/apps/src/lib/api/service-client.ts
+++ b/apps/src/lib/api/service-client.ts
@@ -43,7 +43,11 @@ export const serviceClient = {
     return readInitializeResult(result);
   },
   async getStartupSnapshot(
-    params?: Record<string, unknown>
+    params?: {
+      requestLogLimit?: number;
+      dayStartTs?: number;
+      dayEndTs?: number;
+    }
   ): Promise<StartupSnapshot> {
     const result = await invoke<unknown>(
       "service_startup_snapshot",
@@ -175,10 +179,13 @@ export const serviceClient = {
   clearGatewayErrorLogs: () =>
     invoke("service_requestlog_error_clear", withAddr()),
   clearRequestLogs: () => invoke("service_requestlog_clear", withAddr()),
-  async getTodaySummary(): Promise<RequestLogTodaySummary> {
+  async getTodaySummary(params?: {
+    dayStartTs?: number;
+    dayEndTs?: number;
+  }): Promise<RequestLogTodaySummary> {
     const result = await invoke<unknown>(
       "service_requestlog_today_summary",
-      withAddr()
+      withAddr(params)
     );
     return normalizeTodaySummary(result);
   },

--- a/apps/src/lib/api/startup-snapshot.ts
+++ b/apps/src/lib/api/startup-snapshot.ts
@@ -23,9 +23,10 @@ export const STARTUP_SNAPSHOT_WARMUP_TIMEOUT_MS = 45_000;
  */
 export function buildStartupSnapshotQueryKey(
   addr: string | null | undefined,
-  requestLogLimit = STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT
+  requestLogLimit = STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
+  dayStartTs?: number | null,
 ) {
-  return ["startup-snapshot", addr || null, requestLogLimit] as const;
+  return ["startup-snapshot", addr || null, requestLogLimit, dayStartTs || null] as const;
 }
 
 /**

--- a/apps/src/lib/utils/time.ts
+++ b/apps/src/lib/utils/time.ts
@@ -1,0 +1,77 @@
+"use client";
+
+export interface LocalDayRange {
+  dayStartTs: number;
+  dayEndTs: number;
+  timeZone: string | null;
+}
+
+function getPreferredLocale(): string | undefined {
+  if (typeof document !== "undefined") {
+    const lang = document.documentElement.lang.trim();
+    if (lang) {
+      return lang;
+    }
+  }
+  if (typeof navigator !== "undefined") {
+    const language = String(navigator.language || "").trim();
+    if (language) {
+      return language;
+    }
+  }
+  return undefined;
+}
+
+export function getBrowserTimeZone(): string | null {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+  } catch {
+    return null;
+  }
+}
+
+export function getLocalDayRange(referenceDate = new Date()): LocalDayRange {
+  const start = new Date(
+    referenceDate.getFullYear(),
+    referenceDate.getMonth(),
+    referenceDate.getDate(),
+    0,
+    0,
+    0,
+    0,
+  );
+  const end = new Date(
+    referenceDate.getFullYear(),
+    referenceDate.getMonth(),
+    referenceDate.getDate() + 1,
+    0,
+    0,
+    0,
+    0,
+  );
+
+  return {
+    dayStartTs: Math.floor(start.getTime() / 1000),
+    dayEndTs: Math.floor(end.getTime() / 1000),
+    timeZone: getBrowserTimeZone(),
+  };
+}
+
+export function formatLocalDateTimeFromSeconds(
+  timestamp: number | null | undefined,
+  emptyLabel = "未知",
+): string {
+  if (!timestamp) return emptyLabel;
+  const date = new Date(timestamp * 1000);
+  if (Number.isNaN(date.getTime())) return emptyLabel;
+
+  return new Intl.DateTimeFormat(getPreferredLocale(), {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(date);
+}

--- a/apps/src/lib/utils/usage.ts
+++ b/apps/src/lib/utils/usage.ts
@@ -1,16 +1,7 @@
 "use client";
 
+import { formatLocalDateTimeFromSeconds } from "@/lib/utils/time";
 import { Account, AccountUsage, AvailabilityLevel, RequestLog } from "@/types";
-
-const dateTimeFormatter = new Intl.DateTimeFormat("zh-CN", {
-  year: "numeric",
-  month: "2-digit",
-  day: "2-digit",
-  hour: "2-digit",
-  minute: "2-digit",
-  second: "2-digit",
-  hour12: false,
-});
 
 const COMPACT_NUMBER_UNITS = [
   { value: 1e18, suffix: "E" },
@@ -82,10 +73,7 @@ export function formatTsFromSeconds(
   timestamp: number | null | undefined,
   emptyLabel = "未知"
 ): string {
-  if (!timestamp) return emptyLabel;
-  const date = new Date(timestamp * 1000);
-  if (Number.isNaN(date.getTime())) return emptyLabel;
-  return dateTimeFormatter.format(date);
+  return formatLocalDateTimeFromSeconds(timestamp, emptyLabel);
 }
 
 /**

--- a/crates/service/src/requestlog/requestlog_today_summary.rs
+++ b/crates/service/src/requestlog/requestlog_today_summary.rs
@@ -3,6 +3,8 @@ use codexmanager_core::rpc::types::RequestLogTodaySummaryResult;
 
 use crate::storage_helpers::open_storage;
 
+const MAX_REQUESTED_DAY_RANGE_SECS: i64 = 48 * 60 * 60;
+
 /// 函数 `local_day_bounds_ts`
 ///
 /// 作者: gaohongshun
@@ -37,6 +39,37 @@ fn local_day_bounds_ts() -> Result<(i64, i64), String> {
     Ok((start, end.max(start)))
 }
 
+/// 函数 `resolve_day_bounds_ts`
+///
+/// 作者: gaohongshun
+///
+/// 时间: 2026-04-13
+///
+/// # 参数
+/// - day_start_ts: 参数 day_start_ts
+/// - day_end_ts: 参数 day_end_ts
+///
+/// # 返回
+/// 返回函数执行结果
+fn resolve_day_bounds_ts(
+    day_start_ts: Option<i64>,
+    day_end_ts: Option<i64>,
+) -> Result<(i64, i64), String> {
+    match (day_start_ts, day_end_ts) {
+        (Some(start), Some(end)) => {
+            if end <= start {
+                return Err("dayEndTs must be greater than dayStartTs".to_string());
+            }
+            if end - start > MAX_REQUESTED_DAY_RANGE_SECS {
+                return Err("requested day range is too large".to_string());
+            }
+            Ok((start, end))
+        }
+        (None, None) => local_day_bounds_ts(),
+        _ => Err("dayStartTs and dayEndTs must be provided together".to_string()),
+    }
+}
+
 /// 函数 `read_requestlog_today_summary`
 ///
 /// 作者: gaohongshun
@@ -44,13 +77,17 @@ fn local_day_bounds_ts() -> Result<(i64, i64), String> {
 /// 时间: 2026-04-02
 ///
 /// # 参数
-/// - crate: 参数 crate
+/// - day_start_ts: 参数 day_start_ts
+/// - day_end_ts: 参数 day_end_ts
 ///
 /// # 返回
 /// 返回函数执行结果
-pub(crate) fn read_requestlog_today_summary() -> Result<RequestLogTodaySummaryResult, String> {
+pub(crate) fn read_requestlog_today_summary(
+    day_start_ts: Option<i64>,
+    day_end_ts: Option<i64>,
+) -> Result<RequestLogTodaySummaryResult, String> {
     let storage = open_storage().ok_or_else(|| "open storage failed".to_string())?;
-    let (start_ts, end_ts) = local_day_bounds_ts()?;
+    let (start_ts, end_ts) = resolve_day_bounds_ts(day_start_ts, day_end_ts)?;
     let summary = storage
         .summarize_request_logs_between(start_ts, end_ts)
         .map_err(|err| format!("summarize request logs failed: {err}"))?;
@@ -67,4 +104,30 @@ pub(crate) fn read_requestlog_today_summary() -> Result<RequestLogTodaySummaryRe
         today_tokens: non_cached_input_tokens.saturating_add(output_tokens),
         estimated_cost: summary.estimated_cost_usd.max(0.0),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_day_bounds_ts, MAX_REQUESTED_DAY_RANGE_SECS};
+
+    #[test]
+    fn resolve_day_bounds_uses_requested_range_when_complete() {
+        assert_eq!(
+            resolve_day_bounds_ts(Some(1_700_000_000), Some(1_700_086_400)).unwrap(),
+            (1_700_000_000, 1_700_086_400)
+        );
+    }
+
+    #[test]
+    fn resolve_day_bounds_rejects_partial_range() {
+        let error = resolve_day_bounds_ts(Some(1_700_000_000), None).unwrap_err();
+        assert!(error.contains("provided together"));
+    }
+
+    #[test]
+    fn resolve_day_bounds_rejects_oversized_range() {
+        let error =
+            resolve_day_bounds_ts(Some(0), Some(MAX_REQUESTED_DAY_RANGE_SECS + 1)).unwrap_err();
+        assert!(error.contains("too large"));
+    }
 }

--- a/crates/service/src/rpc_dispatch/requestlog.rs
+++ b/crates/service/src/rpc_dispatch/requestlog.rs
@@ -55,7 +55,12 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
             super::value_or_error(params.and_then(requestlog_error_list::read_gateway_error_logs))
         }
         "requestlog/today_summary" => {
-            super::value_or_error(requestlog_today_summary::read_requestlog_today_summary())
+            let day_start_ts = super::i64_param(req, "dayStartTs");
+            let day_end_ts = super::i64_param(req, "dayEndTs");
+            super::value_or_error(requestlog_today_summary::read_requestlog_today_summary(
+                day_start_ts,
+                day_end_ts,
+            ))
         }
         _ => return None,
     };

--- a/crates/service/src/rpc_dispatch/startup.rs
+++ b/crates/service/src/rpc_dispatch/startup.rs
@@ -17,7 +17,13 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
     let result = match req.method.as_str() {
         "startup/snapshot" => {
             let request_log_limit = super::i64_param(req, "requestLogLimit");
-            super::value_or_error(startup_snapshot::read_startup_snapshot(request_log_limit))
+            let day_start_ts = super::i64_param(req, "dayStartTs");
+            let day_end_ts = super::i64_param(req, "dayEndTs");
+            super::value_or_error(startup_snapshot::read_startup_snapshot(
+                request_log_limit,
+                day_start_ts,
+                day_end_ts,
+            ))
         }
         _ => return None,
     };

--- a/crates/service/src/startup_snapshot.rs
+++ b/crates/service/src/startup_snapshot.rs
@@ -18,6 +18,8 @@ use crate::{
 /// 返回函数执行结果
 pub(crate) fn read_startup_snapshot(
     request_log_limit: Option<i64>,
+    day_start_ts: Option<i64>,
+    day_end_ts: Option<i64>,
 ) -> Result<StartupSnapshotResult, String> {
     let accounts = account_list::read_accounts(AccountListParams::default(), false)?.items;
     let usage_snapshots = usage_list::read_usage_snapshots()?;
@@ -25,7 +27,8 @@ pub(crate) fn read_startup_snapshot(
     let api_keys = apikey_list::read_api_keys()?;
     let api_models = apikey_models::read_model_options(false)?;
     let manual_preferred_account_id = gateway::manual_preferred_account();
-    let request_log_today_summary = requestlog_today_summary::read_requestlog_today_summary()?;
+    let request_log_today_summary =
+        requestlog_today_summary::read_requestlog_today_summary(day_start_ts, day_end_ts)?;
     let request_logs = requestlog_list::read_request_logs(None, request_log_limit)?;
 
     Ok(StartupSnapshotResult {


### PR DESCRIPTION
## 变更摘要

- 修复跨时区场景下“今日”统计与启动快照使用错误日界的问题
- 前端改为基于浏览器本地时区计算当天起止时间，并显式传给 service
- Service 侧支持接收 `dayStartTs` / `dayEndTs`，避免按服务端本地时区推断
- 补充请求日范围参数校验与对应单测

## 改动范围

- [x] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `apps/src/hooks/useLocalDayRange.ts`
- `apps/src/lib/utils/time.ts`
- `apps/src/hooks/useDashboardStats.ts`
- `apps/src/components/layout/app-bootstrap.tsx`
- `apps/src/lib/api/service-client.ts`
- `apps/src/lib/api/startup-snapshot.ts`
- `crates/service/src/requestlog/requestlog_today_summary.rs`
- `crates/service/src/rpc_dispatch/requestlog.rs`
- `crates/service/src/rpc_dispatch/startup.rs`
- `crates/service/src/startup_snapshot.rs`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
pnpm -C apps run build:desktop
- 通过
- Next.js 静态构建成功，关键页面均完成 prerender

cargo test -p codexmanager-service resolve_day_bounds
- 通过
- 3 个新增单测通过：
  - resolve_day_bounds_uses_requested_range_when_complete
  - resolve_day_bounds_rejects_partial_range
  - resolve_day_bounds_rejects_oversized_range
```

未执行的验证与原因：

```text
pnpm -C apps run test
- 本次未执行，当前主要完成了桌面构建验证

pnpm -C apps run build
- 本次未单独执行；已执行更贴近桌面交付路径的 pnpm -C apps run build:desktop

pnpm -C apps run test:ui
- 本次未执行，未涉及 UI 自动化用例补充

cargo test --workspace
- 本次未全量执行；仅针对本次新增的 service 日范围校验逻辑执行了精确测试
```

## 风险与影响面

- 今日统计、启动快照和依赖其缓存键的前端页面都会受到影响，若前后端参数约定不一致可能出现统计为空或缓存错配
- 当前按浏览器本地时区定义“今日”，这符合用户视角，但会与服务端机器时区下的历史行为不同
- Service 侧新增了日范围参数校验，异常参数会直接报错而不是回退默认行为

## 备注

- 提交前请确认未包含敏感 token、cookie、API key