### PR TITLE
修复后台用量线程刷新后 UI 未同步更新的问题

### DIFF
--- a/apps/playwright.config.ts
+++ b/apps/playwright.config.ts
@@ -1,23 +1,34 @@
 import { defineConfig } from "@playwright/test";
 
 const PORT = 3200;
+const LOCAL_TEST_HOST = "localhost";
+
+const noProxyHosts = ["localhost", "127.0.0.1", "::1"];
+const noProxy = [process.env.NO_PROXY, process.env.no_proxy, ...noProxyHosts]
+  .filter(Boolean)
+  .join(",");
+
+process.env.NO_PROXY = noProxy;
+process.env.no_proxy = noProxy;
 
 export default defineConfig({
   testDir: "./tests",
   timeout: 30_000,
   fullyParallel: false,
   use: {
-    baseURL: `http://127.0.0.1:${PORT}`,
+    baseURL: `http://${LOCAL_TEST_HOST}:${PORT}`,
     trace: "on-first-retry",
     video: "retain-on-failure",
   },
   webServer: {
-    command: "node tests/support/static-server.mjs",
-    url: `http://127.0.0.1:${PORT}`,
-    reuseExistingServer: true,
+    command: "pnpm run build:desktop && node tests/support/static-server.mjs",
+    url: `http://${LOCAL_TEST_HOST}:${PORT}`,
+    reuseExistingServer: false,
     timeout: 120_000,
     env: {
+      NO_PROXY: noProxy,
       PORT: String(PORT),
+      no_proxy: noProxy,
     },
   },
 });

--- a/apps/src-tauri/src/lib.rs
+++ b/apps/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
-use tauri::Manager;
+use serde::Serialize;
+use tauri::{Emitter, Manager};
 
 mod app_shell;
 mod app_storage;
@@ -11,6 +12,16 @@ use app_shell::{
     notify_existing_instance_focused, setup_tray, show_main_window, sync_startup_window_state,
     CLOSE_TO_TRAY_ON_CLOSE, TRAY_AVAILABLE,
 };
+
+const USAGE_REFRESH_COMPLETED_EVENT: &str = "usage-refresh-completed";
+
+#[derive(Clone, Serialize)]
+struct UsageRefreshCompletedPayload {
+    source: &'static str,
+    processed: usize,
+    total: usize,
+    completed_at: i64,
+}
 
 /// 函数 `run`
 ///
