### PR TITLE
fix(gateway): 识别 SSE 正文里的 usage-limit 并按配额降权候选账号

### DIFF
--- a/crates/service/src/account/account_status.rs
+++ b/crates/service/src/account/account_status.rs
@@ -192,6 +192,7 @@ pub(crate) fn usage_limit_reason_from_message(message: &str) -> Option<&'static 
     let normalized = message.trim().to_ascii_lowercase();
     if normalized.contains("you've hit your usage limit")
         || normalized.contains("you have hit your usage limit")
+        || normalized.contains("usage limit has been reached")
         || normalized.contains("insufficient_quota")
         || normalized.contains("quota exceeded")
         || normalized.contains("usage exhausted")
@@ -527,6 +528,13 @@ mod tests {
         assert!(!usage_limit_last.should_failover);
         assert!(usage_limit_last.should_mark_account_unavailable);
         assert!(!usage_limit_last.should_mark_default_cooldown);
+
+        // Regression: backend-native WS upstream phrasing.
+        let ws_usage_limit = analyze_gateway_error("The usage limit has been reached", true);
+        assert_eq!(ws_usage_limit.kind, GatewayErrorKind::UsageLimit);
+        assert!(ws_usage_limit.should_failover);
+        assert!(ws_usage_limit.should_mark_account_unavailable);
+        assert!(ws_usage_limit.should_mark_default_cooldown);
     }
 
     /// 函数 `gateway_usage_limit_error_does_not_persist_unavailable_status`

--- a/crates/service/src/gateway/observability/http_bridge/stream_readers/passthrough.rs
+++ b/crates/service/src/gateway/observability/http_bridge/stream_readers/passthrough.rs
@@ -71,6 +71,17 @@ impl PassthroughSseUsageReader {
             if let Some(event_type) = inspection.last_event_type {
                 collector.last_event_type = Some(event_type);
             }
+            // 上游偶尔会用 200 + 正常 data: 帧夹带 "You've hit your usage limit..."
+            // 回覆（不走 response.failed）。这类帧里 delta 文本会让 inspection.usage 被
+            // 初始化为 Some，直接落到下面的 merge_usage 分支，永远不会触发 terminal。
+            // 所以必须在进任何分支前先扫一遍正文；命中 usage-limit 关键字就标 terminal 错误，
+            // 让后续 response_finalize 走 failover + cooldown。
+            if collector.terminal_error.is_none() {
+                if let Some(msg) = extract_usage_limit_from_sse_data(lines) {
+                    collector.saw_terminal = true;
+                    collector.terminal_error = Some(msg);
+                }
+            }
             if inspection.usage.is_none() && inspection.terminal.is_none() {
                 if collector.upstream_error_hint.is_none() {
                     let raw_frame = lines.concat();
@@ -203,5 +214,63 @@ impl Read for PassthroughSseUsageReader {
             }
             self.out_cursor = Cursor::new(self.next_chunk()?);
         }
+    }
+}
+
+fn extract_usage_limit_from_sse_data(lines: &[String]) -> Option<String> {
+    let mut data_payload = String::new();
+    for line in lines {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if let Some(rest) = trimmed.strip_prefix("data:") {
+            if !data_payload.is_empty() {
+                data_payload.push('\n');
+            }
+            data_payload.push_str(rest.trim_start());
+        }
+    }
+    if data_payload.is_empty() {
+        return None;
+    }
+    crate::account_status::usage_limit_reason_from_message(&data_payload)?;
+    Some(data_payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_usage_limit_matches_plain_text_delta() {
+        let lines = vec![
+            "event: response.output_text.delta\n".to_string(),
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"You've hit your usage limit. To get more access now, send a request to your admin or try again at 7:44 PM.\"}\n".to_string(),
+        ];
+        let got = extract_usage_limit_from_sse_data(&lines).expect("must match");
+        assert!(got.contains("hit your usage limit"));
+    }
+
+    #[test]
+    fn extract_usage_limit_matches_quota_exceeded_json() {
+        let lines = vec![
+            "data: {\"error\":{\"code\":\"insufficient_quota\",\"message\":\"quota exceeded\"}}\n".to_string(),
+        ];
+        assert!(extract_usage_limit_from_sse_data(&lines).is_some());
+    }
+
+    #[test]
+    fn extract_usage_limit_ignores_unrelated_content() {
+        let lines = vec![
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello world\"}\n".to_string(),
+        ];
+        assert!(extract_usage_limit_from_sse_data(&lines).is_none());
+    }
+
+    #[test]
+    fn extract_usage_limit_ignores_frames_without_data() {
+        let lines = vec![
+            "event: ping\n".to_string(),
+            ": keepalive\n".to_string(),
+        ];
+        assert!(extract_usage_limit_from_sse_data(&lines).is_none());
     }
 }

--- a/crates/service/src/gateway/routing/selection.rs
+++ b/crates/service/src/gateway/routing/selection.rs
@@ -1,4 +1,5 @@
-use codexmanager_core::storage::{now_ts, Account, Storage, Token};
+use codexmanager_core::storage::{now_ts, Account, Storage, Token, UsageSnapshotRecord};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock, RwLock};
 use std::time::{Duration, Instant};
