### PR TITLE
feat: add server-side Cloudflare 403 recovery scripts for ChatGPT upstream

### DIFF
--- a/docs/zh-CN/report/service部署出现Cloudflare 403错误修复说明.md
+++ b/docs/zh-CN/report/service部署出现Cloudflare 403错误修复说明.md
@@ -1,0 +1,271 @@
+# service部署出现Cloudflare 403错误修复说明
+
+这个方案用于下面这种场景：
+
+- CodexManager 的 service 部署在服务器上运行
+- service 访问 `https://chatgpt.com` 时出现 Cloudflare `403`、`cf-mitigated: challenge`，或者云服务器出口 IP 被风控 / 类似“被 ban”的现象
+- `curl_cffi` 直连或走 WARP 代理访问 `https://chatgpt.com` 可以通过，但 CodexManager 自身通过 `reqwest/rustls` 访问上游时仍然失败
+
+核心思路：
+
+1. 在本机启动一个轻量 HTTP 反向代理
+2. 这个代理内部使用 `curl_cffi` + 浏览器指纹 `impersonate`
+3. CodexManager service 不再直接访问 `chatgpt.com`，而是把上游地址改为本机代理
+
+---
+
+## 1. 一键准备 Cloudflare / WARP 本地代理
+
+如果你就是遇到 Oracle / 其他云服务器部署 service 后，直连 `chatgpt.com` 被 Cloudflare `403` 或 `challenge` 拦截的那类场景，仓库现在提供了一个一键准备脚本：
+
+```bash
+scripts/setup-cloudflare-warp-proxy.sh --port 40000
+```
+
+这个脚本会：
+
+- 安装 `cloudflare-warp`
+- 自动尝试注册 WARP 设备
+- 切到本地代理模式，而不是全局接管模式
+- 把监听端口设置为 `127.0.0.1:40000`
+- 连接 WARP，并打印下一步启动 `curl_cffi` 代理和 `codexmanager.env` 的建议配置
+
+说明：
+
+- 它面向 Ubuntu / Debian 系机器
+- 默认不会改成全局隧道模式，因此不会像全局 WARP 那样更容易把 SSH 链路搞断
+- 脚本同时兼容较新的 `warp-cli mode proxy / proxy port` 和较老的 `set-mode / set-proxy-port` 命令风格
+
+如果你已经自己装好了 WARP，也可以跳过安装：
+
+```bash
+scripts/setup-cloudflare-warp-proxy.sh --skip-install --port 40000
+```
+
+---
+
+## 2. 安装依赖
+
+先安装 Python 依赖：
+
+```bash
+python3 -m pip install --upgrade curl_cffi
+```
+
+如果你的系统没有 `pip`：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3-pip
+python3 -m pip install --upgrade curl_cffi
+```
+
+---
+
+## 3. 启动本地代理
+
+仓库也提供了一个更短的启动脚本：
+
+```bash
+scripts/run-curl-cffi-chatgpt-proxy.sh \
+  --proxy socks5h://127.0.0.1:40000 \
+  --install-deps \
+  --verbose
+```
+
+它会：
+
+- 检查并按需安装 `curl_cffi`
+- 用仓库内的 `curl_cffi_chatgpt_proxy.py` 启动本地代理
+- 打印建议写入 `codexmanager.env` 的配置片段
+
+如果你已经装好了依赖，也可以继续直接运行 Python 脚本：
+
+仓库内已提供脚本：
+
+```bash
+python3 scripts/curl_cffi_chatgpt_proxy.py \
+  --listen 127.0.0.1:8787 \
+  --proxy socks5h://127.0.0.1:40000
+```
+
+常见参数：
+
+- `--listen 127.0.0.1:8787`
+  本地监听地址
+- `--proxy socks5h://127.0.0.1:40000`
+  让 `curl_cffi` 再通过 WARP / Clash / sing-box 出口访问上游
+- `--upstream-origin https://chatgpt.com`
+  默认就是这个，一般不用改
+- `--impersonate chrome124`
+  浏览器指纹，默认已经内置
+
+启动成功后会输出类似：
+
+```text
+curl_cffi proxy listening on http://127.0.0.1:8787 (upstream_origin=https://chatgpt.com, proxy=socks5h://127.0.0.1:40000, impersonate=chrome124)
+point CodexManager at: CODEXMANAGER_UPSTREAM_BASE_URL=http://127.0.0.1:8787/backend-api/codex
+```
+
+---
+
+## 4. 先单独验证代理
+
+先不要改 CodexManager，直接验证这个代理本身是否能通：
+
+```bash
+curl -i http://127.0.0.1:8787/__proxy_health
+```
+
+再验证它是否真的能走到 `chatgpt.com`：
+
+```bash
+curl -i http://127.0.0.1:8787/
+```
+
+如果你的出口环境适合，返回不应再是 `cf-mitigated: challenge` 或 Cloudflare `403` 页面。
+
+---
+
+## 5. 修改 CodexManager 配置
+
+把 `codexmanager.env` 改成这样：
+
+```dotenv
+CODEXMANAGER_SERVICE_ADDR=0.0.0.0:5010
+CODEXMANAGER_WEB_ADDR=0.0.0.0:5011
+CODEXMANAGER_DB_PATH=./data/codexmanager.db
+CODEXMANAGER_RPC_TOKEN_FILE=./data/codexmanager.rpc-token
+CODEXMANAGER_WEB_NO_OPEN=1
+
+# 关键：让 CodexManager 把上游改到本地 curl_cffi 代理
+CODEXMANAGER_UPSTREAM_BASE_URL=http://127.0.0.1:8787/backend-api/codex
+
+# 关键：让 /v1/responses 对 chatgpt.com/backend-api/codex 走兼容增强改写，
+# 避免上游因非流式 responses 形态返回 400。
+CODEXMANAGER_GATEWAY_MODE=enhanced
+```
+
+建议把这项清掉，避免双重代理：
+
+```dotenv
+# 不要再保留旧的 reqwest 出口代理
+# CODEXMANAGER_UPSTREAM_PROXY_URL=socks5h://127.0.0.1:40000
+```
+
+原因：
+
+- 现在真正访问上游的是 `curl_cffi_chatgpt_proxy.py`
+- CodexManager 只需要访问本机 `127.0.0.1:8787`
+- 如果 CodexManager 自己也再走一层 SOCKS 代理，容易把“本地代理请求”又绕回去，增加排障难度
+
+改完后重启：
+
+```bash
+./codexmanager-start
+```
+
+---
+
+## 6. 验证 CodexManager 是否接到了本地代理
+
+重启后先请求模型列表：
+
+```bash
+curl http://127.0.0.1:5010/v1/models \
+  -H 'Authorization: Bearer <你的平台APIKey>'
+```
+
+如果成功，再测具体模型：
+
+```bash
+curl http://127.0.0.1:5010/v1/responses \
+  -H 'Authorization: Bearer <你的平台APIKey>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-5.4",
+    "input": "你好"
+  }'
+```
+
+同时观察 `curl_cffi_chatgpt_proxy.py` 的终端输出。
+
+如果代理脚本有请求日志，而 CodexManager 不再报 `Cloudflare 安全验证页`，说明链路已经切换成功。
+
+---
+
+## 7. 常见问题
+
+### 7.1 `curl_cffi` 能访问 `chatgpt.com`，但 CodexManager 还是 challenge
+
+优先确认两件事：
+
+1. `CODEXMANAGER_UPSTREAM_BASE_URL` 是否真的改成了 `http://127.0.0.1:8787/backend-api/codex`
+2. `CODEXMANAGER_UPSTREAM_PROXY_URL` 是否已经清掉，避免 CodexManager 仍然走旧链路
+3. `CODEXMANAGER_GATEWAY_MODE` 是否设成了 `enhanced`；对 `chatgpt.com/backend-api/codex/responses` 而言，这一项会影响 `stream/store` 等兼容改写
+
+### 7.2 代理脚本启动了，但请求没有打过来
+
+说明 CodexManager 还没切到本地代理。重点检查：
+
+- `codexmanager.env` 是否被当前进程读取
+- 是否完整重启了 `codexmanager-start`
+- 平台 Key 是否单独配置了自己的 `upstreamBaseUrl`
+
+### 7.3 想让脚本自己走 WARP / Clash / sing-box
+
+直接使用：
+
+```bash
+python3 scripts/curl_cffi_chatgpt_proxy.py \
+  --listen 127.0.0.1:8787 \
+  --proxy socks5h://127.0.0.1:40000
+```
+
+如果你使用的是 HTTP 代理，也可以写：
+
+```bash
+python3 scripts/curl_cffi_chatgpt_proxy.py \
+  --listen 127.0.0.1:8787 \
+  --proxy http://127.0.0.1:7890
+```
+
+---
+
+### 7.4 service 进程里总是又带回旧的 `CODEXMANAGER_UPSTREAM_PROXY_URL`
+
+如果你明明已经从 `codexmanager.env` 里删掉了 `CODEXMANAGER_UPSTREAM_PROXY_URL`，但进程环境里仍然出现它，通常是数据库里的持久化设置又把它同步回来了。
+
+可以先检查：
+
+```bash
+sqlite3 ./data/codexmanager.db "select key, value from app_settings where key='gateway.upstream_proxy_url';"
+```
+
+如果查到了旧值，就删掉：
+
+```bash
+sqlite3 ./data/codexmanager.db "delete from app_settings where key='gateway.upstream_proxy_url';"
+```
+
+然后完整重启 `codexmanager-start`。
+
+---
+
+## 8. 适用边界
+
+这个脚本当前主要面向：
+
+- `/backend-api/codex/models`
+- `/backend-api/codex/responses`
+- `/backend-api/codex/chat/completions`
+
+它按原始路径做通用转发，因此通常不需要针对单个接口再单独适配。
+
+如果后续你需要更强的能力，例如：
+
+- 更细的请求头改写
+- WebSocket 特殊处理
+- 单独的重试/日志脱敏
+
+可以继续在 `scripts/curl_cffi_chatgpt_proxy.py` 基础上扩展。