@@ -49,6 +60,20 @@ pub fn run() {
             if let Ok(log_dir) = app.path().app_log_dir() {
                 log::info!("log dir: {}", log_dir.display());
             }
+            let usage_refresh_event_app = app.handle().clone();
+            codexmanager_service::set_usage_refresh_completed_handler(move |event| {
+                let payload = UsageRefreshCompletedPayload {
+                    source: event.source,
+                    processed: event.processed,
+                    total: event.total,
+                    completed_at: event.completed_at,
+                };
+                if let Err(err) = usage_refresh_event_app
+                    .emit(USAGE_REFRESH_COMPLETED_EVENT, payload)
+                {
+                    log::warn!("emit usage refresh completed event failed: {}", err);
+                }
+            });
             if let Err(err) = setup_tray(app.handle()) {
                 TRAY_AVAILABLE.store(false, std::sync::atomic::Ordering::Relaxed);
                 CLOSE_TO_TRAY_ON_CLOSE.store(false, std::sync::atomic::Ordering::Relaxed);

--- a/apps/src/hooks/useAccounts.ts
+++ b/apps/src/hooks/useAccounts.ts
@@ -16,7 +16,7 @@ import { useLocalDayRange } from "@/hooks/useLocalDayRange";
 import { useRuntimeCapabilities } from "@/hooks/useRuntimeCapabilities";
 import { useI18n } from "@/lib/i18n/provider";
 import { useAppStore } from "@/lib/store/useAppStore";
-import { AccountListResult, StartupSnapshot } from "@/types";
+import { AccountListResult, AccountUsage, StartupSnapshot } from "@/types";
 
 type ImportByDirectoryResult = Awaited<ReturnType<typeof accountClient.importByDirectory>>;
 type ImportByFileResult = Awaited<ReturnType<typeof accountClient.importByFile>>;
@@ -112,7 +112,7 @@ function getAccountsAutoRefreshIntervalMs(
   return Math.max(1, intervalSecs) * 1000;
 }
 
-function getUsageRefreshSignalIntervalMs(
+function getUsageListRefreshIntervalMs(
   enabled: boolean,
   intervalSecs: number,
 ): number | false {
@@ -121,6 +121,28 @@ function getUsageRefreshSignalIntervalMs(
     return false;
   }
   return Math.min(5_000, intervalMs);
+}
+
+function buildUsageListFingerprint(usages: AccountUsage[]): string {
+  if (usages.length === 0) {
+    return "";
+  }
+
+  return usages
+    .map((usage) =>
+      [
+        usage.accountId,
+        usage.capturedAt ?? "",
+        usage.usedPercent ?? "",
+        usage.secondaryUsedPercent ?? "",
+        usage.resetsAt ?? "",
+        usage.secondaryResetsAt ?? "",
+        usage.availabilityStatus ?? "",
+        usage.creditsJson ?? "",
+      ].join(":"),
+    )
+    .sort()
+    .join("|");
 }
 
 /**
@@ -152,11 +174,11 @@ export function useAccounts() {
     areAccountQueriesEnabled && backgroundTasks.usagePollingEnabled,
     backgroundTasks.usagePollIntervalSecs,
   );
-  const usageRefreshSignalIntervalMs = getUsageRefreshSignalIntervalMs(
+  const usageListRefreshIntervalMs = getUsageListRefreshIntervalMs(
     areAccountQueriesEnabled && backgroundTasks.usagePollingEnabled,
     backgroundTasks.usagePollIntervalSecs,
   );
-  const latestUsageCapturedAtRef = useRef<number | null>(null);
+  const usageListFingerprintRef = useRef<string | null>(null);
   const startupSnapshot = queryClient.getQueryData<StartupSnapshot>(
     buildStartupSnapshotQueryKey(
       serviceStatus.addr,
@@ -213,72 +235,43 @@ export function useAccounts() {
     queryFn: () => accountClient.listUsage(),
     enabled: areAccountQueriesEnabled,
     retry: 1,
-    refetchInterval: accountsAutoRefreshIntervalMs,
+    refetchInterval: usageListRefreshIntervalMs,
     refetchIntervalInBackground: false,
     placeholderData: (previousData) =>
       previousData || (startupUsages.length > 0 ? startupUsages : undefined),
   });
 
-  const latestUsageSignalQuery = useQuery({
-    queryKey: ["usage", "latest-refresh-signal"],
-    queryFn: () => accountClient.getLatestUsage(),
-    enabled: areAccountQueriesEnabled && backgroundTasks.usagePollingEnabled,
-    retry: 1,
-    refetchInterval: usageRefreshSignalIntervalMs,
-    refetchIntervalInBackground: false,
-  });
-
-  const maxKnownUsageCapturedAt = useMemo(() => {
-    return (usagesQuery.data || []).reduce<number | null>((latest, usage) => {
-      const capturedAt = usage.capturedAt;
-      if (capturedAt == null) {
-        return latest;
-      }
-      return latest == null ? capturedAt : Math.max(latest, capturedAt);
-    }, null);
-  }, [usagesQuery.data]);
+  const usageListFingerprint = useMemo(
+    () => buildUsageListFingerprint(usagesQuery.data || []),
+    [usagesQuery.data],
+  );
 
   useEffect(() => {
     if (!areAccountQueriesEnabled) {
-      latestUsageCapturedAtRef.current = null;
+      usageListFingerprintRef.current = null;
       return;
     }
 
-    const capturedAt = latestUsageSignalQuery.data?.capturedAt ?? null;
-    if (capturedAt == null) {
+    if (!usagesQuery.isFetched) {
       return;
     }
 
-    const previousCapturedAt = latestUsageCapturedAtRef.current;
-    if (
-      previousCapturedAt == null &&
-      maxKnownUsageCapturedAt == null &&
-      !usagesQuery.isFetched
-    ) {
-      return;
-    }
-
-    latestUsageCapturedAtRef.current = capturedAt;
-    const baselineCapturedAt =
-      previousCapturedAt == null
-        ? (maxKnownUsageCapturedAt ?? 0)
-        : previousCapturedAt;
-    if (capturedAt <= baselineCapturedAt) {
+    const previousFingerprint = usageListFingerprintRef.current;
+    usageListFingerprintRef.current = usageListFingerprint;
+    if (previousFingerprint == null || previousFingerprint === usageListFingerprint) {
       return;
     }
 
     void Promise.all([
       queryClient.invalidateQueries({ queryKey: ["accounts", "list"] }),
-      queryClient.invalidateQueries({ queryKey: ["usage", "list"] }),
       queryClient.invalidateQueries({ queryKey: ["usage-aggregate"] }),
       queryClient.invalidateQueries({ queryKey: ["today-summary"] }),
       queryClient.invalidateQueries({ queryKey: ["startup-snapshot"] }),
     ]);
   }, [
     areAccountQueriesEnabled,
-    latestUsageSignalQuery.data?.capturedAt,
-    maxKnownUsageCapturedAt,
     queryClient,
+    usageListFingerprint,
     usagesQuery.isFetched,
   ]);
 

--- a/apps/src/hooks/useAccounts.ts
+++ b/apps/src/hooks/useAccounts.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { accountClient } from "@/lib/api/account-client";
@@ -112,6 +112,17 @@ function getAccountsAutoRefreshIntervalMs(
   return Math.max(1, intervalSecs) * 1000;
 }
 
+function getUsageRefreshSignalIntervalMs(
+  enabled: boolean,
+  intervalSecs: number,
+): number | false {
+  const intervalMs = getAccountsAutoRefreshIntervalMs(enabled, intervalSecs);
+  if (!intervalMs) {
+    return false;
+  }
+  return Math.min(5_000, intervalMs);
+}
+
 /**
  * 函数 `useAccounts`
  *
@@ -141,6 +152,11 @@ export function useAccounts() {
     areAccountQueriesEnabled && backgroundTasks.usagePollingEnabled,
     backgroundTasks.usagePollIntervalSecs,
   );
+  const usageRefreshSignalIntervalMs = getUsageRefreshSignalIntervalMs(
+    areAccountQueriesEnabled && backgroundTasks.usagePollingEnabled,
+    backgroundTasks.usagePollIntervalSecs,
+  );
+  const latestUsageCapturedAtRef = useRef<number | null>(null);
   const startupSnapshot = queryClient.getQueryData<StartupSnapshot>(
     buildStartupSnapshotQueryKey(
       serviceStatus.addr,
@@ -202,6 +218,69 @@ export function useAccounts() {
     placeholderData: (previousData) =>
       previousData || (startupUsages.length > 0 ? startupUsages : undefined),
   });
+
+  const latestUsageSignalQuery = useQuery({
+    queryKey: ["usage", "latest-refresh-signal"],
+    queryFn: () => accountClient.getLatestUsage(),
+    enabled: areAccountQueriesEnabled && backgroundTasks.usagePollingEnabled,
+    retry: 1,
+    refetchInterval: usageRefreshSignalIntervalMs,
+    refetchIntervalInBackground: false,
+  });
+
+  const maxKnownUsageCapturedAt = useMemo(() => {
+    return (usagesQuery.data || []).reduce<number | null>((latest, usage) => {
+      const capturedAt = usage.capturedAt;
+      if (capturedAt == null) {
+        return latest;
+      }
+      return latest == null ? capturedAt : Math.max(latest, capturedAt);
+    }, null);
+  }, [usagesQuery.data]);
+
+  useEffect(() => {
+    if (!areAccountQueriesEnabled) {
+      latestUsageCapturedAtRef.current = null;
+      return;
+    }
+
+    const capturedAt = latestUsageSignalQuery.data?.capturedAt ?? null;
+    if (capturedAt == null) {
+      return;
+    }
+
+    const previousCapturedAt = latestUsageCapturedAtRef.current;
+    if (
+      previousCapturedAt == null &&
+      maxKnownUsageCapturedAt == null &&
+      !usagesQuery.isFetched
+    ) {
+      return;
+    }
+
+    latestUsageCapturedAtRef.current = capturedAt;
+    const baselineCapturedAt =
+      previousCapturedAt == null
+        ? (maxKnownUsageCapturedAt ?? 0)
+        : previousCapturedAt;
+    if (capturedAt <= baselineCapturedAt) {
+      return;
+    }
+
+    void Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["accounts", "list"] }),
+      queryClient.invalidateQueries({ queryKey: ["usage", "list"] }),
+      queryClient.invalidateQueries({ queryKey: ["usage-aggregate"] }),
+      queryClient.invalidateQueries({ queryKey: ["today-summary"] }),
+      queryClient.invalidateQueries({ queryKey: ["startup-snapshot"] }),
+    ]);
+  }, [
+    areAccountQueriesEnabled,
+    latestUsageSignalQuery.data?.capturedAt,
+    maxKnownUsageCapturedAt,
+    queryClient,
+    usagesQuery.isFetched,
+  ]);
 
   const accounts = useMemo(() => {
     return attachUsagesToAccounts(

--- a/apps/src/hooks/useAccounts.ts
+++ b/apps/src/hooks/useAccounts.ts
@@ -10,6 +10,7 @@ import {
   STARTUP_SNAPSHOT_REQUEST_LOG_LIMIT,
 } from "@/lib/api/startup-snapshot";
 import { getAppErrorMessage } from "@/lib/api/transport";
+import { listenUsageRefreshCompleted } from "@/lib/api/usage-refresh-events";
 import { useDesktopPageActive } from "@/hooks/useDesktopPageActive";
 import { useDeferredDesktopActivation } from "@/hooks/useDeferredDesktopActivation";
 import { useLocalDayRange } from "@/hooks/useLocalDayRange";
@@ -245,6 +246,39 @@ export function useAccounts() {
     () => buildUsageListFingerprint(usagesQuery.data || []),
     [usagesQuery.data],
   );
+
+  useEffect(() => {
+    if (!areAccountQueriesEnabled) {
+      return;
+    }
+
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    const refreshVisibleUsageData = () => {
+      void Promise.all([
+        queryClient.refetchQueries({ queryKey: ["usage", "list"], type: "active" }),
+        queryClient.refetchQueries({ queryKey: ["accounts", "list"], type: "active" }),
+        queryClient.invalidateQueries({ queryKey: ["usage-aggregate"] }),
+        queryClient.invalidateQueries({ queryKey: ["today-summary"] }),
+        queryClient.invalidateQueries({ queryKey: ["startup-snapshot"] }),
+      ]);
+    };
+
+    void listenUsageRefreshCompleted(() => {
+      refreshVisibleUsageData();
+    }).then((cleanup) => {
+      if (disposed) {
+        cleanup();
+        return;
+      }
+      unlisten = cleanup;
+    });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [areAccountQueriesEnabled, queryClient]);
 
   useEffect(() => {
     if (!areAccountQueriesEnabled) {

--- a/apps/src/lib/api/account-client.ts
+++ b/apps/src/lib/api/account-client.ts
@@ -401,6 +401,10 @@ export const accountClient = {
     );
     return normalizeUsageSnapshot(unwrapUsageSnapshotPayload(result));
   },
+  async getLatestUsage(): Promise<AccountUsage | null> {
+    const result = await invoke<unknown>("service_usage_read", withAddr());
+    return normalizeUsageSnapshot(unwrapUsageSnapshotPayload(result));
+  },
   async listUsage(): Promise<AccountUsage[]> {
     const result = await invoke<unknown>("service_usage_list", withAddr());
     return normalizeUsageList(result);

--- a/apps/src/lib/api/usage-refresh-events.ts
+++ b/apps/src/lib/api/usage-refresh-events.ts
@@ -1,0 +1,53 @@
+import { isTauriRuntime } from "./transport";
+
+export const USAGE_REFRESH_COMPLETED_EVENT = "usage-refresh-completed";
+
+export interface UsageRefreshCompletedPayload {
+  source?: string;
+  processed?: number;
+  total?: number;
+  completedAt?: number;
+  completed_at?: number;
+}
+
+export type UsageRefreshCompletedHandler = (
+  payload: UsageRefreshCompletedPayload
+) => void;
+
+type Unlisten = () => void;
+
+function readUsageRefreshEventPayload(event: Event): UsageRefreshCompletedPayload {
+  if (event instanceof CustomEvent && typeof event.detail === "object" && event.detail) {
+    return event.detail as UsageRefreshCompletedPayload;
+  }
+  return {};
+}
+
+export async function listenUsageRefreshCompleted(
+  handler: UsageRefreshCompletedHandler
+): Promise<Unlisten> {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const handleWindowEvent = (event: Event) => {
+    handler(readUsageRefreshEventPayload(event));
+  };
+  window.addEventListener(USAGE_REFRESH_COMPLETED_EVENT, handleWindowEvent);
+
+  let unlistenTauri: Unlisten | null = null;
+  if (isTauriRuntime()) {
+    const { listen } = await import("@tauri-apps/api/event");
+    unlistenTauri = await listen<UsageRefreshCompletedPayload>(
+      USAGE_REFRESH_COMPLETED_EVENT,
+      (event) => {
+        handler(event.payload || {});
+      },
+    );
+  }
+
+  return () => {
+    window.removeEventListener(USAGE_REFRESH_COMPLETED_EVENT, handleWindowEvent);
+    unlistenTauri?.();
+  };
+}

--- a/apps/tests/accounts-usage-auto-refresh.spec.ts
+++ b/apps/tests/accounts-usage-auto-refresh.spec.ts
@@ -1,0 +1,179 @@
+import { expect, test } from "@playwright/test";
+
+const SETTINGS_SNAPSHOT = {
+  updateAutoCheck: true,
+  closeToTrayOnClose: false,
+  closeToTraySupported: false,
+  lowTransparency: false,
+  lightweightModeOnCloseToTray: false,
+  codexCliGuideDismissed: true,
+  webAccessPasswordConfigured: false,
+  locale: "zh-CN",
+  localeOptions: ["zh-CN", "en"],
+  serviceAddr: "localhost:48760",
+  serviceListenMode: "loopback",
+  serviceListenModeOptions: ["loopback", "all_interfaces"],
+  routeStrategy: "ordered",
+  routeStrategyOptions: ["ordered", "balanced"],
+  freeAccountMaxModel: "auto",
+  freeAccountMaxModelOptions: ["auto", "gpt-5"],
+  modelForwardRules: "",
+  accountMaxInflight: 1,
+  gatewayOriginator: "codex-cli",
+  gatewayOriginatorDefault: "codex-cli",
+  gatewayUserAgentVersion: "1.0.0",
+  gatewayUserAgentVersionDefault: "1.0.0",
+  gatewayResidencyRequirement: "",
+  gatewayResidencyRequirementOptions: ["", "us"],
+  pluginMarketMode: "builtin",
+  pluginMarketSourceUrl: "",
+  upstreamProxyUrl: "",
+  upstreamStreamTimeoutMs: 600000,
+  upstreamTotalTimeoutMs: 0,
+  sseKeepaliveIntervalMs: 15000,
+  backgroundTasks: {
+    usagePollingEnabled: true,
+    usagePollIntervalSecs: 30,
+    gatewayKeepaliveEnabled: true,
+    gatewayKeepaliveIntervalSecs: 180,
+    tokenRefreshPollingEnabled: true,
+    tokenRefreshPollIntervalSecs: 60,
+    usageRefreshWorkers: 4,
+    httpWorkerFactor: 4,
+    httpWorkerMin: 8,
+    httpStreamWorkerFactor: 1,
+    httpStreamWorkerMin: 2,
+  },
+  envOverrides: {},
+  envOverrideCatalog: [],
+  envOverrideReservedKeys: [],
+  envOverrideUnsupportedKeys: [],
+  theme: "tech",
+  appearancePreset: "classic",
+};
+
+const OLD_USAGE = {
+  accountId: "acct-auto-refresh",
+  availabilityStatus: "available",
+  usedPercent: 15,
+  windowMinutes: 300,
+  resetsAt: 1900000000,
+  secondaryUsedPercent: 25,
+  secondaryWindowMinutes: 10080,
+  secondaryResetsAt: 1900003600,
+  creditsJson: null,
+  capturedAt: 100,
+};
+
+const NEW_USAGE = {
+  ...OLD_USAGE,
+  usedPercent: 40,
+  capturedAt: 200,
+};
+
+test("accounts page refreshes usage after backend polling writes a new snapshot", async ({
+  page,
+}) => {
+  const startedAt = Date.now();
+  let usageListCount = 0;
+
+  await page.route("**/api/runtime", async (route) => {
+    await route.fulfill({
+      contentType: "application/json; charset=utf-8",
+      body: JSON.stringify({
+        mode: "web-gateway",
+        rpcBaseUrl: "/api/rpc",
+        canManageService: false,
+        canSelfUpdate: false,
+        canCloseToTray: false,
+        canOpenLocalDir: false,
+        canUseBrowserFileImport: true,
+        canUseBrowserDownloadExport: true,
+      }),
+    });
+  });
+
+  await page.route("**/api/rpc", async (route) => {
+    const payload = route.request().postDataJSON();
+    const method = typeof payload?.method === "string" ? payload.method : "";
+    const id = payload?.id ?? 1;
+    const elapsedMs = Date.now() - startedAt;
+
+    const ok = (result: unknown) =>
+      route.fulfill({
+        contentType: "application/json; charset=utf-8",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          result,
+        }),
+      });
+
+    if (method === "appSettings/get") {
+      await ok(SETTINGS_SNAPSHOT);
+      return;
+    }
+    if (method === "initialize") {
+      await ok({
+        userAgent: "codex_cli_rs/0.1.19",
+        codexHome: "C:/Users/Test/.codex",
+        platformFamily: "windows",
+        platformOs: "windows",
+      });
+      return;
+    }
+    if (method === "account/list") {
+      await ok({
+        items: [
+          {
+            id: "acct-auto-refresh",
+            name: "auto-refresh@example.com",
+            label: "auto-refresh@example.com",
+            plan_type: "plus",
+            status: "active",
+            sort: 0,
+          },
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 20,
+      });
+      return;
+    }
+    if (method === "account/usage/read") {
+      await ok({ snapshot: elapsedMs >= 1200 ? NEW_USAGE : OLD_USAGE });
+      return;
+    }
+    if (method === "account/usage/list") {
+      usageListCount += 1;
+      await ok({ items: [elapsedMs >= 1200 ? NEW_USAGE : OLD_USAGE] });
+      return;
+    }
+
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json; charset=utf-8",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: -32000,
+          message: `Unhandled RPC method in test: ${method}`,
+        },
+      }),
+    });
+  });
+
+  await page.goto("/accounts/");
+
+  const row = page
+    .locator("tbody tr")
+    .filter({ hasText: "auto-refresh@example.com" })
+    .first();
+
+  await expect(row.getByText("85%", { exact: true }).first()).toBeVisible();
+  await expect(row.getByText("60%", { exact: true }).first()).toBeVisible({
+    timeout: 8_000,
+  });
+  expect(usageListCount).toBeGreaterThanOrEqual(2);
+});

