### PR TITLE
[codex] Fix compact prompt cache key handling

### DIFF
--- a/crates/service/src/gateway/local_validation/request.rs
+++ b/crates/service/src/gateway/local_validation/request.rs
@@ -1248,6 +1248,11 @@ pub(super) fn build_local_validation_result(
         initial_service_tier_diagnostic.raw_value.as_deref(),
         initial_service_tier_diagnostic.normalized_value.as_deref(),
     );
+    body = super::super::clear_prompt_cache_key_when_native_anchor(
+        normalized_path.as_str(),
+        body,
+        &incoming_headers,
+    );
     let initial_request_meta = super::super::parse_request_metadata(&body);
     let native_codex_client = is_native_codex_client_request(&incoming_headers);
     log::debug!(

--- a/crates/service/src/gateway/observability/http_bridge/delivery.rs
+++ b/crates/service/src/gateway/observability/http_bridge/delivery.rs
@@ -1389,6 +1389,65 @@ fn respond_invalid_compact_success_body(
     )
 }
 
+fn respond_compact_success_body(
+    request: Request,
+    status: StatusCode,
+    headers: Vec<Header>,
+    usage: UpstreamResponseUsage,
+    body: &[u8],
+    request_id: Option<&str>,
+    cf_ray: Option<&str>,
+    auth_error: Option<&str>,
+    identity_error_code: Option<&str>,
+    content_type: &Option<String>,
+    trace_id: Option<&str>,
+) -> UpstreamResponseBridgeResult {
+    if !compact_success_body_is_valid(body) {
+        return respond_invalid_compact_success_body(
+            request,
+            usage,
+            body,
+            request_id,
+            cf_ray,
+            auth_error,
+            identity_error_code,
+            trace_id,
+        );
+    }
+
+    let len = Some(body.len());
+    let response = Response::new(
+        status,
+        headers,
+        std::io::Cursor::new(body.to_vec()),
+        len,
+        None,
+    );
+    let delivery_error = request.respond(response).err().map(|err| err.to_string());
+    with_bridge_debug_meta(
+        UpstreamResponseBridgeResult {
+            usage,
+            stream_terminal_seen: true,
+            stream_terminal_error: None,
+            delivery_error,
+            upstream_error_hint: None,
+            delivered_status_code: None,
+            upstream_request_id: None,
+            upstream_cf_ray: None,
+            upstream_auth_error: None,
+            upstream_identity_error_code: None,
+            upstream_content_type: None,
+            last_sse_event_type: None,
+        },
+        &request_id.map(str::to_string),
+        &cf_ray.map(str::to_string),
+        &auth_error.map(str::to_string),
+        &identity_error_code.map(str::to_string),
+        content_type,
+        None,
+    )
+}
+
 /// 函数 `respond_invalid_compact_non_success_body`
 ///
 /// 作者: gaohongshun
@@ -2277,6 +2336,32 @@ pub(crate) fn respond_with_upstream(
                     None,
                 ));
             }
+            if is_stream && !is_sse && status.0 < 400 && is_compact_request_path(request_path) {
+                let upstream_body = upstream
+                    .bytes()
+                    .map_err(|err| format!("read upstream body failed: {err}"))?;
+                let usage = if is_json {
+                    serde_json::from_slice::<Value>(upstream_body.as_ref())
+                        .ok()
+                        .map(|value| parse_usage_from_json(&value))
+                        .unwrap_or_default()
+                } else {
+                    UpstreamResponseUsage::default()
+                };
+                return Ok(respond_compact_success_body(
+                    request,
+                    status,
+                    headers,
+                    usage,
+                    upstream_body.as_ref(),
+                    upstream_request_id.as_deref(),
+                    upstream_cf_ray.as_deref(),
+                    upstream_auth_error.as_deref(),
+                    upstream_identity_error_code.as_deref(),
+                    &upstream_content_type,
+                    trace_id,
+                ));
+            }
             if is_sse || is_stream {
                 let usage_collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
                 let response_body: Box<dyn std::io::Read + Send> =
@@ -3084,6 +3169,26 @@ pub(crate) fn respond_with_stream_upstream(
                     &upstream_identity_error_code,
                     &upstream_content_type,
                     None,
+                ));
+            }
+
+            if is_stream && !is_sse && status.0 < 400 && is_compact_request_path(request_path) {
+                let upstream_body = upstream
+                    .read_all_bytes()
+                    .map_err(|err| format!("read upstream body failed: {err}"))?;
+                let usage = UpstreamResponseUsage::default();
+                return Ok(respond_compact_success_body(
+                    request,
+                    status,
+                    headers,
+                    usage,
+                    upstream_body.as_ref(),
+                    upstream_request_id.as_deref(),
+                    upstream_cf_ray.as_deref(),
+                    upstream_auth_error.as_deref(),
+                    upstream_identity_error_code.as_deref(),
+                    &upstream_content_type,
+                    trace_id,
                 ));
             }
 