@@ -11,6 +12,10 @@ static CANDIDATE_CACHE_TTL_MS: AtomicU64 = AtomicU64::new(DEFAULT_CANDIDATE_CACH
 static CURRENT_DB_PATH: OnceLock<RwLock<String>> = OnceLock::new();
 const DEFAULT_CANDIDATE_CACHE_TTL_MS: u64 = 500;
 const CANDIDATE_CACHE_TTL_ENV: &str = "CODEXMANAGER_CANDIDATE_CACHE_TTL_MS";
+// OpenAI 在 used_percent 未到 100 时就会触发 usage limit（常见于 ChatGPT Plus OAuth
+// 账号的 5 小时窗口）。将快要耗尽的账号降权到候选列表尾部，避免网关反复挑到它。
+const LOW_QUOTA_THRESHOLD_ENV: &str = "CODEXMANAGER_LOW_QUOTA_THRESHOLD_PERCENT";
+const DEFAULT_LOW_QUOTA_THRESHOLD_PERCENT: f64 = 95.0;
 
 #[derive(Clone)]
 struct CandidateSnapshotCache {
@@ -68,10 +73,63 @@ fn collect_gateway_candidates_uncached(storage: &Storage) -> Result<Vec<(Account
         }
         out.push((candidate_account, token));
     }
+    demote_low_quota_candidates(storage, &mut out);
     if out.is_empty() {
         log_no_candidates(storage);
     }
     Ok(out)
+}
+
+/// 将快要耗尽的账号（primary 或 secondary used_percent 超过阈值）稳定地排到列表尾部。
+/// 不从候选中剔除，保证在全部账号都被降权的极端场景下仍有号可用。
+fn demote_low_quota_candidates(storage: &Storage, candidates: &mut Vec<(Account, Token)>) {
+    if candidates.len() < 2 {
+        return;
+    }
+    let snapshots = load_usage_snapshots(storage);
+    if snapshots.is_empty() {
+        return;
+    }
+    let threshold = low_quota_threshold_percent();
+    candidates.sort_by_key(|(account, _)| {
+        if is_low_quota_account(&account.id, &snapshots, threshold) {
+            1u8
+        } else {
+            0u8
+        }
+    });
+}
+
+fn load_usage_snapshots(storage: &Storage) -> HashMap<String, UsageSnapshotRecord> {
+    storage
+        .latest_usage_snapshots_by_account()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|snap| (snap.account_id.clone(), snap))
+        .collect()
+}
+
+fn is_low_quota_account(
+    account_id: &str,
+    snapshots: &HashMap<String, UsageSnapshotRecord>,
+    threshold: f64,
+) -> bool {
+    let Some(snap) = snapshots.get(account_id) else {
+        return false;
+    };
+    let primary_low = snap.used_percent.is_some_and(|pct| pct >= threshold);
+    let secondary_low = snap
+        .secondary_used_percent
+        .is_some_and(|pct| pct >= threshold);
+    primary_low || secondary_low
+}
+
+fn low_quota_threshold_percent() -> f64 {
+    std::env::var(LOW_QUOTA_THRESHOLD_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<f64>().ok())
+        .filter(|pct| pct.is_finite() && *pct > 0.0 && *pct <= 100.0)
+        .unwrap_or(DEFAULT_LOW_QUOTA_THRESHOLD_PERCENT)
 }
 
 /// 函数 `read_candidate_cache`