--- a/apps/tests/accounts-usage-auto-refresh.spec.ts
+++ b/apps/tests/accounts-usage-auto-refresh.spec.ts
@@ -74,8 +74,8 @@ const NEW_USAGE = {
 test("accounts page refreshes usage after backend polling writes a new snapshot", async ({
   page,
 }) => {
-  const startedAt = Date.now();
   let usageListCount = 0;
+  let newSnapshotAvailable = false;
 
   await page.route("**/api/runtime", async (route) => {
     await route.fulfill({
@@ -97,7 +97,6 @@ test("accounts page refreshes usage after backend polling writes a new snapshot"
     const payload = route.request().postDataJSON();
     const method = typeof payload?.method === "string" ? payload.method : "";
     const id = payload?.id ?? 1;
-    const elapsedMs = Date.now() - startedAt;
 
     const ok = (result: unknown) =>
       route.fulfill({
@@ -141,12 +140,12 @@ test("accounts page refreshes usage after backend polling writes a new snapshot"
       return;
     }
     if (method === "account/usage/read") {
-      await ok({ snapshot: elapsedMs >= 1200 ? NEW_USAGE : OLD_USAGE });
+      await ok({ snapshot: newSnapshotAvailable ? NEW_USAGE : OLD_USAGE });
       return;
     }
     if (method === "account/usage/list") {
       usageListCount += 1;
-      await ok({ items: [elapsedMs >= 1200 ? NEW_USAGE : OLD_USAGE] });
+      await ok({ items: [newSnapshotAvailable ? NEW_USAGE : OLD_USAGE] });
       return;
     }
 
@@ -172,6 +171,7 @@ test("accounts page refreshes usage after backend polling writes a new snapshot"
     .first();
 
   await expect(row.getByText("85%", { exact: true }).first()).toBeVisible();
+  newSnapshotAvailable = true;
   await expect(row.getByText("60%", { exact: true }).first()).toBeVisible({
     timeout: 8_000,
   });

--- a/apps/tests/accounts-usage-auto-refresh.spec.ts
+++ b/apps/tests/accounts-usage-auto-refresh.spec.ts
@@ -198,8 +198,15 @@ test("accounts page refreshes usage after backend polling writes a new snapshot"
 
   await expect(row.getByText("85%", { exact: true }).first()).toBeVisible();
   newSnapshotAvailable = true;
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("usage-refresh-completed", {
+        detail: { source: "polling", processed: 1, total: 2 },
+      })
+    );
+  });
   await expect(row.getByText("60%", { exact: true }).first()).toBeVisible({
-    timeout: 8_000,
+    timeout: 2_000,
   });
   expect(usageListCount).toBeGreaterThanOrEqual(2);
 });

--- a/apps/tests/accounts-usage-auto-refresh.spec.ts
+++ b/apps/tests/accounts-usage-auto-refresh.spec.ts
@@ -71,6 +71,19 @@ const NEW_USAGE = {
   capturedAt: 200,
 };
 
+const UNCHANGED_NEWER_USAGE = {
+  accountId: "acct-newer-snapshot",
+  availabilityStatus: "available",
+  usedPercent: 20,
+  windowMinutes: 300,
+  resetsAt: 1900007200,
+  secondaryUsedPercent: 30,
+  secondaryWindowMinutes: 10080,
+  secondaryResetsAt: 1900010800,
+  creditsJson: null,
+  capturedAt: 1_000,
+};
+
 test("accounts page refreshes usage after backend polling writes a new snapshot", async ({
   page,
 }) => {
@@ -132,20 +145,33 @@ test("accounts page refreshes usage after backend polling writes a new snapshot"
             status: "active",
             sort: 0,
           },
+          {
+            id: "acct-newer-snapshot",
+            name: "newer-snapshot@example.com",
+            label: "newer-snapshot@example.com",
+            plan_type: "plus",
+            status: "active",
+            sort: 1,
+          },
         ],
-        total: 1,
+        total: 2,
         page: 1,
         pageSize: 20,
       });
       return;
     }
     if (method === "account/usage/read") {
-      await ok({ snapshot: newSnapshotAvailable ? NEW_USAGE : OLD_USAGE });
+      await ok({ snapshot: UNCHANGED_NEWER_USAGE });
       return;
     }
     if (method === "account/usage/list") {
       usageListCount += 1;
-      await ok({ items: [newSnapshotAvailable ? NEW_USAGE : OLD_USAGE] });
+      await ok({
+        items: [
+          newSnapshotAvailable ? NEW_USAGE : OLD_USAGE,
+          UNCHANGED_NEWER_USAGE,
+        ],
+      });
       return;
     }
 

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -115,6 +115,7 @@ pub use auth::{rpc_auth_token, rpc_auth_token_matches};
 pub use lifecycle::bootstrap::{initialize_storage_if_needed, portable};
 pub use lifecycle::shutdown::{clear_shutdown_flag, request_shutdown, shutdown_requested};
 pub use lifecycle::startup::{start_one_shot_server, start_server, ServerHandle};
+pub use usage_refresh::{set_usage_refresh_completed_handler, UsageRefreshCompletedEvent};
 
 /// 函数 `test_env_guard`
 ///

--- a/crates/service/src/usage/refresh/batch.rs
+++ b/crates/service/src/usage/refresh/batch.rs
@@ -7,10 +7,11 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use super::{
-    build_workspace_map_from_accounts, open_storage, record_usage_refresh_failure,
-    record_usage_refresh_metrics, refresh_usage_for_token, DEFAULT_USAGE_POLL_BATCH_LIMIT,
-    DEFAULT_USAGE_POLL_CYCLE_BUDGET_SECS, ENV_USAGE_POLL_BATCH_LIMIT,
-    ENV_USAGE_POLL_CYCLE_BUDGET_SECS, USAGE_POLL_CURSOR, USAGE_REFRESH_WORKERS,
+    build_workspace_map_from_accounts, notify_usage_refresh_completed, open_storage,
+    record_usage_refresh_failure, record_usage_refresh_metrics, refresh_usage_for_token,
+    DEFAULT_USAGE_POLL_BATCH_LIMIT, DEFAULT_USAGE_POLL_CYCLE_BUDGET_SECS,
+    ENV_USAGE_POLL_BATCH_LIMIT, ENV_USAGE_POLL_CYCLE_BUDGET_SECS, USAGE_POLL_CURSOR,
+    USAGE_REFRESH_WORKERS,
 };
 
 /// 函数 `refresh_usage_for_all_accounts`
@@ -35,7 +36,9 @@ pub(crate) fn refresh_usage_for_all_accounts() -> Result<(), String> {
     if tasks.is_empty() {
         return Ok(());
     }
-    run_usage_refresh_tasks(tasks)?;
+    let total = tasks.len();
+    let processed = run_usage_refresh_tasks(tasks)?;
+    notify_usage_refresh_completed("manual_all", processed, total);
     Ok(())
 }
 
@@ -100,6 +103,7 @@ pub(crate) fn refresh_usage_for_polling_batch() -> Result<(), String> {
             cycle_budget.map(|budget| budget.as_secs()).unwrap_or(0)
         );
     }
+    notify_usage_refresh_completed("polling", processed, total);
     Ok(())
 }
 

--- a/crates/service/src/usage/refresh/mod.rs
+++ b/crates/service/src/usage/refresh/mod.rs
@@ -4,7 +4,7 @@ use codexmanager_core::usage::parse_usage_snapshot;
 use crossbeam_channel::unbounded;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -129,6 +129,19 @@ struct UsageRefreshResult {
     _status: UsageAvailabilityStatus,
 }
 
+#[derive(Debug, Clone)]
+pub struct UsageRefreshCompletedEvent {
+    pub source: &'static str,
+    pub processed: usize,
+    pub total: usize,
+    pub completed_at: i64,
+}
+
+type UsageRefreshCompletedHandler = Arc<dyn Fn(UsageRefreshCompletedEvent) + Send + Sync>;
+
+static USAGE_REFRESH_COMPLETED_HANDLER: OnceLock<Mutex<Option<UsageRefreshCompletedHandler>>> =
+    OnceLock::new();
+
 pub(crate) use self::batch::refresh_usage_for_all_accounts;
 use self::batch::refresh_usage_for_polling_batch;
 #[cfg(test)]
@@ -145,6 +158,31 @@ pub(crate) use self::settings::{
     background_tasks_settings, reload_background_tasks_runtime_from_env,
     set_background_tasks_settings, BackgroundTasksSettingsPatch,
 };
+
+pub fn set_usage_refresh_completed_handler<F>(handler: F)
+where
+    F: Fn(UsageRefreshCompletedEvent) + Send + Sync + 'static,
+{
+    let slot = USAGE_REFRESH_COMPLETED_HANDLER.get_or_init(|| Mutex::new(None));
+    let mut guard = crate::lock_utils::lock_recover(slot, "usage_refresh_completed_handler");
+    *guard = Some(Arc::new(handler));
+}
+
+pub(crate) fn notify_usage_refresh_completed(source: &'static str, processed: usize, total: usize) {
+    let handler = USAGE_REFRESH_COMPLETED_HANDLER.get().and_then(|slot| {
+        let guard = crate::lock_utils::lock_recover(slot, "usage_refresh_completed_handler");
+        guard.clone()
+    });
+
+    if let Some(handler) = handler {
+        handler(UsageRefreshCompletedEvent {
+            source,
+            processed,
+            total,
+            completed_at: now_ts(),
+        });
+    }
+}
 
 /// 函数 `ensure_usage_polling`
 ///
@@ -388,6 +426,7 @@ pub(crate) fn refresh_usage_for_account(account_id: &str) -> Result<(), String> 
         }
     }
     record_usage_refresh_metrics(true, started_at);
+    notify_usage_refresh_completed("single", 1, 1);
     Ok(())
 }
 