--- a/crates/service/src/gateway/request/tests/request_rewrite_tests.rs
+++ b/crates/service/src/gateway/request/tests/request_rewrite_tests.rs
@@ -1862,6 +1862,34 @@ fn responses_compact_keeps_only_codex_compact_body_fields() {
     assert!(object.get("unknown_field").is_none());
 }
 
+#[test]
+fn responses_compact_removes_prompt_cache_key_without_codex_base_rewrite() {
+    let _guard = crate::test_env_guard();
+    let body = json!({
+        "model": "gpt-5.5",
+        "instructions": "compact instructions",
+        "input": "compact me",
+        "prompt_cache_key": "pc_compact",
+        "reasoning": { "effort": "low" },
+        "text": { "verbosity": "low" },
+        "tools": [],
+        "parallel_tool_calls": false
+    });
+    let out = apply_request_overrides_with_service_tier_and_prompt_cache_key_scope(
+        "/v1/responses/compact",
+        serde_json::to_vec(&body).expect("serialize request body"),
+        None,
+        None,
+        None,
+        None,
+        Some("pc_compact"),
+        false,
+    );
+    let value: serde_json::Value = serde_json::from_slice(&out).expect("parse output body");
+
+    assert!(value.get("prompt_cache_key").is_none());
+}
+
 /// 函数 `responses_compact_defaults_parallel_tool_calls_to_false_for_codex_backend`
 ///
 /// 作者: gaohongshun

