### PR TITLE
feat:添加一键测试连通性

### DIFF
--- a/apps/src/app/aggregate-api/page.tsx
+++ b/apps/src/app/aggregate-api/page.tsx
@@ -122,6 +122,7 @@ export default function AggregateApiPage() {
   >({});
   const [loadingSecretId, setLoadingSecretId] = useState<string | null>(null);
   const [testingApiId, setTestingApiId] = useState<string | null>(null);
+  const [testingAll, setTestingAll] = useState(false);
   const [togglingApiId, setTogglingApiId] = useState<string | null>(null);
   const [statusOverrides, setStatusOverrides] = useState<Record<string, boolean>>(
     {},
@@ -245,6 +246,42 @@ export default function AggregateApiPage() {
     },
     onError: (error: unknown) => {
       toast.error(`${t("测试")} ${t("失败")}: ${error instanceof Error ? error.message : String(error)}`);
+    },
+  });
+
+  const testAllMutation = useMutation({
+    mutationFn: async (apiIds: string[]) => {
+      const results = await Promise.allSettled(
+        apiIds.map((id) => accountClient.testAggregateApiConnection(id))
+      );
+      return results;
+    },
+    onMutate: async () => {
+      setTestingAll(true);
+    },
+    onSuccess: async (results) => {
+      const successCount = results.filter(
+        (r) => r.status === "fulfilled" && r.value.ok
+      ).length;
+      const failCount = results.length - successCount;
+
+      if (failCount === 0) {
+        toast.success(t("全部测试完成，{count} 个连通", { count: successCount }));
+      } else {
+        toast.warning(
+          t("测试完成：{success} 个连通，{fail} 个失败", {
+            success: successCount,
+            fail: failCount,
+          })
+        );
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["aggregate-apis"] });
+      setTestingAll(false);
+    },
+    onError: (error: unknown) => {
+      toast.error(`${t("批量测试失败")}: ${error instanceof Error ? error.message : String(error)}`);
     },
   });
 
@@ -578,6 +615,22 @@ export default function AggregateApiPage() {
                 <div className="text-xs text-muted-foreground">
                   {t("共")} {filteredAggregateApis.length} {t("条")}
                 </div>
+                <Button
+                  variant="outline"
+                  className="h-10 gap-2"
+                  onClick={() => {
+                    const apiIds = filteredAggregateApis.map((api) => api.id);
+                    if (apiIds.length === 0) {
+                      toast.info(t("暂无可测试的聚合 API"));
+                      return;
+                    }
+                    testAllMutation.mutate(apiIds);
+                  }}
+                  disabled={!isServiceReady || testingAll || filteredAggregateApis.length === 0}
+                >
+                  <RefreshCw className={testingAll ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
+                  {t("测试全部")}
+                </Button>
                 <Button
                   className="h-10 gap-2 shadow-lg shadow-primary/20"
                   onClick={openCreateModal}


### PR DESCRIPTION
• ## 变更摘要

  - 在聚合 API 管理页新增“测试全部”按钮，支持对当前筛选结果执行一键批量连通性测试
  - 增加批量测试中的加载态、空列表提示，以及成功/失败数量汇总提示
  - 复用现有单条测试能力，无新增后端接口或协议改动

  ## 改动范围

  - [x] Frontend
  - [ ] Desktop / Tauri
  - [ ] Service
  - [ ] Gateway / Protocol Adapter
  - [ ] Docs / Governance
  - [ ] Workflow / Release

  ## 主要文件

  - `apps/src/app/aggregate-api/page.tsx`

  ## 验证

  - [ ] `pnpm -C apps run test`
  - [x] `pnpm -C apps run build`
  - [ ] `pnpm -C apps run test:ui`
  - [ ] `cargo test --workspace`
  - [x] 其他本地验证已说明

  已执行的实际验证：

  ```text
  pnpm -C apps run build
  - 执行时间：2026-04-15
  - 结果：通过

  pnpm -C apps run build:desktop
  - 执行时间：2026-04-15
  - 结果：通过

  未执行的验证与原因：

  pnpm -C apps run test


  pnpm -C apps run test:ui


  cargo test --workspace
  - 本次提交仅涉及前端页面文件 apps/src/app/aggregate-api/page.tsx，未涉及 Rust / Tauri / 后端逻辑，本次未执行

  ## 风险与影响面

  - 影响范围限定在 /aggregate-api 页面前端交互
  - 批量测试会并发调用现有连通性测试接口，聚合 API 数量较多时可能瞬时增加测试请求压力
  - 结果提示由单条反馈扩展为汇总反馈，需要关注与现有用户预期是否一致

  ## 备注