--- a/crates/service/src/usage/tests/usage_refresh_tests.rs
+++ b/crates/service/src/usage/tests/usage_refresh_tests.rs
@@ -1,13 +1,32 @@
 use super::{
     clear_pending_usage_refresh_tasks_for_tests, enqueue_usage_refresh_with_worker,
-    next_usage_poll_cursor, reset_usage_poll_cursor_for_tests, resolve_token_refresh_issuer,
-    run_token_refresh_task, should_retry_usage_refresh_with_token, token_refresh_access_exp_cutoff,
+    next_usage_poll_cursor, notify_usage_refresh_completed, reset_usage_poll_cursor_for_tests,
+    resolve_token_refresh_issuer, run_token_refresh_task, set_usage_refresh_completed_handler,
+    should_retry_usage_refresh_with_token, token_refresh_access_exp_cutoff,
     token_refresh_due_cutoff, token_refresh_schedule, usage_poll_batch_indices,
 };
 use codexmanager_core::storage::{now_ts, Account, Storage, Token};
 use std::collections::HashSet;
 use std::sync::mpsc;
 use std::time::Duration;
+
+#[test]
+fn usage_refresh_completed_handler_receives_notification() {
+    let _guard = crate::test_env_guard();
+    let (tx, rx) = mpsc::channel();
+    set_usage_refresh_completed_handler(move |event| {
+        let _ = tx.send(event);
+    });
+
+    notify_usage_refresh_completed("test-notify", 2, 3);
+    let event = rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("usage refresh completed event");
+    assert_eq!(event.source, "test-notify");
+    assert_eq!(event.processed, 2);
+    assert_eq!(event.total, 3);
+    assert!(event.completed_at > 0);
+}
 
 /// 函数 `enqueue_usage_refresh_for_same_account_is_deduplicated_until_finish`
 ///