--- a/crates/service/src/gateway/request/thread_anchor.rs
+++ b/crates/service/src/gateway/request/thread_anchor.rs
@@ -42,7 +42,13 @@ pub(crate) fn clear_prompt_cache_key_when_native_anchor(
     body: Vec<u8>,
     headers: &IncomingHeaderSnapshot,
 ) -> Vec<u8> {
-    if !has_native_thread_anchor(headers) || !path.starts_with("/v1/responses") {
+    if !path.starts_with("/v1/responses") {
+        return body;
+    }
+    // Compact requests should not forward client-side prompt cache keys.
+    let should_clear_prompt_cache_key =
+        has_native_thread_anchor(headers) || super::official_responses_http::is_compact_path(path);
+    if !should_clear_prompt_cache_key {
         return body;
     }
     let Ok(mut payload) = serde_json::from_slice::<serde_json::Value>(&body) else {
@@ -150,6 +156,24 @@ mod tests {
         .expect("serialize request body");
 
         let actual = clear_prompt_cache_key_when_native_anchor("/v1/responses", body, &headers);
+        let value: serde_json::Value =
+            serde_json::from_slice(&actual).expect("parse rewritten request body");
+
+        assert!(value.get("prompt_cache_key").is_none());
+    }
+
+    #[test]
+    fn compact_request_removes_prompt_cache_key_without_native_anchor() {
+        let headers = sample_headers(None, None, Some("pk_test"));
+        let body = serde_json::to_vec(&json!({
+            "model": "gpt-5.4",
+            "input": "hello",
+            "prompt_cache_key": "client-thread"
+        }))
+        .expect("serialize request body");
+
+        let actual =
+            clear_prompt_cache_key_when_native_anchor("/v1/responses/compact", body, &headers);
         let value: serde_json::Value =
             serde_json::from_slice(&actual).expect("parse rewritten request body");
 

--- a/crates/service/src/gateway/upstream/proxy_pipeline/candidate_state.rs
+++ b/crates/service/src/gateway/upstream/proxy_pipeline/candidate_state.rs
@@ -435,6 +435,29 @@ mod tests {
     }
 
     #[test]
+    fn compact_body_for_attempt_removes_existing_prompt_cache_key() {
+        let mut state = CandidateExecutionState::default();
+        let body = Bytes::from_static(
+            br#"{"model":"gpt-5.5","input":"hello","prompt_cache_key":"client-thread"}"#,
+        );
+        let mut setup = sample_setup();
+        setup.has_sticky_fallback_conversation = true;
+
+        let actual = state.body_for_attempt(
+            "/v1/responses/compact",
+            &body,
+            true,
+            &setup,
+            None,
+            Some("thread-from-conversation"),
+        );
+        let value: serde_json::Value =
+            serde_json::from_slice(actual.as_ref()).expect("parse rewritten body");
+
+        assert!(value.get("prompt_cache_key").is_none());
+    }
+
+    #[test]
     fn strip_session_affinity_preserves_same_workspace_when_thread_anchor_exists() {
         let mut state = CandidateExecutionState::default();
         let first = Account {


### PR DESCRIPTION
## 概要

本 PR 修复 CodexManager 在当前上游 Codex compact 行为变化后，`/v1/responses/compact` 可能失败或被误判失败的问题。

核心处理：compact 请求在进入本地 metadata 解析和路由前移除客户端侧 `prompt_cache_key`，并让 gateway 正确识别 compact 成功返回的 JSON 响应，而不是把它当成缺失 SSE 结束事件的中断流。

## 更新说明

### Bug 原理

- 上游 Codex compact 行为发生变化：`/backend-api/codex/responses/compact` 现在可能会拒绝带有客户端 `prompt_cache_key` 的 compact payload。
- CodexManager 原先只在 native thread anchor 场景下清理 `prompt_cache_key`。compact 请求在本地 validation 阶段会先解析 metadata、决定路由和候选账号，因此这个字段可能在清理前已经参与了后续请求重写，并最终进入上游 attempt body。
- 实测中，上游会返回具有误导性的 `400 Stream must be set to true`。请求本身已经带有 `stream: true`，真正触发问题的是 compact payload 中残留的 `prompt_cache_key`。
- 当前上游 compact 成功时返回的是普通 JSON（`response.compaction`），不是 SSE 事件流。CodexManager 的部分 bridge 路径会按 streaming SSE 处理，从而把上游 `200` 成功响应误记为 `502 stream_interrupted`。

### 改动方式

- 在本地 metadata 解析和路由决策之前，对 `/v1/responses/compact` 提前清理 `prompt_cache_key`。
- 扩展已有的 prompt cache key 清理逻辑：compact 请求即使没有 native thread anchor，也会移除客户端侧 `prompt_cache_key`。
- 保证 compact request rewrite 和 candidate attempt body 不会重新带回 `prompt_cache_key`。
- 对 `stream: true` 的 compact 请求，若上游成功返回非 SSE JSON，则按 compact 成功 JSON 正常交付，不再要求 SSE terminal event。
- 增加 compact 相关回归测试，覆盖 request rewrite、thread anchor 清理和 candidate attempt body。

### 改动点

- `crates/service/src/gateway/local_validation/request.rs`
  - 在 request metadata 解析前清理 compact 请求中的 `prompt_cache_key`。
- `crates/service/src/gateway/request/thread_anchor.rs`
  - 将 compact path 纳入已有 prompt cache key 清理 helper。
- `crates/service/src/gateway/request/tests/request_rewrite_tests.rs`
  - 增加 compact rewrite 不保留 `prompt_cache_key` 的回归测试。
- `crates/service/src/gateway/upstream/proxy_pipeline/candidate_state.rs`
  - 增加 candidate attempt body 不保留 compact `prompt_cache_key` 的回归测试。
- `crates/service/src/gateway/observability/http_bridge/delivery.rs`
  - 处理 compact 成功 JSON 响应，避免把上游 `200` 误判为 stream interrupted。

### 局限性

- 目前只在本地 macOS CodexManager desktop build 上验证过，Windows/Linux 运行环境尚未单独验证。
- 验证基于 2026-05-08 观察到的当前上游 Codex compact 行为；如果上游 compact 协议再次变化，可能还需要继续调整。
- 本 PR 不修改账号登录、provider 选择、`~/.codex` 配置、compact 阈值或模型路由策略。
- 修复范围仅限 OpenAI/Codex compact path，不泛化改变其他 endpoint 的 prompt cache key 行为。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p codexmanager-service compact`
- `cargo test -p codexmanager-service preferred_client_prompt_cache_key`