### PR TITLE
Fix Team account import identity matching

### DIFF
--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -190,6 +190,56 @@ pub fn extract_chatgpt_account_id(token: &str) -> Option<String> {
         .and_then(|v| normalize_chatgpt_account_id(Some(v)))
 }
 
+/// 函数 `extract_chatgpt_user_id`
+///
+/// 作者: gaohongshun
+///
+/// 时间: 2026-04-02
+///
+/// # 参数
+/// - token: 参数 token
+///
+/// # 返回
+/// 返回函数执行结果
+pub fn extract_chatgpt_user_id(token: &str) -> Option<String> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let json = std::str::from_utf8(&decoded).ok()?;
+    let value: serde_json::Value = serde_json::from_str(json).ok()?;
+    for key in ["chatgpt_user_id", "user_id"] {
+        if let Some(v) = value.get(key).and_then(|v| v.as_str()) {
+            let trimmed = v.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    value
+        .get("https://api.openai.com/auth")
+        .and_then(|v| v.as_object())
+        .and_then(|auth| {
+            ["chatgpt_user_id", "user_id"].into_iter().find_map(|key| {
+                auth.get(key)
+                    .and_then(|v| v.as_str())
+                    .map(str::trim)
+                    .filter(|v| !v.is_empty())
+                    .map(str::to_string)
+            })
+        })
+        .or_else(|| {
+            value
+                .get("sub")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(str::to_string)
+        })
+}
+
 /// 函数 `extract_workspace_id`
 ///
 /// 作者: gaohongshun

--- a/crates/core/tests/auth.rs
+++ b/crates/core/tests/auth.rs
@@ -120,3 +120,15 @@ fn extract_scope_ids_from_token_filters_storage_style_identity_suffix() {
         Some("org-AP6ypcMi84Thfueli6EU3B4m".to_string())
     );
 }
+
+#[test]
+fn extract_chatgpt_user_id_prefers_nested_user_identity() {
+    let token = jwt_with_json(
+        r#"{"sub":"subject-1","https://api.openai.com/auth":{"chatgpt_user_id":"user-1","user_id":"fallback-user"}}"#,
+    );
+
+    assert_eq!(
+        codexmanager_core::auth::extract_chatgpt_user_id(&token),
+        Some("user-1".to_string())
+    );
+}