--- a/scripts/curl_cffi_chatgpt_proxy.py
+++ b/scripts/curl_cffi_chatgpt_proxy.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+Local reverse proxy for ChatGPT Codex upstream using curl_cffi browser impersonation.
+
+Why this exists:
+- CodexManager currently talks to the upstream with reqwest/rustls.
+- On some cloud hosts, Cloudflare still challenges that client stack even when a SOCKS proxy is used.
+- curl_cffi can impersonate a real browser TLS/HTTP fingerprint and often passes where reqwest does not.
+
+Typical usage:
+  python3 scripts/curl_cffi_chatgpt_proxy.py \
+    --listen 127.0.0.1:8787 \
+    --proxy socks5h://127.0.0.1:40000
+
+Then point CodexManager to:
+  CODEXMANAGER_UPSTREAM_BASE_URL=http://127.0.0.1:8787/backend-api/codex
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Dict, Iterable, Tuple
+from urllib.parse import urlsplit, urlunsplit
+
+from curl_cffi import requests
+
+
+DEFAULT_LISTEN = "127.0.0.1:8787"
+DEFAULT_UPSTREAM_ORIGIN = "https://chatgpt.com"
+DEFAULT_IMPERSONATE = "chrome124"
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+SKIP_REQUEST_HEADERS = HOP_BY_HOP_HEADERS | {
+    "host",
+    "content-length",
+}
+SKIP_RESPONSE_HEADERS = HOP_BY_HOP_HEADERS | {
+    "content-length",
+    "content-encoding",
+    "server",
+    "date",
+}
+ERROR_BODY_LOG_LIMIT = 4096
+REQUEST_BODY_LOG_LIMIT = 4096
+DEBUG_HEADER_ALLOWLIST = {
+    "accept",
+    "content-type",
+    "authorization",
+    "chatgpt-account-id",
+    "openai-account-id",
+    "origin",
+    "referer",
+    "user-agent",
+    "x-requested-with",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Local curl_cffi-based reverse proxy for ChatGPT Codex upstream."
+    )
+    parser.add_argument(
+        "--listen",
+        default=os.environ.get("CURL_CFFI_PROXY_LISTEN", DEFAULT_LISTEN),
+        help="listen host:port (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--upstream-origin",
+        default=os.environ.get(
+            "CURL_CFFI_PROXY_UPSTREAM_ORIGIN", DEFAULT_UPSTREAM_ORIGIN
+        ),
+        help="target origin, path is preserved from the incoming request (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--proxy",
+        default=os.environ.get("CURL_CFFI_PROXY_URL", ""),
+        help="optional outgoing proxy for curl_cffi, e.g. socks5h://127.0.0.1:40000",
+    )
+    parser.add_argument(
+        "--impersonate",
+        default=os.environ.get("CURL_CFFI_PROXY_IMPERSONATE", DEFAULT_IMPERSONATE),
+        help="curl_cffi browser fingerprint profile (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--connect-timeout",
+        type=float,
+        default=float(os.environ.get("CURL_CFFI_PROXY_CONNECT_TIMEOUT", "15")),
+        help="upstream connect timeout in seconds (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--read-timeout",
+        type=float,
+        default=float(os.environ.get("CURL_CFFI_PROXY_READ_TIMEOUT", "600")),
+        help="upstream read timeout in seconds (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=os.environ.get("CURL_CFFI_PROXY_VERBOSE", "").lower() in {"1", "true", "yes"},
+        help="print request/response details to stderr",
+    )
+    return parser.parse_args()
+
+
+def split_host_port(value: str) -> Tuple[str, int]:
+    if ":" not in value:
+        raise ValueError(f"invalid listen address: {value!r}, expected host:port")
+    host, raw_port = value.rsplit(":", 1)
+    return host, int(raw_port)
+
+
+def normalize_origin(value: str) -> str:
+    raw = value.strip().rstrip("/")
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(
+            f"invalid upstream origin: {value!r}, expected http(s)://host[:port]"
+        )
+    return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
+def target_url(origin: str, request_target: str) -> str:
+    parts = urlsplit(request_target)
+    path = parts.path or "/"
+    return urlunsplit((urlsplit(origin).scheme, urlsplit(origin).netloc, path, parts.query, ""))
+
+
+def build_request_headers(handler: BaseHTTPRequestHandler) -> Dict[str, str]:
+    outgoing: Dict[str, str] = {}
+    for key, value in handler.headers.items():
+        lowered = key.lower()
+        if lowered in SKIP_REQUEST_HEADERS:
+            continue
+        outgoing[key] = value
+    return outgoing
+
+
+def response_headers_for_client(
+    response: requests.Response,
+) -> Iterable[Tuple[str, str]]:
+    for key, value in response.headers.items():
+        if key.lower() in SKIP_RESPONSE_HEADERS:
+            continue
+        yield key, value
+
+
+def redact_header_value(name: str, value: str) -> str:
+    lowered = name.lower()
+    if lowered == "authorization":
+        prefix, _, suffix = value.partition(" ")
+        if suffix:
+            return f"{prefix} ***"
+        return "***"
+    return value
+
+
+def debug_request_headers(headers: Dict[str, str]) -> str:
+    pairs = []
+    for key in sorted(headers):
+        if key.lower() not in DEBUG_HEADER_ALLOWLIST:
+            continue
+        pairs.append(f"{key}={redact_header_value(key, headers[key])}")
+    return ", ".join(pairs) if pairs else "-"
+
+
+def body_preview(body: bytes, limit: int) -> str:
+    if not body:
+        return "<empty>"
+    preview = body[:limit]
+    return preview.decode("utf-8", errors="replace")
+
+
+class ProxyServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, server_address: Tuple[str, int], config: argparse.Namespace):
+        super().__init__(server_address, ProxyHandler)
+        self.config = config
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "curl-cffi-chatgpt-proxy"
+    sys_version = ""
+
+    def do_GET(self) -> None:
+        self._handle()
+
+    def do_POST(self) -> None:
+        self._handle()
+
+    def do_PUT(self) -> None:
+        self._handle()
+
+    def do_PATCH(self) -> None:
+        self._handle()
+
+    def do_DELETE(self) -> None:
+        self._handle()
+
+    def do_OPTIONS(self) -> None:
+        self._handle()
+
+    def do_HEAD(self) -> None:
+        self._handle()
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        sys.stderr.write("%s - - [%s] %s\n" % (self.address_string(), self.log_date_time_string(), fmt % args))
+
+    def _health_response(self) -> None:
+        payload = {
+            "ok": True,
+            "listen": self.server.server_address,
+            "upstreamOrigin": self.server.config.upstream_origin,
+            "proxy": self.server.config.proxy or None,
+            "impersonate": self.server.config.impersonate,
+        }
+        body = json.dumps(payload).encode("utf-8")
+        self.close_connection = True
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _handle(self) -> None:
+        try:
+            if self.path == "/__proxy_health":
+                self._health_response()
+                return
+
+            content_length = int(self.headers.get("Content-Length", "0") or "0")
+            body = self.rfile.read(content_length) if content_length > 0 else b""
+            cfg = self.server.config
+            url = target_url(cfg.upstream_origin, self.path)
+            headers = build_request_headers(self)
+            proxies = None
+            if cfg.proxy:
+                proxies = {"http": cfg.proxy, "https": cfg.proxy}
+
+            if cfg.verbose:
+                sys.stderr.write(
+                    f"[proxy] {self.command} {self.path} -> {url} body={len(body)}B "
+                    f"headers=[{debug_request_headers(headers)}]\n"
+                )
+                if body:
+                    sys.stderr.write(
+                        f"[proxy] request body preview={body_preview(body, REQUEST_BODY_LOG_LIMIT)}\n"
+                    )
+
+            try:
+                upstream = requests.request(
+                    method=self.command,
+                    url=url,
+                    headers=headers,
+                    data=body,
+                    proxies=proxies,
+                    impersonate=cfg.impersonate,
+                    stream=True,
+                    timeout=(cfg.connect_timeout, cfg.read_timeout),
+                    allow_redirects=False,
+                )
+            except Exception as err:
+                if cfg.verbose:
+                    sys.stderr.write(f"[proxy] upstream request failed: {err}\n")
+                message = {
+                    "error": "upstream_request_failed",
+                    "detail": str(err),
+                    "url": url,
+                }
+                encoded = json.dumps(message, ensure_ascii=False).encode("utf-8")
+                self.close_connection = True
+                self.send_response(HTTPStatus.BAD_GATEWAY)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                if self.command != "HEAD":
+                    self.wfile.write(encoded)
+                return
+
+            try:
+                self.close_connection = True
+                if cfg.verbose and upstream.status_code >= 400:
+                    content_type = upstream.headers.get("Content-Type", "")
+                    try:
+                        preview = upstream.content[:ERROR_BODY_LOG_LIMIT]
+                    except Exception:
+                        preview = b""
+                    if preview:
+                        try:
+                            preview_text = preview.decode("utf-8", errors="replace")
+                        except Exception:
+                            preview_text = repr(preview)
+                    else:
+                        preview_text = "<empty>"
+                    sys.stderr.write(
+                        "[proxy] upstream error "
+                        f"status={upstream.status_code} "
+                        f"content_type={content_type or '-'} "
+                        f"body_preview={preview_text}\n"
+                    )
+
+                self.send_response(upstream.status_code)
+                for key, value in response_headers_for_client(upstream):
+                    self.send_header(key, value)
+                # We stream close-delimited bodies to stay compatible with SSE-style responses
+                # without re-buffering the whole upstream payload in memory.
+                self.send_header("Connection", "close")
+                self.send_header("X-Curl-Cffi-Proxy", "1")
+                self.end_headers()
+
+                if self.command == "HEAD":
+                    return
+
+                for chunk in upstream.iter_content(chunk_size=8192):
+                    if not chunk:
+                        continue
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                return
+            finally:
+                upstream.close()
+        except (BrokenPipeError, ConnectionResetError):
+            return
+        except Exception:
+            sys.stderr.write("[proxy] unexpected handler error:\n")
+            traceback.print_exc(file=sys.stderr)
+            try:
+                payload = json.dumps(
+                    {
+                        "error": "proxy_internal_error",
+                        "detail": "unexpected handler error",
+                    }
+                ).encode("utf-8")
+                self.close_connection = True
+                self.send_response(HTTPStatus.INTERNAL_SERVER_ERROR)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Content-Length", str(len(payload)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                if self.command != "HEAD":
+                    self.wfile.write(payload)
+            except (BrokenPipeError, ConnectionResetError):
+                return
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        host, port = split_host_port(args.listen)
+        args.upstream_origin = normalize_origin(args.upstream_origin)
+    except ValueError as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 2
+
+    server = ProxyServer((host, port), args)
+    display_host = host if host not in {"0.0.0.0", ""} else "127.0.0.1"
+    print(
+        f"curl_cffi proxy listening on http://{display_host}:{port} "
+        f"(upstream_origin={args.upstream_origin}, proxy={args.proxy or '-'}, impersonate={args.impersonate})"
+    )
+    print(
+        "point CodexManager at: "
+        f"CODEXMANAGER_UPSTREAM_BASE_URL=http://{display_host}:{port}/backend-api/codex"
+    )
+    try:
+        server.serve_forever(poll_interval=0.5)
+    except KeyboardInterrupt:
+        print("\nstopping proxy")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-curl-cffi-chatgpt-proxy.sh
+++ b/scripts/run-curl-cffi-chatgpt-proxy.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LISTEN="${CURL_CFFI_PROXY_LISTEN:-127.0.0.1:8787}"
+UPSTREAM_ORIGIN="${CURL_CFFI_PROXY_UPSTREAM_ORIGIN:-https://chatgpt.com}"
+IMPERSONATE="${CURL_CFFI_PROXY_IMPERSONATE:-chrome124}"
+PROXY_URL="${CURL_CFFI_PROXY_URL:-socks5h://127.0.0.1:40000}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+INSTALL_DEPS=false
+VERBOSE=false
+NO_UPSTREAM_PROXY=false
+PRINT_ENV=false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/run-curl-cffi-chatgpt-proxy.sh [options]
+
+Options:
+  --listen HOST:PORT         Local listen address (default: 127.0.0.1:8787)
+  --proxy URL                Upstream proxy for curl_cffi (default: socks5h://127.0.0.1:40000)
+  --no-upstream-proxy        Connect to chatgpt.com directly without an extra proxy hop
+  --upstream-origin URL      Upstream origin (default: https://chatgpt.com)
+  --impersonate PROFILE      curl_cffi impersonation profile (default: chrome124)
+  --python BIN               Python executable to use (default: python3)
+  --install-deps             Install curl_cffi if it is missing
+  --verbose                  Enable verbose proxy logging
+  --print-env                Print the recommended CodexManager env snippet and exit
+EOF
+}
+
+step() {
+  printf '%s\n' "$*"
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+ensure_python_dependency() {
+  if "$PYTHON_BIN" -c 'import curl_cffi' >/dev/null 2>&1; then
+    return
+  fi
+  if [[ "$INSTALL_DEPS" != "true" ]]; then
+    echo "error: python package 'curl_cffi' is missing; rerun with --install-deps" >&2
+    exit 1
+  fi
+  step "installing python dependency: curl_cffi"
+  "$PYTHON_BIN" -m pip install --upgrade curl_cffi
+}
+
+print_env_snippet() {
+  cat <<EOF
+CODEXMANAGER_UPSTREAM_BASE_URL=http://${LISTEN}/backend-api/codex
+CODEXMANAGER_GATEWAY_MODE=enhanced
+# Leave CODEXMANAGER_UPSTREAM_PROXY_URL unset.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --listen)
+      LISTEN="${2:-}"
+      shift 2
+      ;;
+    --proxy)
+      PROXY_URL="${2:-}"
+      shift 2
+      ;;
+    --no-upstream-proxy)
+      NO_UPSTREAM_PROXY=true
+      shift
+      ;;
+    --upstream-origin)
+      UPSTREAM_ORIGIN="${2:-}"
+      shift 2
+      ;;
+    --impersonate)
+      IMPERSONATE="${2:-}"
+      shift 2
+      ;;
+    --python)
+      PYTHON_BIN="${2:-}"
+      shift 2
+      ;;
+    --install-deps)
+      INSTALL_DEPS=true
+      shift
+      ;;
+    --verbose)
+      VERBOSE=true
+      shift
+      ;;
+    --print-env)
+      PRINT_ENV=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$PRINT_ENV" == "true" ]]; then
+  print_env_snippet
+  exit 0
+fi
+
+need_cmd "$PYTHON_BIN"
+ensure_python_dependency
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY_SCRIPT="$SCRIPT_DIR/curl_cffi_chatgpt_proxy.py"
+
+if [[ ! -f "$PY_SCRIPT" ]]; then
+  echo "error: proxy entry script not found: $PY_SCRIPT" >&2
+  exit 1
+fi
+
+cmd=(
+  "$PYTHON_BIN" "$PY_SCRIPT"
+  --listen "$LISTEN"
+  --upstream-origin "$UPSTREAM_ORIGIN"
+  --impersonate "$IMPERSONATE"
+)
+
+if [[ "$NO_UPSTREAM_PROXY" != "true" ]]; then
+  cmd+=(--proxy "$PROXY_URL")
+fi
+if [[ "$VERBOSE" == "true" ]]; then
+  cmd+=(--verbose)
+fi
+
+step "launching curl_cffi ChatGPT proxy"
+if [[ "$NO_UPSTREAM_PROXY" == "true" ]]; then
+  step "  upstream proxy: <direct>"
+else
+  step "  upstream proxy: $PROXY_URL"
+fi
+step "  listen: http://$LISTEN"
+step "  suggested codexmanager.env:"
+print_env_snippet | sed 's/^/    /'
+
+exec "${cmd[@]}"