--- a/crates/service/src/usage/usage_refresh.rs
+++ b/crates/service/src/usage/usage_refresh.rs
@@ -7,3 +7,4 @@ pub(crate) use refresh::{
     refresh_usage_for_all_accounts, reload_background_tasks_runtime_from_env,
     set_background_tasks_settings, BackgroundTasksSettingsPatch,
 };
+pub use refresh::{set_usage_refresh_completed_handler, UsageRefreshCompletedEvent};


### PR DESCRIPTION
## 变更摘要

- 修复“账号管理”页面停留期间无法在后台用量轮询完成后立即刷新额度条的问题
- 将刷新策略从前端定时探测调整为事件驱动：用量轮询批次一结束，Service 立即通知 Tauri，Tauri 再通知前端账号页刷新
- 保留用量列表短间隔刷新作为兜底，但主路径不再依赖页面切换或下一轮前端定时器
- 补充前后端回归验证，覆盖“收到用量轮询完成事件后，账号页立即重拉并更新额度条”的关键路径

## 改动范围

- [x] Frontend
- [x] Desktop / Tauri
- [x] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/usage/refresh/mod.rs`
- `crates/service/src/usage/refresh/batch.rs`
- `crates/service/src/usage/usage_refresh.rs`
- `apps/src-tauri/src/lib.rs`
- `apps/src/lib/api/usage-refresh-events.ts`
- `apps/src/hooks/useAccounts.ts`
- `apps/tests/accounts-usage-auto-refresh.spec.ts`

## 主要改动

- Service 层新增 `UsageRefreshCompletedEvent` 与完成回调注册能力，用量轮询批次、批量手动刷新、单账号刷新完成后都会发出刷新完成通知
- 用量轮询线程在 `refresh_usage_for_polling_batch` 返回前触发 `notify_usage_refresh_completed("polling", processed, total)`，确保后台轮询一完成就产生前端可消费的信号
- Tauri 启动时注册 Service 回调，并通过 `usage-refresh-completed` 事件广播给前端窗口
- 前端新增 `listenUsageRefreshCompleted`，桌面端监听 Tauri 事件，测试环境支持同名 `CustomEvent`
- 账号页收到事件后立即 `refetch` 活跃的账号列表与用量列表，并失效用量汇总、今日摘要和启动快照缓存
- 回归用例改为显式派发 `usage-refresh-completed` 事件，并要求页面在 2 秒内从旧额度更新到新额度，避免再依赖 5 秒兜底轮询

## 实现效果

- “用量轮询线程”完成一次批次刷新后，正在停留的“账号管理”页面会立即重拉账号与用量数据
- 多账号场景下不再依赖“最新一条快照”判断，因此不会因为其他账号快照时间更晚而漏刷新当前账号额度条
- 页面切换仍会触发原有数据刷新，但不再是看到最新额度的必要条件

## 验证

- [ ] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [x] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
pnpm -C apps run build:desktop
pnpm -C apps run lint
pnpm -C apps run test:runtime
PLAYWRIGHT_BROWSERS_PATH=/private/tmp/codex-ms-playwright pnpm -C apps exec playwright test tests/accounts-usage-auto-refresh.spec.ts
PLAYWRIGHT_BROWSERS_PATH=/private/tmp/codex-ms-playwright pnpm -C apps exec playwright test tests/accounts-usage-auto-refresh.spec.ts --repeat-each=2
PLAYWRIGHT_BROWSERS_PATH=/private/tmp/codex-ms-playwright pnpm -C apps exec playwright test tests/accounts-usage-auto-refresh.spec.ts --repeat-each=3
cargo fmt --all --check
cargo test -p codexmanager-service usage_refresh_completed_handler_receives_notification
cargo test --workspace
cargo tauri build --bundles app
codesign --verify --deep --strict --verbose=2 apps/src-tauri/target/release/bundle/macos/CodexManager.app
hdiutil verify apps/src-tauri/target/release/bundle/dmg/CodexManager_0.2.8_aarch64.dmg
```

未执行的验证与原因：

```text
pnpm -C apps run test：apps/package.json 当前没有 test 脚本；已执行 test:runtime、build:desktop、lint 与目标 Playwright 回归。
pnpm -C apps run test:ui：apps/package.json 当前没有 test:ui 脚本；已按文件连续执行账号页自动刷新 Playwright 回归。
```

补充说明：

```text
pnpm -C apps run lint 通过，当前仅输出仓库既有 warning，无 error。
最新 DMG SHA256：364c13838c915c3cfff355a4d029ee1570fd5a499cfed225008cf5099cf546f8
```

## 风险与影响面

- 影响面覆盖 Service 后台用量刷新、Tauri 事件广播和账号页前端查询刷新
- 新增事件只在用量刷新完成后广播，不改变后端存储结构、RPC 接口入参或现有用量数据格式
- 账号页仍保留短间隔用量列表刷新作为兜底；即使事件监听不可用，页面仍能通过原有查询机制更新

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
