### PR TITLE
fix: adjust quota overview timing layout

### DIFF
--- a/apps/src/app/accounts/accounts-page-helpers.tsx
+++ b/apps/src/app/accounts/accounts-page-helpers.tsx
@@ -5,6 +5,7 @@ import { Power, PowerOff, RefreshCw, Zap } from "lucide-react";
 import { useI18n } from "@/lib/i18n/provider";
 import { cn } from "@/lib/utils";
 import {
+  formatRemainingDurationFromSeconds,
   formatTsFromSeconds,
   getExtraUsageDisplayRows,
   getUsageDisplayBuckets,
@@ -183,15 +184,6 @@ function QuotaProgress({
 export function QuotaOverviewCell({ items }: { items: QuotaSummaryItem[] }) {
   const { t } = useI18n();
   const summaryItems = items.slice(0, 2);
-  const resetSummary = summaryItems
-    .map(
-      (item) =>
-        `${item.label}${t("重置")}: ${formatTsFromSeconds(
-          item.resetsAt,
-          item.emptyResetText ?? t("未知"),
-        )}`,
-    )
-    .join(" · ");
 
   return (
     <Tooltip>
@@ -201,7 +193,7 @@ export function QuotaOverviewCell({ items }: { items: QuotaSummaryItem[] }) {
             {summaryItems.map((item) => (
               <div key={item.id} className="min-w-0 flex-1 space-y-1">
                 <div className="flex items-center justify-between text-[10px]">
-                  <span className="text-muted-foreground">{item.label}</span>
+                  <span className="truncate text-muted-foreground">{item.label}</span>
                   <span className="font-medium text-foreground/80">
                     {item.remainPercent == null
                       ? (item.emptyText ?? "--")
@@ -228,8 +220,28 @@ export function QuotaOverviewCell({ items }: { items: QuotaSummaryItem[] }) {
               </div>
             ))}
           </div>
-          <div className="mt-1 truncate text-[10px] text-muted-foreground">
-            {resetSummary}
+          <div className="mt-1 grid grid-cols-2 gap-3 text-[10px] text-muted-foreground">
+            {summaryItems.map((item) => (
+              <div
+                key={`${item.id}-reset`}
+                className="flex min-w-0 items-center justify-between gap-2"
+              >
+                <span className="min-w-0 truncate">
+                  {formatTsFromSeconds(
+                    item.resetsAt,
+                    item.emptyResetText ?? t("未知"),
+                  )}
+                </span>
+                <span className="shrink-0">
+                  {formatRemainingDurationFromSeconds(
+                    item.resetsAt,
+                    item.id.endsWith("-primary") ? "hours" : "days",
+                    item.emptyResetText ?? t("未知"),
+                  )}
+                  后刷新
+                </span>
+              </div>
+            ))}
           </div>
         </div>
       </TooltipTrigger>

--- a/apps/src/lib/utils/usage.ts
+++ b/apps/src/lib/utils/usage.ts
@@ -76,6 +76,58 @@ export function formatTsFromSeconds(
   return formatLocalDateTimeFromSeconds(timestamp, emptyLabel);
 }
 
+export function formatRemainingDurationFromSeconds(
+  timestamp: number | null | undefined,
+  mode: "hours" | "days" = "hours",
+  emptyLabel = "未知",
+): string {
+  if (!timestamp) return emptyLabel;
+  const diffSeconds = Math.max(0, timestamp - Math.floor(Date.now() / 1000));
+  const totalMinutes = Math.ceil(diffSeconds / 60);
+
+  if (diffSeconds < 10 * 60) {
+    const minutes = Math.floor(diffSeconds / 60);
+    const seconds = diffSeconds % 60;
+    if (mode === "hours") {
+      const hours = Math.floor(minutes / MINUTES_PER_HOUR);
+      const remainMinutes = minutes % MINUTES_PER_HOUR;
+      if (hours > 0) {
+        return `${hours}h${remainMinutes}min${seconds}s`;
+      }
+      return `${remainMinutes}min${seconds}s`;
+    }
+    if (minutes > 0) {
+      return `${minutes}min${seconds}s`;
+    }
+    return `${seconds}s`;
+  }
+
+  if (mode === "hours") {
+    const hours = Math.floor(totalMinutes / MINUTES_PER_HOUR);
+    const minutes = totalMinutes % MINUTES_PER_HOUR;
+    return `${hours}h${String(minutes).padStart(2, "0")}min`;
+  }
+
+  const days = Math.floor(totalMinutes / MINUTES_PER_DAY);
+  const hours = Math.floor((totalMinutes % MINUTES_PER_DAY) / MINUTES_PER_HOUR);
+  const minutes = totalMinutes % MINUTES_PER_HOUR;
+  const parts: string[] = [];
+
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (parts.length > 0) {
+    parts.push(`${String(minutes).padStart(2, "0")}min`);
+  } else {
+    parts.push(`${minutes}min`);
+  }
+
+  return parts.join("");
+}
+
 /**
  * 函数 `trimTrailingZeros`
  *


### PR DESCRIPTION
## 变更摘要 / Summary

- 调整账号页额度概览卡的底部信息布局：左下角显示具体重置时间，右下角显示距离重置的剩余倒计时。
- 新增共享的倒计时格式化逻辑，支持 5 小时窗口与 7 天窗口，并在剩余时间少于 10 分钟时显示秒。
- Adjust the quota overview footer on the accounts page so each window shows the reset timestamp on the left and the countdown text on the right.
- Add shared countdown formatting for both the 5-hour and 7-day windows, including second-level precision when less than 10 minutes remain.

## 改动范围 / Scope

- [x] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件 / Key Files

- `apps/src/app/accounts/accounts-page-helpers.tsx`
- `apps/src/lib/utils/usage.ts`

## 示例图 / Example

![Quota overview example](https://github.com/user-attachments/assets/0da7dd02-8f7b-4275-acfd-c2cca8c7479b)

## 验证 / Validation

- [ ] `pnpm -C apps run test`
- [x] `pnpm -C apps run build:desktop`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明 / Other local validation explained below

已执行的实际验证 / Completed validation:

```text
pnpm run build:desktop
- result: passed
```

未执行的验证与原因 / Skipped validation and why:

```text
- pnpm -C apps run test: 本次未执行，当前改动仅涉及账号页额度卡布局与倒计时格式。
- pnpm -C apps run test:ui: 本次未执行，当前未补充对应 UI 自动化用例。
- cargo test --workspace: 本次未执行，当前改动未涉及 Rust / service / gateway。
```

## 风险与影响面 / Risks & Impact

- 影响范围限定在账号页额度概览卡的展示层，不改变后端 usage 数据来源与计算结果。
- 倒计时文本现在依赖前端当前时间进行格式化，因此只影响展示，不影响服务端实际重置时间。
- This change is limited to the presentation of quota overview cards on the accounts page and does not alter backend usage calculations.
- Countdown text is now formatted from the frontend current time, which affects display only and does not change the actual reset timestamp.

## 备注 / Notes

- 本 PR 已清理为纯前端 UI 修改，不包含此前其他分支上的自动刷新逻辑变更。
- This PR has been cleaned up to contain UI-only changes and excludes the earlier auto-refresh logic work.