--- a/crates/service/src/gateway/routing/tests/selection_tests.rs
+++ b/crates/service/src/gateway/routing/tests/selection_tests.rs
@@ -1,4 +1,7 @@
-use super::{clear_candidate_cache_for_tests, collect_gateway_candidates, CANDIDATE_CACHE_TTL_ENV};
+use super::{
+    clear_candidate_cache_for_tests, collect_gateway_candidates, CANDIDATE_CACHE_TTL_ENV,
+    LOW_QUOTA_THRESHOLD_ENV,
+};
 use crate::account_status::mark_account_unavailable_for_gateway_error;
 use codexmanager_core::storage::{now_ts, Account, Storage, Token, UsageSnapshotRecord};
 
@@ -461,6 +464,183 @@ fn gateway_usage_limit_with_exhausted_snapshot_invalidates_candidate_snapshot_ca
         std::env::set_var("CODEXMANAGER_DB_PATH", value);
     } else {
         std::env::remove_var("CODEXMANAGER_DB_PATH");
+    }
+    super::reload_from_env();
+}
+
+/// 低配额账号（used_percent 超过阈值）应当被稳定地排到候选列表尾部，
+/// 配额充足的账号优先被挑选，避免反复打到快耗尽的号上。
+#[test]
+fn low_quota_accounts_are_demoted_to_tail() {
+    let _guard = crate::test_env_guard();
+    let previous_ttl = std::env::var(CANDIDATE_CACHE_TTL_ENV).ok();
+    let previous_db_path = std::env::var("CODEXMANAGER_DB_PATH").ok();
+    let previous_threshold = std::env::var(LOW_QUOTA_THRESHOLD_ENV).ok();
+    std::env::set_var(CANDIDATE_CACHE_TTL_ENV, "0");
+    std::env::set_var("CODEXMANAGER_DB_PATH", "selection-low-quota-test");
+    std::env::set_var(LOW_QUOTA_THRESHOLD_ENV, "95");
+    super::reload_from_env();
+    clear_candidate_cache_for_tests();
+
+    let storage = Storage::open_in_memory().expect("open");
+    storage.init().expect("init");
+
+    let now = now_ts();
+    let rows: Vec<(&str, i64, f64, Option<f64>)> = vec![
+        ("acc-exhausted", 0, 99.0, None),
+        ("acc-healthy-high", 1, 10.0, None),
+        ("acc-secondary-low", 2, 10.0, Some(99.0)),
+        ("acc-healthy-low", 3, 5.0, None),
+    ];
+    for (id, sort, primary_pct, secondary_pct) in &rows {
+        storage
+            .insert_account(&Account {
+                id: (*id).to_string(),
+                label: (*id).to_string(),
+                issuer: "issuer".to_string(),
+                chatgpt_account_id: None,
+                workspace_id: None,
+                group_name: None,
+                sort: *sort,
+                status: "active".to_string(),
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("insert account");
+        storage
+            .insert_token(&Token {
+                account_id: (*id).to_string(),
+                id_token: "id".to_string(),
+                access_token: "access".to_string(),
+                refresh_token: "refresh".to_string(),
+                api_key_access_token: None,
+                last_refresh: now,
+            })
+            .expect("insert token");
+        storage
+            .insert_usage_snapshot(&UsageSnapshotRecord {
+                account_id: (*id).to_string(),
+                used_percent: Some(*primary_pct),
+                window_minutes: Some(300),
+                resets_at: None,
+                secondary_used_percent: *secondary_pct,
+                secondary_window_minutes: secondary_pct.map(|_| 10_080),
+                secondary_resets_at: None,
+                credits_json: None,
+                captured_at: now,
+            })
+            .expect("insert snapshot");
+    }
+
+    let candidates = collect_gateway_candidates(&storage).expect("collect candidates");
+    let ids: Vec<&str> = candidates
+        .iter()
+        .map(|(account, _)| account.id.as_str())
+        .collect();
+    assert_eq!(ids.len(), 4);
+    assert_eq!(&ids[..2], &["acc-healthy-high", "acc-healthy-low"]);
+    let tail: Vec<&str> = ids[2..].to_vec();
+    assert!(tail.contains(&"acc-exhausted"));
+    assert!(tail.contains(&"acc-secondary-low"));
+
+    clear_candidate_cache_for_tests();
+    if let Some(value) = previous_ttl {
+        std::env::set_var(CANDIDATE_CACHE_TTL_ENV, value);
+    } else {
+        std::env::remove_var(CANDIDATE_CACHE_TTL_ENV);
+    }
+    if let Some(value) = previous_db_path {
+        std::env::set_var("CODEXMANAGER_DB_PATH", value);
+    } else {
+        std::env::remove_var("CODEXMANAGER_DB_PATH");
+    }
+    if let Some(value) = previous_threshold {
+        std::env::set_var(LOW_QUOTA_THRESHOLD_ENV, value);
+    } else {
+        std::env::remove_var(LOW_QUOTA_THRESHOLD_ENV);
+    }
+    super::reload_from_env();
+}
+
+/// 全部账号都触阈时不应把候选清空，保底仍返回所有账号（稳定顺序）。
+#[test]
+fn all_low_quota_still_returns_candidates() {
+    let _guard = crate::test_env_guard();
+    let previous_ttl = std::env::var(CANDIDATE_CACHE_TTL_ENV).ok();
+    let previous_db_path = std::env::var("CODEXMANAGER_DB_PATH").ok();
+    let previous_threshold = std::env::var(LOW_QUOTA_THRESHOLD_ENV).ok();
+    std::env::set_var(CANDIDATE_CACHE_TTL_ENV, "0");
+    std::env::set_var("CODEXMANAGER_DB_PATH", "selection-all-low-quota-test");
+    std::env::set_var(LOW_QUOTA_THRESHOLD_ENV, "95");
+    super::reload_from_env();
+    clear_candidate_cache_for_tests();
+
+    let storage = Storage::open_in_memory().expect("open");
+    storage.init().expect("init");
+
+    let now = now_ts();
+    for (id, sort) in &[("acc-a", 0_i64), ("acc-b", 1_i64)] {
+        storage
+            .insert_account(&Account {
+                id: (*id).to_string(),
+                label: (*id).to_string(),
+                issuer: "issuer".to_string(),
+                chatgpt_account_id: None,
+                workspace_id: None,
+                group_name: None,
+                sort: *sort,
+                status: "active".to_string(),
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("insert account");
+        storage
+            .insert_token(&Token {
+                account_id: (*id).to_string(),
+                id_token: "id".to_string(),
+                access_token: "access".to_string(),
+                refresh_token: "refresh".to_string(),
+                api_key_access_token: None,
+                last_refresh: now,
+            })
+            .expect("insert token");
+        storage
+            .insert_usage_snapshot(&UsageSnapshotRecord {
+                account_id: (*id).to_string(),
+                used_percent: Some(98.0),
+                window_minutes: Some(300),
+                resets_at: None,
+                secondary_used_percent: None,
+                secondary_window_minutes: None,
+                secondary_resets_at: None,
+                credits_json: None,
+                captured_at: now,
+            })
+            .expect("insert snapshot");
+    }
+
+    let candidates = collect_gateway_candidates(&storage).expect("collect candidates");
+    let ids: Vec<&str> = candidates
+        .iter()
+        .map(|(account, _)| account.id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["acc-a", "acc-b"]);
+
+    clear_candidate_cache_for_tests();
+    if let Some(value) = previous_ttl {
+        std::env::set_var(CANDIDATE_CACHE_TTL_ENV, value);
+    } else {
+        std::env::remove_var(CANDIDATE_CACHE_TTL_ENV);
+    }
+    if let Some(value) = previous_db_path {
+        std::env::set_var("CODEXMANAGER_DB_PATH", value);
+    } else {
+        std::env::remove_var("CODEXMANAGER_DB_PATH");
+    }
+    if let Some(value) = previous_threshold {
+        std::env::set_var(LOW_QUOTA_THRESHOLD_ENV, value);
+    } else {
+        std::env::remove_var(LOW_QUOTA_THRESHOLD_ENV);
     }
     super::reload_from_env();
 }

--- a/crates/service/tests/gateway_logs.rs
+++ b/crates/service/tests/gateway_logs.rs
@@ -8,5 +8,7 @@ mod openai;
 mod retry_logging;
 #[path = "gateway_logs/support.rs"]
 mod support;
+#[path = "gateway_logs/usage_limit_failover.rs"]
+mod usage_limit_failover;
 
 pub(crate) use support::*;

--- a/crates/service/tests/gateway_logs/support.rs
+++ b/crates/service/tests/gateway_logs/support.rs
@@ -762,6 +762,21 @@ pub(super) fn start_mock_upstream_sequence_lenient(
     Receiver<CapturedUpstreamRequest>,
     thread::JoinHandle<()>,
 ) {
+    let typed = responses
+        .into_iter()
+        .map(|(status, body)| (status, body, "application/json".to_string()))
+        .collect();
+    start_mock_upstream_sequence_lenient_with_content_types(typed, idle_timeout)
+}
+
+pub(super) fn start_mock_upstream_sequence_lenient_with_content_types(
+    responses: Vec<(u16, String, String)>,
+    idle_timeout: Duration,
+) -> (
+    String,
+    Receiver<CapturedUpstreamRequest>,
+    thread::JoinHandle<()>,
+) {
     let listener = bind_test_listener("mock upstream");
     let addr = listener.local_addr().expect("mock upstream addr");
     let (tx, rx) = mpsc::channel();
@@ -771,20 +786,22 @@ pub(super) fn start_mock_upstream_sequence_lenient(
         let fallback_body =
             "{\"error\":{\"message\":\"unexpected extra upstream request\",\"type\":\"server_error\"}}"
                 .to_string();
+        let fallback_ct = "application/json".to_string();
         loop {
             let Some((mut stream, captured)) = accept_http_request(&listener, idle_timeout) else {
                 break;
             };
             let _ = tx.send(captured);
 
-            let (status, body) = responses
+            let (status, body, content_type) = responses
                 .get(idx)
-                .map(|(status, body)| (*status, body.as_str()))
-                .unwrap_or((500, fallback_body.as_str()));
+                .map(|(status, body, ct)| (*status, body.as_str(), ct.as_str()))
+                .unwrap_or((500, fallback_body.as_str(), fallback_ct.as_str()));
             let body_bytes = body.as_bytes().to_vec();
             let header = format!(
-                "HTTP/1.1 {} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                "HTTP/1.1 {} OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
                 status,
+                content_type,
                 body_bytes.len()
             );
             stream

--- a/crates/service/tests/gateway_logs/usage_limit_failover.rs
+++ b/crates/service/tests/gateway_logs/usage_limit_failover.rs
@@ -1,0 +1,299 @@
+use super::*;
+use codexmanager_core::storage::UsageSnapshotRecord;
+
+/// 当上游用 200 + SSE `data:` 正文夹带 "You've hit your usage limit" 回应时，
+/// 网关不能在同一次请求里重试（流已经吐给客户端），但必须把该请求内部标记成 failover：
+/// - 客户端侧 HTTP status 仍保持 200（原样透传上游响应）
+/// - request_log 的 status_code 应为 502（failover 记账，用于观察/冷却）
+///
+/// 这条链路覆盖：PassthroughSseUsageReader 扫描 data 正文（Fix A）→
+/// bridge.stream_terminal_error → response_finalize 的 failover 分支。
+#[test]
+fn gateway_usage_limit_in_sse_marks_request_as_failover() {
+    let _lock = test_env_guard();
+    let dir = new_test_dir("codexmanager-gateway-usage-limit-sse-failover");
+    let db_path: PathBuf = dir.join("codexmanager.db");
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+
+    let usage_limit_sse = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"You've hit your usage limit. To get more access now, send a request to your admin or try again at 7:44 PM.\"}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let (upstream_addr, upstream_rx, upstream_join) =
+        start_mock_upstream_sequence_lenient_with_content_types(
+            vec![(
+                200,
+                usage_limit_sse.to_string(),
+                "text/event-stream".to_string(),
+            )],
+            Duration::from_secs(3),
+        );
+    let upstream_base = format!("http://{upstream_addr}/backend-api/codex");
+    let _upstream_guard = EnvGuard::set("CODEXMANAGER_UPSTREAM_BASE_URL", &upstream_base);
+
+    let storage = Storage::open(&db_path).expect("open db");
+    storage.init().expect("init db");
+    let now = now_ts();
+
+    // 两个候选账号都健康（10%），以保证 has_more_candidates=true 让
+    // should_failover_for_gateway_error 返回 true，走 failover 标记分支。
+    for (id, sort) in [("acc_primary", 0_i64), ("acc_secondary", 1_i64)] {
+        storage
+            .insert_account(&Account {
+                id: id.to_string(),
+                label: id.to_string(),
+                issuer: "https://auth.openai.com".to_string(),
+                chatgpt_account_id: Some(format!("chatgpt_{id}")),
+                workspace_id: None,
+                group_name: None,
+                sort,
+                status: "active".to_string(),
+                created_at: now + sort,
+                updated_at: now + sort,
+            })
+            .expect("insert account");
+        storage
+            .insert_token(&Token {
+                account_id: id.to_string(),
+                id_token: String::new(),
+                access_token: format!("access_{id}"),
+                refresh_token: String::new(),
+                api_key_access_token: Some(format!("api_access_{id}")),
+                last_refresh: now,
+            })
+            .expect("insert token");
+        storage
+            .insert_usage_snapshot(&UsageSnapshotRecord {
+                account_id: id.to_string(),
+                used_percent: Some(10.0),
+                window_minutes: Some(300),
+                resets_at: None,
+                secondary_used_percent: None,
+                secondary_window_minutes: None,
+                secondary_resets_at: None,
+                credits_json: None,
+                captured_at: now,
+            })
+            .expect("insert snapshot");
+    }
+
+    let platform_key = "pk_usage_limit_failover_marker";
+    storage
+        .insert_api_key(&ApiKey {
+            id: "gk_usage_limit_failover_marker".to_string(),
+            name: Some("usage-limit-failover-marker".to_string()),
+            model_slug: Some("gpt-5.3-codex".to_string()),
+            reasoning_effort: None,
+            service_tier: None,
+            rotation_strategy: "account_rotation".to_string(),
+            aggregate_api_id: None,
+            account_plan_filter: None,
+            aggregate_api_url: None,
+            client_type: "codex".to_string(),
+            protocol_type: "openai_compat".to_string(),
+            auth_scheme: "authorization_bearer".to_string(),
+            upstream_base_url: None,
+            static_headers_json: None,
+            key_hash: hash_platform_key_for_test(platform_key),
+            status: "active".to_string(),
+            created_at: now,
+            last_used_at: None,
+        })
+        .expect("insert api key");
+
+    let server = codexmanager_service::start_one_shot_server().expect("start server");
+    let req_body_json = serde_json::json!({
+        "model": "gpt-5.3-codex",
+        "input": "hello",
+        "stream": true
+    });
+    let req_body = serde_json::to_string(&req_body_json).expect("serialize request");
+    let (status, _body) = post_http_raw(
+        &server.addr,
+        "/v1/responses",
+        &req_body,
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &format!("Bearer {platform_key}")),
+        ],
+    );
+    server.join();
+    assert_eq!(status, 200, "客户端看到的 HTTP status 应原样透传 200");
+
+    let captured = upstream_rx
+        .recv_timeout(Duration::from_secs(3))
+        .expect("receive upstream request");
+    upstream_join.join().expect("join mock upstream");
+    let auth = captured
+        .headers
+        .get("authorization")
+        .map(String::as_str)
+        .unwrap_or_default();
+    assert!(
+        auth.contains("access_acc_primary"),
+        "应命中 sort=0 的 primary 账号，实际 auth 头：{auth}"
+    );
+
+    // 等 request log 异步落盘。
+    let mut log = None;
+    for _ in 0..40 {
+        let logs = storage
+            .list_request_logs(Some("key:=gk_usage_limit_failover_marker"), 20)
+            .expect("list request logs");
+        log = logs
+            .into_iter()
+            .find(|item| item.request_path == "/v1/responses");
+        if log.is_some() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    let log = log.expect("request log should be recorded");
+    assert_eq!(
+        log.status_code,
+        Some(502),
+        "usage-limit 在 SSE 正文里时应触发 failover 记账（status_for_log=502），实际 {:?}",
+        log.status_code
+    );
+    assert_eq!(
+        log.account_id.as_deref(),
+        Some("acc_primary"),
+        "failover 记录应记在命中 usage-limit 的 primary 账号下"
+    );
+}
+
+/// Fix B 端到端：快要耗尽的账号（99% used）即使 sort 排前，也应被降权到候选尾部，
+/// 首个请求直接命中健康账号，不必经历失败-重试流程。
+#[test]
+fn gateway_low_quota_account_is_skipped_on_first_request() {
+    let _lock = test_env_guard();
+    let dir = new_test_dir("codexmanager-gateway-low-quota-skip");
+    let db_path: PathBuf = dir.join("codexmanager.db");
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+
+    let ok_sse = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_lowq_ok\",\"model\":\"gpt-5.3-codex\",\"usage\":{\"input_tokens\":3,\"output_tokens\":1,\"total_tokens\":4}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let (upstream_addr, upstream_rx, upstream_join) =
+        start_mock_upstream_sequence_lenient_with_content_types(
+            vec![(200, ok_sse.to_string(), "text/event-stream".to_string())],
+            Duration::from_secs(3),
+        );
+    let upstream_base = format!("http://{upstream_addr}/backend-api/codex");
+    let _upstream_guard = EnvGuard::set("CODEXMANAGER_UPSTREAM_BASE_URL", &upstream_base);
+
+    let storage = Storage::open(&db_path).expect("open db");
+    storage.init().expect("init db");
+    let now = now_ts();
+
+    // sort=0 的账号快照 99%（快耗尽），sort=1 的健康（10%）。
+    // Fix B 应把 exhausted 排到尾部，实际请求只打 healthy。
+    let rows: Vec<(&str, i64, f64)> = vec![("acc_exhausted", 0, 99.0), ("acc_healthy", 1, 10.0)];
+    for (id, sort, used_pct) in &rows {
+        storage
+            .insert_account(&Account {
+                id: (*id).to_string(),
+                label: (*id).to_string(),
+                issuer: "https://auth.openai.com".to_string(),
+                chatgpt_account_id: Some(format!("chatgpt_{id}")),
+                workspace_id: None,
+                group_name: None,
+                sort: *sort,
+                status: "active".to_string(),
+                created_at: now + *sort,
+                updated_at: now + *sort,
+            })
+            .expect("insert account");
+        storage
+            .insert_token(&Token {
+                account_id: (*id).to_string(),
+                id_token: String::new(),
+                access_token: format!("access_{id}"),
+                refresh_token: String::new(),
+                api_key_access_token: Some(format!("api_access_{id}")),
+                last_refresh: now,
+            })
+            .expect("insert token");
+        storage
+            .insert_usage_snapshot(&UsageSnapshotRecord {
+                account_id: (*id).to_string(),
+                used_percent: Some(*used_pct),
+                window_minutes: Some(300),
+                resets_at: None,
+                secondary_used_percent: None,
+                secondary_window_minutes: None,
+                secondary_resets_at: None,
+                credits_json: None,
+                captured_at: now,
+            })
+            .expect("insert snapshot");
+    }
+
+    let platform_key = "pk_low_quota_skip";
+    storage
+        .insert_api_key(&ApiKey {
+            id: "gk_low_quota_skip".to_string(),
+            name: Some("low-quota-skip".to_string()),
+            model_slug: Some("gpt-5.3-codex".to_string()),
+            reasoning_effort: None,
+            service_tier: None,
+            rotation_strategy: "account_rotation".to_string(),
+            aggregate_api_id: None,
+            account_plan_filter: None,
+            aggregate_api_url: None,
+            client_type: "codex".to_string(),
+            protocol_type: "openai_compat".to_string(),
+            auth_scheme: "authorization_bearer".to_string(),
+            upstream_base_url: None,
+            static_headers_json: None,
+            key_hash: hash_platform_key_for_test(platform_key),
+            status: "active".to_string(),
+            created_at: now,
+            last_used_at: None,
+        })
+        .expect("insert api key");
+
+    let server = codexmanager_service::start_one_shot_server().expect("start server");
+    let request_body = serde_json::json!({
+        "model": "gpt-5.3-codex",
+        "input": "hello",
+        "stream": true
+    });
+    let request_body = serde_json::to_string(&request_body).expect("serialize request");
+    let (status, gateway_body) = post_http_raw(
+        &server.addr,
+        "/v1/responses",
+        &request_body,
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &format!("Bearer {platform_key}")),
+        ],
+    );
+    server.join();
+    assert_eq!(status, 200, "gateway response: {gateway_body}");
+
+    let captured = upstream_rx
+        .recv_timeout(Duration::from_secs(3))
+        .expect("receive upstream request");
+    upstream_join.join().expect("join mock upstream");
+
+    let auth = captured
+        .headers
+        .get("authorization")
+        .map(String::as_str)
+        .unwrap_or_default();
+    assert!(
+        auth.contains("access_acc_healthy"),
+        "即便 sort=0 的账号排在前，99% used 的账号也应该被降到尾部；实际 auth 头：{auth}"
+    );
+    assert!(
+        upstream_rx
+            .recv_timeout(Duration::from_millis(300))
+            .is_err(),
+        "低配额账号应被直接跳过，不应再有第二次上游请求"
+    );
+}


### PR DESCRIPTION
## 背景

OpenAI 的 usage-limit 并不总是走 `event: response.failed`：部分场景下会用 `200 OK + SSE data` 帧把 "You've hit your usage limit. To get more access now, ..." 当成**普通助手内容**流回来。目前 HTTP SSE 链路识别不到这种形态，导致：

- `bridge.stream_terminal_error` 不设置 → `response_finalize` 不走 failover
- 账号不会被 `mark_account_cooldown` / `mark_account_unavailable_for_gateway_error`
- 下次请求路由还是挑到这个快耗尽的号，用户反复看到 "You've hit your usage limit"

`responses_websocket.rs` 的 `infer_ws_terminal_status` 已经做了类似识别（`crate::account_status::usage_limit_reason_from_message`），但 HTTP SSE 的 passthrough 路径没有对应处理；`list_gateway_candidates` 又只按 `used_percent < 100` 过滤，实际 OpenAI 在 95-99% 就会开始拒绝，健康的号排不到前面。

Closes #118

## 变更

### Fix A — `passthrough.rs::update_usage_from_frame`

在所有分支之前扫一遍 `data:` 正文，命中 `usage_limit_reason_from_message` 就把 `collector.saw_terminal = true` 且 `collector.terminal_error = Some(payload)`。原有的 `inspection.usage.is_none() && inspection.terminal.is_none()` 早退分支会被带有 `delta` 文本的帧跳过（delta 会 `get_or_insert` 出 `Some` 的 usage），所以必须放在最前面。

后续 `response_finalize` 的 `bridge.is_ok(is_stream) = false` → `final_error = Some(usage-limit payload)` → `should_failover_for_gateway_error` 返回 true → 走 `FinalizeUpstreamResponseOutcome::Failover` + `mark_account_cooldown` 路径。当前请求的字节已经流给了客户端（无法回滚），但账号被记账 + cooldown，下一条请求就会跳过这个号。

### Fix B — `selection.rs::demote_low_quota_candidates`

`collect_gateway_candidates_uncached` 里加一遍**稳定排序**：读 `latest_usage_snapshots_by_account`，`used_percent` 或 `secondary_used_percent` 超过阈值的账号排到候选列表尾部。

- 阈值通过环境变量 `CODEXMANAGER_LOW_QUOTA_THRESHOLD_PERCENT` 配置，默认 `95`
- **不剔除**任何账号，只重排 —— 全部触阈时保底仍返回所有账号
- 稳定排序，健康账号之间的原有 sort 次序保留

会话粘性（`rotate_to_bound_account`）运行在 Fix B 之后：绑定的账号仍会被旋转到 `[0]`，粘性不会被 Fix B 破坏。新会话走 Fix B 的配额偏好；有绑定的老会话走粘性，两者不冲突。

## 测试

新增 8 条，本地全绿（workspace 上已有的预先失败数不变）：

- `crates/service/src/gateway/observability/http_bridge/stream_readers/passthrough.rs` 4 个单元：
  - `extract_usage_limit_matches_plain_text_delta` — OpenAI 的 apology delta 帧被识别
  - `extract_usage_limit_matches_quota_exceeded_json` — `insufficient_quota` / `quota exceeded` 形态
  - `extract_usage_limit_ignores_unrelated_content` — 正常 delta 不误伤
  - `extract_usage_limit_ignores_frames_without_data` — 纯 event/keepalive 帧不误伤
- `crates/service/src/gateway/routing/tests/selection_tests.rs` 2 个单元：
  - `low_quota_accounts_are_demoted_to_tail` — primary 或 secondary 触阈都会被降权，稳定保序
  - `all_low_quota_still_returns_candidates` — 全部触阈时保底返回
- `crates/service/tests/gateway_logs/usage_limit_failover.rs` 2 个集成：
  - `gateway_usage_limit_in_sse_marks_request_as_failover` — mock 上游用 `text/event-stream` 正文夹带 usage-limit 文本，真实 HTTP 走完一圈，断言 `request_log.status_code == 502` 且 `account_id` 记在命中的 primary 号下
  - `gateway_low_quota_account_is_skipped_on_first_request` — primary 号快照 99%、secondary 号 10%，即便 sort=0 的是 primary，请求也必须落到 secondary

跑法：
```bash
cargo test -p codexmanager-service --lib extract_usage_limit
cargo test -p codexmanager-service --lib low_quota
cargo test -p codexmanager-service --test gateway_logs usage_limit_failover
```

## 兼容性

- 默认阈值 95；如果旧部署里账号一直在 95% 以下，行为和之前一致
- 没有改 storage schema、没有改 RPC 协议、没有改 API Key / Account 字段
- `support.rs` 里把 `start_mock_upstream_sequence_lenient` 重构为调用新的 `_with_content_types` 变体，公开接口兼容（`start_mock_upstream_sequence` 签名不变）