### PR TITLE
fix: auto refresh accounts usage list on polling interval

### DIFF
--- a/apps/src/hooks/useAccounts.ts
+++ b/apps/src/hooks/useAccounts.ts
@@ -94,6 +94,19 @@ function formatUsageRefreshErrorMessage(
   return message;
 }
 
+function getAccountsAutoRefreshIntervalMs(
+  enabled: boolean,
+  intervalSecs: number,
+): number | false {
+  if (!enabled) {
+    return false;
+  }
+  if (typeof document !== "undefined" && document.visibilityState !== "visible") {
+    return false;
+  }
+  return Math.max(1, intervalSecs) * 1000;
+}
+
 /**
  * 函数 `useAccounts`
  *
@@ -112,11 +125,16 @@ export function useAccounts() {
   const { t } = useI18n();
   const localDayRange = useLocalDayRange();
   const serviceStatus = useAppStore((state) => state.serviceStatus);
+  const backgroundTasks = useAppStore((state) => state.appSettings.backgroundTasks);
   const { canAccessManagementRpc } = useRuntimeCapabilities();
   const isServiceReady = canAccessManagementRpc && serviceStatus.connected;
   const isPageActive = useDesktopPageActive("/accounts/");
   const areAccountQueriesEnabled = useDeferredDesktopActivation(
     isServiceReady && isPageActive,
+  );
+  const accountsAutoRefreshIntervalMs = getAccountsAutoRefreshIntervalMs(
+    areAccountQueriesEnabled && backgroundTasks.usagePollingEnabled,
+    backgroundTasks.usagePollIntervalSecs,
   );
   const startupSnapshot = queryClient.getQueryData<StartupSnapshot>(
     buildStartupSnapshotQueryKey(
@@ -155,6 +173,8 @@ export function useAccounts() {
     queryFn: () => accountClient.list(),
     enabled: areAccountQueriesEnabled,
     retry: 1,
+    refetchInterval: accountsAutoRefreshIntervalMs,
+    refetchIntervalInBackground: false,
     placeholderData: (previousData): AccountListResult | undefined =>
       previousData ||
       (startupAccounts.length > 0
@@ -172,6 +192,8 @@ export function useAccounts() {
     queryFn: () => accountClient.listUsage(),
     enabled: areAccountQueriesEnabled,
     retry: 1,
+    refetchInterval: accountsAutoRefreshIntervalMs,
+    refetchIntervalInBackground: false,
     placeholderData: (previousData) =>
       previousData || (startupUsages.length > 0 ? startupUsages : undefined),
   });


### PR DESCRIPTION
## 变更摘要 / Summary

- 修复账号页没有跟随后台“用量轮询线程”自动刷新列表的问题。
- 前端在账号页激活且页面可见时，按配置的 usage 轮询间隔自动刷新账号列表与额度列表。
- Fix the accounts page so it automatically refreshes with the configured background usage polling interval.
- Refresh the account list and usage list on the accounts page according to the configured usage polling interval when the page is active and visible.

## 改动范围 / Scope

- [x] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件 / Key Files

- `apps/src/hooks/useAccounts.ts`

## 验证 / Validation

- [ ] `pnpm -C apps run test`
- [x] `pnpm -C apps run build:desktop`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明 / Other local validation explained below

已执行的实际验证 / Completed validation:

```text
pnpm run build:desktop
- result: passed
```

未执行的验证与原因 / Skipped validation and why:

```text
- pnpm -C apps run test: 本次未执行，当前改动仅涉及账号页查询轮询节奏。
- pnpm -C apps run test:ui: 本次未执行，当前未补充对应 UI 自动化用例。
- cargo test --workspace: 本次未执行，当前改动未涉及 Rust / service / gateway。
```

## 风险与影响面 / Risks & Impact

- 改动仅作用于账号页列表与用量查询的自动 refetch 节奏，不改变后端 usage 数据本身。
- 自动刷新仅在账号页激活且页面可见时运行，不会在后台页面持续拉取。
- This change only affects the auto-refetch cadence for the accounts list and usage queries, without changing backend usage data itself.
- Polling runs only when the accounts page is active and visible, and stays disabled in background pages.

## 备注 / Notes

- 后端原本已经按配置刷新 usage 数据；这次补的是前端列表未按相同间隔重新拉取的问题。
- The backend was already refreshing usage snapshots; this patch aligns the accounts page refetch behavior with the configured polling interval.
