### PR TITLE
Update 运行与部署指南.md

### DIFF
--- a/docs/zh-CN/report/运行与部署指南.md
+++ b/docs/zh-CN/report/运行与部署指南.md
@@ -12,6 +12,51 @@
 3. 如回调失败，粘贴回调链接手动完成解析。
 4. 刷新用量并确认账号状态。
 
+## 通过 ccswitch 接入
+如果你希望通过 ccswitch 使用 CodexManager，可按下面步骤操作：
+
+1. 进入“平台密钥”，新建一个通用 Key。
+2. 进入 ccswitch，新建一个供应商，并把上一步生成的通用 Key 填入供应商里的 API Key 空白处。
+3. 将下面示例 `config.toml` 复制到 ccswitch / Codex 使用的 `config.toml` 中，保存即可。
+
+常见路径：
+- macOS / Linux：`~/.codex/config.toml`
+- Windows：`%USERPROFILE%\.codex\config.toml`
+
+示例 `config.toml`：
+
+```toml
+model = "gpt-5.4"
+model_provider = "cm"
+review_model = "gpt-5.4"
+personality = "none"
+model_reasoning_effort = "xhigh"
+plan_mode_reasoning_effort = "xhigh"
+model_reasoning_summary = "detailed"
+model_verbosity = "medium"
+model_supports_reasoning_summaries = true
+approval_policy = "on-request"
+allow_login_shell = true
+sandbox_mode = "workspace-write"
+cli_auth_credentials_store = "file"
+chatgpt_base_url = "https://chatgpt.com/backend-api/"
+mcp_oauth_credentials_store = "auto"
+check_for_update_on_startup = true
+web_search = "live"
+approvals_reviewer = "user"
+service_tier = "fast"
+
+[model_providers.cm]
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+web_search = "live"
+name = "OpenAI"
+base_url = "http://localhost:48760/v1"
+wire_api = "responses"
+```
+
+- 如果你在设置页改过服务端口，请把 `base_url` 里的 `48760` 同步改成当前端口。
+
 ## 账号导入与导出
 - `批量导入`：选择多个 `.json/.txt` 文件后统一导入。
 - `按文件夹导入`：仅桌面端可用；选择目录后递归扫描其中 `.json` 文件并批量导入，空文件会自动跳过。


### PR DESCRIPTION
添加了 ccSwitch 可视化配置说明

## 变更摘要

- 在运行与部署指南中新增 ccSwitch 可视化配置说明
- 补充平台密钥创建、在 ccSwitch 供应商中填写 API Key、复制示例 `config.toml` 的接入步骤
- 补充 `config.toml` 示例、常见配置路径以及默认端口变更提醒

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [x] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `docs/zh-CN/report/运行与部署指南.md`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
人工检查文档内容与排版，确认新增“通过 ccswitch 接入”小节已写入运行与部署指南，步骤、示例 config.toml、常见路径和端口提醒表述完整。