--- a/scripts/setup-cloudflare-warp-proxy.sh
+++ b/scripts/setup-cloudflare-warp-proxy.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT=40000
+SKIP_INSTALL=false
+DISCONNECT_FIRST=false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/setup-cloudflare-warp-proxy.sh [--port 40000] [--skip-install] [--disconnect-first]
+
+What this script does:
+  1. Installs Cloudflare WARP on Ubuntu/Debian (unless --skip-install is used)
+  2. Registers the local device if needed
+  3. Switches WARP into local proxy mode
+  4. Sets the proxy port (default: 40000)
+  5. Connects WARP and prints the next-step commands for CodexManager
+
+Notes:
+  - This script intentionally uses local proxy mode instead of full-tunnel mode.
+  - It tries both new and legacy warp-cli subcommands to stay compatible with different client versions.
+EOF
+}
+
+step() {
+  printf '%s\n' "$*"
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+need_cmd() {
+  if ! have_cmd "$1"; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+as_root() {
+  if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+detect_codename() {
+  if have_cmd lsb_release; then
+    lsb_release -cs
+    return
+  fi
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    if [[ -n "${VERSION_CODENAME:-}" ]]; then
+      printf '%s\n' "$VERSION_CODENAME"
+      return
+    fi
+    if [[ -n "${UBUNTU_CODENAME:-}" ]]; then
+      printf '%s\n' "$UBUNTU_CODENAME"
+      return
+    fi
+  fi
+  echo "error: unable to detect distro codename" >&2
+  exit 1
+}
+
+install_cloudflare_warp() {
+  local codename arch repo_line
+  codename="$(detect_codename)"
+  arch="$(dpkg --print-architecture)"
+  repo_line="deb [arch=${arch} signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ ${codename} main"
+
+  step "installing Cloudflare WARP apt repo for ${codename}/${arch}"
+  need_cmd curl
+  need_cmd gpg
+  as_root mkdir -p /usr/share/keyrings /etc/apt/sources.list.d
+  curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg \
+    | as_root gpg --yes --dearmor --output /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg
+  printf '%s\n' "$repo_line" | as_root tee /etc/apt/sources.list.d/cloudflare-client.list >/dev/null
+  as_root apt-get update
+  as_root apt-get install -y cloudflare-warp
+}
+
+warp_cli() {
+  warp-cli --accept-tos "$@"
+}
+
+warp_try() {
+  if warp_cli "$@" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+ensure_registered() {
+  if warp_try registration show; then
+    step "WARP device registration already exists"
+    return
+  fi
+  if warp_try registration new; then
+    step "created a new WARP device registration"
+    return
+  fi
+  if warp_try register; then
+    step "created a new WARP device registration via legacy command"
+    return
+  fi
+  echo "error: failed to register WARP device" >&2
+  exit 1
+}
+
+set_proxy_mode() {
+  if warp_try tunnel protocol set MASQUE; then
+    step "set WARP tunnel protocol to MASQUE"
+  else
+    step "warning: failed to force MASQUE via CLI; continuing anyway"
+  fi
+
+  if warp_try mode proxy; then
+    step "switched WARP to proxy mode"
+    return
+  fi
+  if warp_try set-mode proxy; then
+    step "switched WARP to proxy mode via legacy command"
+    return
+  fi
+  echo "error: failed to switch WARP into proxy mode" >&2
+  exit 1
+}
+
+set_proxy_port() {
+  local port="$1"
+  if warp_try proxy port "$port"; then
+    step "set WARP proxy port to ${port}"
+    return
+  fi
+  if warp_try set-proxy-port "$port"; then
+    step "set WARP proxy port to ${port} via legacy command"
+    return
+  fi
+  echo "error: failed to set WARP proxy port to ${port}" >&2
+  exit 1
+}
+
+connect_warp() {
+  if [[ "$DISCONNECT_FIRST" == "true" ]]; then
+    warp_try disconnect || true
+  fi
+  if warp_try connect; then
+    step "connected WARP"
+    return
+  fi
+  echo "error: failed to connect WARP" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)
+      PORT="${2:-}"
+      shift 2
+      ;;
+    --skip-install)
+      SKIP_INSTALL=true
+      shift
+      ;;
+    --disconnect-first)
+      DISCONNECT_FIRST=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! "$PORT" =~ ^[0-9]+$ ]] || (( PORT < 1 || PORT > 65535 )); then
+  echo "error: --port must be an integer between 1 and 65535" >&2
+  exit 2
+fi
+
+need_cmd dpkg
+
+if [[ "$SKIP_INSTALL" != "true" ]]; then
+  install_cloudflare_warp
+fi
+
+need_cmd warp-cli
+
+ensure_registered
+set_proxy_mode
+set_proxy_port "$PORT"
+connect_warp
+
+step ""
+step "WARP status:"
+warp_cli status || true
+
+step ""
+step "Suggested next steps:"
+step "  1. Start the local curl_cffi proxy:"
+step "     scripts/run-curl-cffi-chatgpt-proxy.sh --proxy socks5h://127.0.0.1:${PORT} --install-deps"
+step "  2. Set these values in codexmanager.env:"
+step "     CODEXMANAGER_UPSTREAM_BASE_URL=http://127.0.0.1:8787/backend-api/codex"
+step "     CODEXMANAGER_GATEWAY_MODE=enhanced"
+step "  3. Leave CODEXMANAGER_UPSTREAM_PROXY_URL unset to avoid double-proxying local requests"