--- a/crates/service/src/account/account_import.rs
+++ b/crates/service/src/account/account_import.rs
@@ -1,11 +1,12 @@
 use codexmanager_core::auth::{
-    extract_chatgpt_account_id, extract_workspace_id, parse_id_token_claims, DEFAULT_ISSUER,
+    extract_chatgpt_account_id, extract_chatgpt_user_id, extract_workspace_id,
+    parse_id_token_claims, IdTokenClaims, DEFAULT_ISSUER,
 };
 use codexmanager_core::storage::{now_ts, Account, Storage, Token};
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use crate::account_identity::{
@@ -18,6 +19,7 @@ const MAX_ERROR_ITEMS: usize = 50;
 const DEFAULT_IMPORT_BATCH_SIZE: usize = 200;
 const IMPORT_BATCH_SIZE_ENV: &str = "CODEXMANAGER_ACCOUNT_IMPORT_BATCH_SIZE";
 const ACCOUNT_SORT_STEP: i64 = 5;
+const IMPORT_TOKEN_SUBJECT_PREFIX: &str = "import-token-";
 
 #[derive(Debug, Serialize)]
 pub(crate) struct AccountImportResult {
@@ -57,6 +59,9 @@ struct ImportAccountMeta {
 #[derive(Default)]
 struct ExistingAccountIndex {
     by_id: HashMap<String, Account>,
+    by_subject_storage_id: HashMap<String, String>,
+    by_subject_key: HashMap<String, String>,
+    ambiguous_subject_keys: HashSet<String>,
     next_sort: i64,
 }
 
@@ -80,6 +85,11 @@ impl ExistingAccountIndex {
                 .next_sort
                 .max(account.sort.saturating_add(ACCOUNT_SORT_STEP));
             idx.by_id.insert(account.id.clone(), account);
+        }
+        for token in storage.list_tokens().map_err(|e| e.to_string())? {
+            if let Some(account) = idx.by_id.get(&token.account_id).cloned() {
+                idx.index_token_subject(&account, &token);
+            }
         }
         Ok(idx)
     }
@@ -106,13 +116,61 @@ impl ExistingAccountIndex {
         fallback_subject_key: Option<&str>,
         account_id_hint: Option<&str>,
     ) -> Option<String> {
+        if let Some(found) =
+            self.find_by_subject_identity(chatgpt_account_id, workspace_id, fallback_subject_key)
+        {
+            return Some(found);
+        }
+        if fallback_subject_key.is_some() {
+            return None;
+        }
         pick_existing_account_id_by_identity(
             self.by_id.values(),
             chatgpt_account_id,
             workspace_id,
-            fallback_subject_key,
+            None,
             account_id_hint,
         )
+    }
+
+    /// 函数 `find_by_subject_identity`
+    ///
+    /// 作者: gaohongshun
+    ///
+    /// 时间: 2026-04-02
+    ///
+    /// # 参数
+    /// - self: 参数 self
+    /// - chatgpt_account_id: 参数 chatgpt_account_id
+    /// - workspace_id: 参数 workspace_id
+    /// - fallback_subject_key: 参数 fallback_subject_key
+    ///
+    /// # 返回
+    /// 返回函数执行结果
+    fn find_by_subject_identity(
+        &self,
+        chatgpt_account_id: Option<&str>,
+        workspace_id: Option<&str>,
+        fallback_subject_key: Option<&str>,
+    ) -> Option<String> {
+        let subject_key = fallback_subject_key
+            .map(str::trim)
+            .filter(|v| !v.is_empty())?;
+        let scoped_id =
+            build_account_storage_id(subject_key, chatgpt_account_id, workspace_id, None);
+        if self.by_id.contains_key(&scoped_id) {
+            return Some(scoped_id);
+        }
+        if let Some(account_id) = self.by_subject_storage_id.get(&scoped_id) {
+            return Some(account_id.clone());
+        }
+        if self.by_id.contains_key(subject_key) {
+            return Some(subject_key.to_string());
+        }
+        if let Some(account_id) = self.by_subject_key.get(subject_key) {
+            return Some(account_id.clone());
+        }
+        None
     }
 
     /// 函数 `upsert_index`
@@ -129,6 +187,73 @@ impl ExistingAccountIndex {
     /// 无
     fn upsert_index(&mut self, account: &Account) {
         self.by_id.insert(account.id.clone(), account.clone());
+    }
+
+    /// 函数 `index_token_subject`
+    ///
+    /// 作者: gaohongshun
+    ///
+    /// 时间: 2026-04-02
+    ///
+    /// # 参数
+    /// - self: 参数 self
+    /// - account: 参数 account
+    /// - token: 参数 token
+    ///
+    /// # 返回
+    /// 无
+    fn index_token_subject(&mut self, account: &Account, token: &Token) {
+        let Some(subject_account_id) = extract_import_subject_account_id(
+            None,
+            &token.id_token,
+            &token.access_token,
+            &token.refresh_token,
+        ) else {
+            return;
+        };
+        let Some(subject_key) =
+            build_fallback_subject_key(Some(subject_account_id.as_str()), None::<&str>)
+        else {
+            return;
+        };
+        let scoped_id = build_account_storage_id(
+            subject_key.as_str(),
+            account.chatgpt_account_id.as_deref(),
+            account.workspace_id.as_deref(),
+            None,
+        );
+        self.by_subject_storage_id
+            .insert(scoped_id, account.id.clone());
+        self.record_subject_key(subject_key, account.id.clone());
+    }
+
+    /// 函数 `record_subject_key`
+    ///
+    /// 作者: gaohongshun
+    ///
+    /// 时间: 2026-04-02
+    ///
+    /// # 参数
+    /// - self: 参数 self
+    /// - subject_key: 参数 subject_key
+    /// - account_id: 参数 account_id
+    ///
+    /// # 返回
+    /// 无
+    fn record_subject_key(&mut self, subject_key: String, account_id: String) {
+        if self.ambiguous_subject_keys.contains(&subject_key) {
+            return;
+        }
+        match self.by_subject_key.get(&subject_key) {
+            Some(existing) if existing == &account_id => {}
+            Some(_) => {
+                self.by_subject_key.remove(&subject_key);
+                self.ambiguous_subject_keys.insert(subject_key);
+            }
+            None => {
+                self.by_subject_key.insert(subject_key, account_id);
+            }
+        }
     }
 }
 
@@ -510,10 +635,13 @@ fn import_single_item(
     let payload = extract_token_payload(&item)?;
     let meta = extract_account_meta(item);
     let claims = parse_id_token_claims(&payload.id_token).ok();
-    let subject_account_id = claims
-        .as_ref()
-        .map(|c| c.sub.trim().to_string())
-        .filter(|v| !v.is_empty());
+    let token_fingerprint = token_fingerprint(&payload.refresh_token);
+    let subject_account_id = extract_import_subject_account_id(
+        claims.as_ref(),
+        &payload.id_token,
+        &payload.access_token,
+        &payload.refresh_token,
+    );
     let chatgpt_account_id = clean_value(
         meta.chatgpt_account_id
             .clone()
@@ -524,8 +652,7 @@ fn import_single_item(
                     .and_then(|c| c.auth.as_ref()?.chatgpt_account_id.clone())
             })
             .or_else(|| extract_chatgpt_account_id(&payload.id_token))
-            .or_else(|| extract_chatgpt_account_id(&payload.access_token))
-            .or_else(|| payload.account_id_hint.clone()),
+            .or_else(|| extract_chatgpt_account_id(&payload.access_token)),
     );
 
     let workspace_id = clean_value(
@@ -534,11 +661,15 @@ fn import_single_item(
             .or_else(|| claims.as_ref().and_then(|c| c.workspace_id.clone()))
             .or_else(|| extract_workspace_id(&payload.id_token))
             .or_else(|| extract_workspace_id(&payload.access_token))
+            .or_else(|| payload.account_id_hint.clone())
             .or_else(|| chatgpt_account_id.clone()),
     );
-    let token_fingerprint = token_fingerprint(&payload.refresh_token);
     let fallback_subject_key =
         build_fallback_subject_key(subject_account_id.as_deref(), None::<&str>);
+    let token_fingerprint_for_id = match subject_account_id.as_deref() {
+        Some(subject) if subject.starts_with(IMPORT_TOKEN_SUBJECT_PREFIX) => None,
+        _ => Some(token_fingerprint.as_str()),
+    };
     let account_id = index
         .find_existing_account_id(
             chatgpt_account_id.as_deref(),
@@ -551,7 +682,7 @@ fn import_single_item(
             subject_account_id.as_deref(),
             chatgpt_account_id.as_deref(),
             workspace_id.as_deref(),
-            Some(token_fingerprint.as_str()),
+            token_fingerprint_for_id,
         )?);
 
     let label = meta
@@ -666,7 +797,55 @@ fn import_single_item(
     };
     storage.insert_token(&token).map_err(|e| e.to_string())?;
     index.upsert_index(&account);
+    index.index_token_subject(&account, &token);
     Ok(created)
+}
+
+/// 函数 `extract_import_subject_account_id`
+///
+/// 作者: gaohongshun
+///
+/// 时间: 2026-04-02
+///
+/// # 参数
+/// - claims: 参数 claims
+/// - id_token: 参数 id_token
+/// - access_token: 参数 access_token
+/// - refresh_token: 参数 refresh_token
+///
+/// # 返回
+/// 返回函数执行结果
+fn extract_import_subject_account_id(
+    claims: Option<&IdTokenClaims>,
+    id_token: &str,
+    access_token: &str,
+    refresh_token: &str,
+) -> Option<String> {
+    clean_value(
+        claims
+            .and_then(|c| {
+                c.auth.as_ref().and_then(|auth| {
+                    auth.chatgpt_user_id
+                        .clone()
+                        .or_else(|| auth.user_id.clone())
+                })
+            })
+            .or_else(|| {
+                claims
+                    .map(|c| c.sub.trim().to_string())
+                    .filter(|v| !v.is_empty())
+            })
+            .or_else(|| extract_chatgpt_user_id(id_token))
+            .or_else(|| extract_chatgpt_user_id(access_token))
+            .or_else(|| {
+                if refresh_token.trim().is_empty() {
+                    None
+                } else {
+                    let token_fingerprint = token_fingerprint(refresh_token);
+                    Some(format!("{IMPORT_TOKEN_SUBJECT_PREFIX}{token_fingerprint}"))
+                }
+            }),
+    )
 }
 
 /// 函数 `extract_token_payload`

--- a/crates/service/src/account/tests/account_import_tests.rs
+++ b/crates/service/src/account/tests/account_import_tests.rs
@@ -3,13 +3,15 @@ use super::{
     resolve_logical_account_id, ExistingAccountIndex, ImportTokenPayload,
 };
 use crate::account_identity::build_account_storage_id;
-use codexmanager_core::storage::{now_ts, Account, Storage};
+use codexmanager_core::storage::{now_ts, Account, Storage, Token};
 use serde_json::json;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const TEST_ID_TOKEN_WS_A: &str = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdWItMSIsImVtYWlsIjoidGVzdEBleGFtcGxlLmNvbSIsIndvcmtzcGFjZV9pZCI6IndzLWEiLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiY2dwdC0xIn19.sig";
 const TEST_ID_TOKEN_META: &str = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdWItMSIsImVtYWlsIjoibWV0YUBleGFtcGxlLmNvbSIsIndvcmtzcGFjZV9pZCI6IndzLW1ldGEiLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiY2dwdC1tZXRhIn19.sig";
+const TEST_ACCESS_TOKEN_TEAM_USER_A: &str = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdWJqZWN0LWEiLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoidGVhbS0xIiwiY2hhdGdwdF91c2VyX2lkIjoidXNlci1hIn19.sig";
+const TEST_ACCESS_TOKEN_TEAM_USER_B: &str = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdWJqZWN0LWIiLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoidGVhbS0xIiwiY2hhdGdwdF91c2VyX2lkIjoidXNlci1iIn19.sig";
 
 /// 函数 `unique_temp_db_path`
 ///
@@ -322,6 +324,120 @@ fn import_single_item_reuses_existing_login_account_by_scope_identity() {
         .expect("find token")
         .expect("token");
     assert_eq!(token.account_id, accounts[0].id);
+}
+
+/// 函数 `import_single_item_distinguishes_team_members_sharing_account_hint`
+///
+/// 作者: gaohongshun
+///
+/// 时间: 2026-04-02
+///
+/// # 参数
+/// 无
+///
+/// # 返回
+/// 无
+#[test]
+fn import_single_item_distinguishes_team_members_sharing_account_hint() {
+    let storage = Storage::open_in_memory().expect("open in memory");
+    storage.init().expect("init");
+    let mut idx = ExistingAccountIndex::build(&storage).expect("build index");
+
+    let user_a = json!({
+        "tokens": {
+            "access_token": TEST_ACCESS_TOKEN_TEAM_USER_A,
+            "account_id": "team-1",
+            "refresh_token": "refresh.user-a"
+        }
+    });
+    let user_b = json!({
+        "tokens": {
+            "access_token": TEST_ACCESS_TOKEN_TEAM_USER_B,
+            "account_id": "team-1",
+            "refresh_token": "refresh.user-b"
+        }
+    });
+
+    assert!(import_single_item(&storage, &mut idx, &user_a, 1).expect("import user a"));
+    assert!(import_single_item(&storage, &mut idx, &user_b, 2).expect("import user b"));
+
+    let accounts = storage.list_accounts().expect("list accounts");
+    assert_eq!(accounts.len(), 2);
+    assert!(accounts
+        .iter()
+        .any(|account| account.id.starts_with("user-a::")));
+    assert!(accounts
+        .iter()
+        .any(|account| account.id.starts_with("user-b::")));
+    assert!(accounts
+        .iter()
+        .all(|account| account.workspace_id.as_deref() == Some("team-1")));
+
+    assert!(!import_single_item(&storage, &mut idx, &user_a, 3).expect("reimport user a"));
+    assert_eq!(storage.list_accounts().expect("list accounts").len(), 2);
+}
+
+/// 函数 `import_single_item_reuses_legacy_team_account_when_token_subject_matches`
+///
+/// 作者: gaohongshun
+///
+/// 时间: 2026-04-02
+///
+/// # 参数
+/// 无
+///
+/// # 返回
+/// 无
+#[test]
+fn import_single_item_reuses_legacy_team_account_when_token_subject_matches() {
+    let storage = Storage::open_in_memory().expect("open in memory");
+    storage.init().expect("init");
+    let now = now_ts();
+    storage
+        .insert_account(&Account {
+            id: "team-1".to_string(),
+            label: "legacy team account".to_string(),
+            issuer: "https://auth.openai.com".to_string(),
+            chatgpt_account_id: Some("team-1".to_string()),
+            workspace_id: Some("team-1".to_string()),
+            group_name: None,
+            sort: 0,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("insert legacy account");
+    storage
+        .insert_token(&Token {
+            account_id: "team-1".to_string(),
+            id_token: "".to_string(),
+            access_token: TEST_ACCESS_TOKEN_TEAM_USER_A.to_string(),
+            refresh_token: "refresh.user-a.old".to_string(),
+            api_key_access_token: None,
+            last_refresh: now,
+        })
+        .expect("insert legacy token");
+
+    let mut idx = ExistingAccountIndex::build(&storage).expect("build index");
+    let item = json!({
+        "tokens": {
+            "access_token": TEST_ACCESS_TOKEN_TEAM_USER_A,
+            "account_id": "team-1",
+            "refresh_token": "refresh.user-a.new"
+        }
+    });
+
+    let created = import_single_item(&storage, &mut idx, &item, 1).expect("import item");
+    assert!(!created);
+
+    let accounts = storage.list_accounts().expect("list accounts");
+    assert_eq!(accounts.len(), 1);
+    assert_eq!(accounts[0].id, "team-1");
+    let token = storage
+        .find_token_by_account_id("team-1")
+        .expect("find token")
+        .expect("token");
+    assert_eq!(token.refresh_token, "refresh.user-a.new");
 }
 
 /// 函数 `import_single_item_prefers_meta_fields_for_new_account`


### PR DESCRIPTION
## Summary
- Use per-user JWT identity (chatgpt_user_id / user_id / sub) when importing accounts, so multiple ChatGPT Team members sharing the same account_id are not merged.
- Keep existing imported/login accounts compatible by indexing subject identity from stored tokens before import.
- Treat import account_id as workspace fallback instead of a ChatGPT account id fallback to avoid same-team collisions.

## Tests
- rustfmt --edition 2021 --check crates/core/src/auth/mod.rs crates/core/tests/auth.rs crates/service/src/account/account_import.rs crates/service/src/account/tests/account_import_tests.rs
- cargo test -p codexmanager-service import_single_item
- cargo test -p codexmanager-core extract_chatgpt_user_id_prefers_nested_user_identity