### PR DESCRIPTION
## 变更摘要

当前在云服务器上部署 CodexManager service 时，如果 service 直接访问 `https://chatgpt.com`，在部分 Oracle / 云厂商出口环境下容易命中 Cloudflare `403`、`cf-mitigated: challenge` 或 IP 风控，导致模型列表可用但实际 `/responses`、`/chat/completions` 调用失败。现有默认链路下，用户需要手动安装 WARP、切换本地代理模式、再额外启动 `curl_cffi` 中转代理，步骤较多且排障成本高。

这次改动把这条已验证可用的修复路径收敛成仓库内可复用的脚本和文档，目标是让“服务器部署下的 Cloudflare 403 修复”有一套标准、可复现、便于提 issue / 复盘 / 继续维护的落地方案。

- 新增一套面向服务器部署场景的 Cloudflare 403 修复方案，用于 CodexManager service 直连 `https://chatgpt.com` 被 Cloudflare challenge / 403 / IP 风控拦截时的应急接入。
- 增加 Cloudflare WARP 本地代理一键配置脚本，收敛 Ubuntu / Debian 服务器上的手工安装与代理模式切换步骤。
- 增加 `curl_cffi` 本地中转代理启动脚本，统一输出适合 `codexmanager.env` 的最小配置。
- 补充中文文档与变更记录，明确 `CODEXMANAGER_GATEWAY_MODE=enhanced`、持久化 `gateway.upstream_proxy_url` 清理方式，以及最小可跑链路。

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [x] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `scripts/setup-cloudflare-warp-proxy.sh`
- `scripts/run-curl-cffi-chatgpt-proxy.sh`
- `scripts/curl_cffi_chatgpt_proxy.py`
- `docs/zh-CN/report/service部署出现Cloudflare 403错误修复说明.md`
- `docs/zh-CN/CHANGELOG.md`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
bash -n scripts/setup-cloudflare-warp-proxy.sh
bash -n scripts/run-curl-cffi-chatgpt-proxy.sh
python3 -m py_compile scripts/curl_cffi_chatgpt_proxy.py
