### PR TITLE
[codex] Add aggregate API balance queries

### DIFF
--- a/apps/src-tauri/src/commands/aggregate_api.rs
+++ b/apps/src-tauri/src/commands/aggregate_api.rs
@@ -50,6 +50,12 @@ pub async fn service_aggregate_api_create(
     model_override: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    balance_query_enabled: Option<bool>,
+    balance_query_template: Option<String>,
+    balance_query_base_url: Option<String>,
+    balance_query_access_token: Option<String>,
+    balance_query_user_id: Option<String>,
+    balance_query_config_json: Option<String>,
 ) -> Result<serde_json::Value, String> {
     let params = serde_json::json!({
         "providerType": provider_type,
@@ -65,6 +71,12 @@ pub async fn service_aggregate_api_create(
         "modelOverride": model_override,
         "username": username,
         "password": password,
+        "balanceQueryEnabled": balance_query_enabled,
+        "balanceQueryTemplate": balance_query_template,
+        "balanceQueryBaseUrl": balance_query_base_url,
+        "balanceQueryAccessToken": balance_query_access_token,
+        "balanceQueryUserId": balance_query_user_id,
+        "balanceQueryConfigJson": balance_query_config_json,
     });
     rpc_call_in_background("aggregateApi/create", addr, Some(params)).await
 }
@@ -104,6 +116,12 @@ pub async fn service_aggregate_api_update(
     model_override: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    balance_query_enabled: Option<bool>,
+    balance_query_template: Option<String>,
+    balance_query_base_url: Option<String>,
+    balance_query_access_token: Option<String>,
+    balance_query_user_id: Option<String>,
+    balance_query_config_json: Option<String>,
 ) -> Result<serde_json::Value, String> {
     let params = serde_json::json!({
         "id": id,
@@ -121,6 +139,12 @@ pub async fn service_aggregate_api_update(
         "modelOverride": model_override,
         "username": username,
         "password": password,
+        "balanceQueryEnabled": balance_query_enabled,
+        "balanceQueryTemplate": balance_query_template,
+        "balanceQueryBaseUrl": balance_query_base_url,
+        "balanceQueryAccessToken": balance_query_access_token,
+        "balanceQueryUserId": balance_query_user_id,
+        "balanceQueryConfigJson": balance_query_config_json,
     });
     rpc_call_in_background("aggregateApi/update", addr, Some(params)).await
 }
@@ -186,4 +210,13 @@ pub async fn service_aggregate_api_test_connection(
 ) -> Result<serde_json::Value, String> {
     let params = serde_json::json!({ "id": id });
     rpc_call_in_background("aggregateApi/testConnection", addr, Some(params)).await
+}
+
+#[tauri::command]
+pub async fn service_aggregate_api_refresh_balance(
+    addr: Option<String>,
+    id: String,
+) -> Result<serde_json::Value, String> {
+    let params = serde_json::json!({ "id": id });
+    rpc_call_in_background("aggregateApi/refreshBalance", addr, Some(params)).await
 }

--- a/apps/src-tauri/src/commands/registry.rs
+++ b/apps/src-tauri/src/commands/registry.rs
@@ -82,6 +82,7 @@ macro_rules! invoke_handler {
             crate::commands::aggregate_api::service_aggregate_api_update,
             crate::commands::aggregate_api::service_aggregate_api_delete,
             crate::commands::aggregate_api::service_aggregate_api_test_connection,
+            crate::commands::aggregate_api::service_aggregate_api_refresh_balance,
             crate::commands::apikey::service_apikey_list,
             crate::commands::apikey::service_apikey_read_secret,
             crate::commands::apikey::service_apikey_create,

--- a/apps/src/app/aggregate-api/page.tsx
+++ b/apps/src/app/aggregate-api/page.tsx
@@ -57,7 +57,11 @@ import { useDeferredDesktopActivation } from "@/hooks/useDeferredDesktopActivati
 import { usePageTransitionReady } from "@/hooks/usePageTransitionReady";
 import { useRuntimeCapabilities } from "@/hooks/useRuntimeCapabilities";
 import { useI18n } from "@/lib/i18n/provider";
-import { AggregateApi, AggregateApiSecretResult } from "@/types";
+import {
+  AggregateApi,
+  AggregateApiBalanceSnapshot,
+  AggregateApiSecretResult,
+} from "@/types";
 
 type TranslateFn = (key: string, values?: Record<string, string | number>) => string;
 
@@ -71,6 +75,43 @@ const AGGREGATE_API_PROVIDER_FILTER_LABELS: Record<string, string> = {
   codex: "Codex",
   claude: "Claude",
 };
+
+function parseBalanceSnapshot(api: AggregateApi): AggregateApiBalanceSnapshot | null {
+  const raw = String(api.lastBalanceJson || "").trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<AggregateApiBalanceSnapshot>;
+    return {
+      isValid: parsed.isValid ?? true,
+      invalidMessage: parsed.invalidMessage ?? null,
+      remaining: typeof parsed.remaining === "number" ? parsed.remaining : null,
+      unit: typeof parsed.unit === "string" ? parsed.unit : null,
+      planName: typeof parsed.planName === "string" ? parsed.planName : null,
+      total: typeof parsed.total === "number" ? parsed.total : null,
+      used: typeof parsed.used === "number" ? parsed.used : null,
+      extra:
+        parsed.extra && typeof parsed.extra === "object"
+          ? (parsed.extra as Record<string, unknown>)
+          : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function formatBalanceAmount(snapshot: AggregateApiBalanceSnapshot | null) {
+  if (!snapshot || typeof snapshot.remaining !== "number") {
+    return "-";
+  }
+  const unit = String(snapshot.unit || "").trim();
+  const value = Number.isInteger(snapshot.remaining)
+    ? String(snapshot.remaining)
+    : snapshot.remaining.toFixed(2);
+  if (unit.toUpperCase() === "USD") {
+    return `$${value}`;
+  }
+  return unit ? `${value} ${unit}` : value;
+}
 
 /**
  * 函数 `getTestBadge`
@@ -123,6 +164,8 @@ export default function AggregateApiPage() {
   const [loadingSecretId, setLoadingSecretId] = useState<string | null>(null);
   const [testingApiId, setTestingApiId] = useState<string | null>(null);
   const [testingAll, setTestingAll] = useState(false);
+  const [refreshingBalanceId, setRefreshingBalanceId] = useState<string | null>(null);
+  const [refreshingBalances, setRefreshingBalances] = useState(false);
   const [togglingApiId, setTogglingApiId] = useState<string | null>(null);
   const [statusOverrides, setStatusOverrides] = useState<Record<string, boolean>>(
     {},
@@ -223,6 +266,67 @@ export default function AggregateApiPage() {
     );
   };
 
+  const renderBalanceStatus = (api: AggregateApi) => {
+    if (!api.balanceQueryEnabled) {
+      return <Badge variant="secondary">{t("未启用")}</Badge>;
+    }
+
+    const snapshot = parseBalanceSnapshot(api);
+    if (api.lastBalanceStatus === "success" && snapshot) {
+      const badge = (
+        <Badge className="border-emerald-500/20 bg-emerald-500/10 text-emerald-600">
+          {formatBalanceAmount(snapshot)}
+        </Badge>
+      );
+      const details = [
+        snapshot.planName ? `${t("套餐")}: ${snapshot.planName}` : null,
+        typeof snapshot.used === "number"
+          ? `${t("已用")}: ${snapshot.used.toFixed(2)}`
+          : null,
+        typeof snapshot.total === "number"
+          ? `${t("总额")}: ${snapshot.total.toFixed(2)}`
+          : null,
+      ].filter(Boolean);
+
+      if (details.length === 0) {
+        return badge;
+      }
+      return (
+        <Tooltip>
+          <TooltipTrigger render={<div />} className="inline-flex cursor-help">
+            {badge}
+          </TooltipTrigger>
+          <TooltipContent className="max-w-sm whitespace-pre-wrap break-words">
+            {details.join("\n")}
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    if (api.lastBalanceStatus === "failed") {
+      const badge = (
+        <Badge className="border-red-500/20 bg-red-500/10 text-red-500">
+          {t("查询失败")}
+        </Badge>
+      );
+      if (!api.lastBalanceError) {
+        return badge;
+      }
+      return (
+        <Tooltip>
+          <TooltipTrigger render={<div />} className="inline-flex cursor-help">
+            {badge}
+          </TooltipTrigger>
+          <TooltipContent className="max-w-sm whitespace-pre-wrap break-words">
+            {api.lastBalanceError}
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    return <Badge variant="secondary">{t("未查询")}</Badge>;
+  };
+
   const testMutation = useMutation({
     mutationFn: (apiId: string) =>
       accountClient.testAggregateApiConnection(apiId),
@@ -282,6 +386,66 @@ export default function AggregateApiPage() {
     },
     onError: (error: unknown) => {
       toast.error(`${t("批量测试失败")}: ${error instanceof Error ? error.message : String(error)}`);
+    },
+  });
+
+  const refreshBalanceMutation = useMutation({
+    mutationFn: (apiId: string) => accountClient.refreshAggregateApiBalance(apiId),
+    onMutate: async (apiId) => {
+      setRefreshingBalanceId(apiId);
+    },
+    onSuccess: async (result) => {
+      if (result.ok) {
+        toast.success(t("余额已刷新"));
+        return;
+      }
+      toast.warning(
+        t("余额查询失败 {reason}", {
+          reason: result.message || t("未返回具体错误信息"),
+        }),
+      );
+    },
+    onSettled: async (_result, _error, apiId) => {
+      await queryClient.invalidateQueries({ queryKey: ["aggregate-apis"] });
+      setRefreshingBalanceId((current) => (current === apiId ? null : current));
+    },
+    onError: (error: unknown) => {
+      toast.error(`${t("余额查询失败")}: ${error instanceof Error ? error.message : String(error)}`);
+    },
+  });
+
+  const refreshAllBalancesMutation = useMutation({
+    mutationFn: async (apiIds: string[]) => {
+      const results = await Promise.allSettled(
+        apiIds.map((id) => accountClient.refreshAggregateApiBalance(id))
+      );
+      return results;
+    },
+    onMutate: async () => {
+      setRefreshingBalances(true);
+    },
+    onSuccess: async (results) => {
+      const successCount = results.filter(
+        (r) => r.status === "fulfilled" && r.value.ok
+      ).length;
+      const failCount = results.length - successCount;
+      if (failCount === 0) {
+        toast.success(t("余额刷新完成：{count} 个成功", { count: successCount }));
+      } else {
+        toast.warning(
+          t("余额刷新完成：{success} 个成功，{fail} 个失败", {
+            success: successCount,
+            fail: failCount,
+          })
+        );
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["aggregate-apis"] });
+      setRefreshingBalances(false);
+    },
+    onError: (error: unknown) => {
+      toast.error(`${t("批量刷新余额失败")}: ${error instanceof Error ? error.message : String(error)}`);
     },
   });
 
@@ -632,6 +796,28 @@ export default function AggregateApiPage() {
                   {t("测试全部")}
                 </Button>
                 <Button
+                  variant="outline"
+                  className="h-10 gap-2"
+                  onClick={() => {
+                    const apiIds = filteredAggregateApis
+                      .filter((api) => api.balanceQueryEnabled)
+                      .map((api) => api.id);
+                    if (apiIds.length === 0) {
+                      toast.info(t("暂无已启用余额检测的聚合 API"));
+                      return;
+                    }
+                    refreshAllBalancesMutation.mutate(apiIds);
+                  }}
+                  disabled={
+                    !isServiceReady ||
+                    refreshingBalances ||
+                    filteredAggregateApis.every((api) => !api.balanceQueryEnabled)
+                  }
+                >
+                  <RefreshCw className={refreshingBalances ? "h-4 w-4 animate-spin" : "h-4 w-4"} />
+                  {t("刷新余额")}
+                </Button>
+                <Button
                   className="h-10 gap-2 shadow-lg shadow-primary/20"
                   onClick={openCreateModal}
                   disabled={!isServiceReady}
@@ -653,6 +839,7 @@ export default function AggregateApiPage() {
                   <TableHead className="w-[148px]">{t("密钥")}</TableHead>
                   <TableHead className="w-[64px] text-center">{t("顺序")}</TableHead>
                   <TableHead className="w-[130px]">{t("测试连通性")}</TableHead>
+                  <TableHead className="w-[150px]">{t("余额")}</TableHead>
                   <TableHead className="w-[112px] text-right pr-4">{t("状态")}</TableHead>
                   <TableHead className="table-sticky-action-head w-[112px] text-center">
                     {t("操作")}
@@ -679,6 +866,9 @@ export default function AggregateApiPage() {
                         <Skeleton className="h-6 w-20 rounded-full" />
                       </TableCell>
                       <TableCell>
+                        <Skeleton className="h-6 w-24 rounded-full" />
+                      </TableCell>
+                      <TableCell>
                         <Skeleton className="h-6 w-16 rounded-full" />
                       </TableCell>
                       <TableCell className="table-sticky-action-cell text-center">
@@ -688,7 +878,7 @@ export default function AggregateApiPage() {
                   ))
                 ) : filteredAggregateApis.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={7} className="h-48 text-center">
+                    <TableCell colSpan={8} className="h-48 text-center">
                       <div className="flex flex-col items-center justify-center gap-2 text-muted-foreground">
                         <ShieldCheck className="h-8 w-8 opacity-20" />
                         <p>
@@ -889,6 +1079,58 @@ export default function AggregateApiPage() {
                               </TooltipTrigger>
                               <TooltipContent className="max-w-sm whitespace-pre-wrap break-words">
                                 {api.lastTestError}
+                              </TooltipContent>
+                            </Tooltip>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap align-middle">
+                          <div className="flex items-center gap-2">
+                            {renderBalanceStatus(api)}
+                            <Tooltip>
+                              <TooltipTrigger render={<span />} className="inline-flex">
+                                <Button
+                                  variant="outline"
+                                  size="icon"
+                                  className="h-7 w-7"
+                                  disabled={
+                                    !isServiceReady ||
+                                    !api.balanceQueryEnabled ||
+                                    refreshingBalanceId === api.id ||
+                                    refreshingBalances
+                                  }
+                                  onClick={() =>
+                                    refreshBalanceMutation.mutate(api.id)
+                                  }
+                                >
+                                  <RefreshCw
+                                    className={
+                                      refreshingBalanceId === api.id
+                                        ? "h-3.5 w-3.5 animate-spin"
+                                        : "h-3.5 w-3.5"
+                                    }
+                                  />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>{t("刷新余额")}</TooltipContent>
+                            </Tooltip>
+                          </div>
+                          {api.lastBalanceAt ? (
+                            <p className="mt-1 text-[10px] text-muted-foreground">
+                              {formatTsFromSeconds(api.lastBalanceAt, t("未知时间"))}
+                            </p>
+                          ) : null}
+                          {api.lastBalanceStatus === "failed" && api.lastBalanceError ? (
+                            <Tooltip>
+                              <TooltipTrigger
+                                render={<div />}
+                                className="mt-1 block max-w-full cursor-help text-left"
+                              >
+                                <p className="max-w-[180px] truncate text-[10px] text-red-500/90">
+                                  {api.lastBalanceError}
+                                </p>
+                              </TooltipTrigger>
+                              <TooltipContent className="max-w-sm whitespace-pre-wrap break-words">
+                                {api.lastBalanceError}
                               </TooltipContent>
                             </Tooltip>
                           ) : null}

--- a/apps/src/components/layout/app-bootstrap.tsx
+++ b/apps/src/components/layout/app-bootstrap.tsx
@@ -35,6 +35,8 @@ const DEFAULT_SERVICE_ADDR = "localhost:48760";
 const STARTUP_WARMUP_LABEL = "[startup warmup]";
 const CODEX_CLI_GUIDE_SESSION_DISMISSED_KEY =
   "codexmanager.codexCliGuide.sessionDismissed";
+const UNSUPPORTED_RUNTIME_AUTO_RETRY_LIMIT = 8;
+const UNSUPPORTED_RUNTIME_AUTO_RETRY_DELAY_MS = 1500;
 
 function readCodexCliGuideSessionDismissed() {
   if (typeof window === "undefined") {
@@ -114,6 +116,7 @@ export function AppBootstrap({ children }: { children: React.ReactNode }) {
   const [isInitializing, setIsInitializing] = useState(true);
   const hasInitializedOnce = useRef(false);
   const hasBootstrappedOnce = useRef(false);
+  const unsupportedRuntimeRetryCountRef = useRef(0);
   const serviceStatusRef = useRef(serviceStatus);
   const runtimeCapabilitiesRef = useRef(runtimeCapabilities);
   const [error, setError] = useState<string | null>(null);
@@ -269,6 +272,7 @@ export function AppBootstrap({ children }: { children: React.ReactNode }) {
         setIsInitializing(false);
         return;
       }
+      unsupportedRuntimeRetryCountRef.current = 0;
 
       const settings = await appClient.getSettings();
       const addr = normalizeServiceAddr(settings.serviceAddr || DEFAULT_SERVICE_ADDR);
@@ -420,6 +424,26 @@ export function AppBootstrap({ children }: { children: React.ReactNode }) {
     hasBootstrappedOnce.current = true;
     void init();
   }, [init]);
+
+  useEffect(() => {
+    if (
+      hasInitializedOnce.current ||
+      isInitializing ||
+      !error ||
+      !isUnsupportedWebRuntime ||
+      typeof window === "undefined" ||
+      unsupportedRuntimeRetryCountRef.current >=
+        UNSUPPORTED_RUNTIME_AUTO_RETRY_LIMIT
+    ) {
+      return;
+    }
+
+    const retryId = window.setTimeout(() => {
+      unsupportedRuntimeRetryCountRef.current += 1;
+      void init();
+    }, UNSUPPORTED_RUNTIME_AUTO_RETRY_DELAY_MS);
+    return () => window.clearTimeout(retryId);
+  }, [error, init, isInitializing, isUnsupportedWebRuntime]);
 
   useEffect(() => {
     if (isDesktopRuntime || typeof window === "undefined") {

--- a/apps/src/components/modals/aggregate-api-modal.tsx
+++ b/apps/src/components/modals/aggregate-api-modal.tsx
@@ -41,6 +41,44 @@ const AGGREGATE_API_URL_PLACEHOLDERS: Record<string, string> = {
   claude: "例如：https://api.anthropic.com/v1",
 };
 
+type BalanceQueryTemplate = "generic" | "new_api" | "custom";
+type BalanceCustomAuth = "provider_bearer" | "balance_bearer" | "none";
+
+interface BalanceCustomConfig {
+  path?: unknown;
+  auth?: unknown;
+  remainingPath?: unknown;
+  unit?: unknown;
+  multiplier?: unknown;
+  totalPath?: unknown;
+  usedPath?: unknown;
+  planPath?: unknown;
+  validPath?: unknown;
+  invalidMessagePath?: unknown;
+}
+
+const parseBalanceCustomConfig = (
+  value: string | null | undefined
+): BalanceCustomConfig => {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object"
+      ? (parsed as BalanceCustomConfig)
+      : {};
+  } catch {
+    return {};
+  }
+};
+
+const stringConfigValue = (value: unknown, fallback = "") =>
+  typeof value === "string" ? value : fallback;
+
+const normalizeBalanceCustomAuth = (value: unknown): BalanceCustomAuth =>
+  value === "balance_bearer" || value === "none"
+    ? value
+    : "provider_bearer";
+
 interface AggregateApiModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -93,6 +131,27 @@ export function AggregateApiModal({
   const [actionCustomEnabled, setActionCustomEnabled] = useState(false);
   const [action, setAction] = useState("");
   const [modelOverride, setModelOverride] = useState("");
+  const [balanceQueryEnabled, setBalanceQueryEnabled] = useState(false);
+  const [balanceQueryTemplate, setBalanceQueryTemplate] =
+    useState<BalanceQueryTemplate>("generic");
+  const [balanceQueryBaseUrl, setBalanceQueryBaseUrl] = useState("");
+  const [balanceQueryAccessToken, setBalanceQueryAccessToken] = useState("");
+  const [balanceQueryUserId, setBalanceQueryUserId] = useState("");
+  const [balanceCustomPath, setBalanceCustomPath] = useState("/v1/usage");
+  const [balanceCustomAuth, setBalanceCustomAuth] =
+    useState<BalanceCustomAuth>("provider_bearer");
+  const [balanceCustomRemainingPath, setBalanceCustomRemainingPath] =
+    useState("remaining");
+  const [balanceCustomUnit, setBalanceCustomUnit] = useState("USD");
+  const [balanceCustomMultiplier, setBalanceCustomMultiplier] = useState("1");
+  const [balanceCustomTotalPath, setBalanceCustomTotalPath] = useState("");
+  const [balanceCustomUsedPath, setBalanceCustomUsedPath] = useState("");
+  const [balanceCustomPlanPath, setBalanceCustomPlanPath] = useState("");
+  const [balanceCustomValidPath, setBalanceCustomValidPath] = useState("");
+  const [
+    balanceCustomInvalidMessagePath,
+    setBalanceCustomInvalidMessagePath,
+  ] = useState("");
   const [key, setKey] = useState("");
   const [generatedKey, setGeneratedKey] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -156,6 +215,39 @@ export function AggregateApiModal({
     setAction(nextAction);
     setActionCustomEnabled(aggregateApi?.action !== null && aggregateApi?.action !== undefined);
     setModelOverride(aggregateApi?.modelOverride || "");
+    setBalanceQueryEnabled(Boolean(aggregateApi?.balanceQueryEnabled));
+    const nextBalanceQueryTemplate =
+      aggregateApi?.balanceQueryTemplate === "new_api"
+        ? "new_api"
+        : aggregateApi?.balanceQueryTemplate === "custom"
+          ? "custom"
+          : "generic";
+    setBalanceQueryTemplate(nextBalanceQueryTemplate);
+    setBalanceQueryBaseUrl(aggregateApi?.balanceQueryBaseUrl || "");
+    setBalanceQueryAccessToken("");
+    setBalanceQueryUserId(aggregateApi?.balanceQueryUserId || "");
+    const customConfig = parseBalanceCustomConfig(
+      aggregateApi?.balanceQueryConfigJson
+    );
+    setBalanceCustomPath(stringConfigValue(customConfig.path, "/v1/usage"));
+    setBalanceCustomAuth(normalizeBalanceCustomAuth(customConfig.auth));
+    setBalanceCustomRemainingPath(
+      stringConfigValue(customConfig.remainingPath, "remaining")
+    );
+    setBalanceCustomUnit(stringConfigValue(customConfig.unit, "USD"));
+    setBalanceCustomMultiplier(
+      typeof customConfig.multiplier === "number" &&
+        Number.isFinite(customConfig.multiplier)
+        ? String(customConfig.multiplier)
+        : "1"
+    );
+    setBalanceCustomTotalPath(stringConfigValue(customConfig.totalPath));
+    setBalanceCustomUsedPath(stringConfigValue(customConfig.usedPath));
+    setBalanceCustomPlanPath(stringConfigValue(customConfig.planPath));
+    setBalanceCustomValidPath(stringConfigValue(customConfig.validPath));
+    setBalanceCustomInvalidMessagePath(
+      stringConfigValue(customConfig.invalidMessagePath)
+    );
     setKey("");
     setUsername("");
     setPassword("");
@@ -265,6 +357,46 @@ export function AggregateApiModal({
         }
       }
     }
+    let balanceQueryConfigJson: string | null = null;
+    if (balanceQueryTemplate === "custom") {
+      const customPath = balanceCustomPath.trim();
+      const remainingPath = balanceCustomRemainingPath.trim();
+      const multiplierText = balanceCustomMultiplier.trim() || "1";
+      const multiplier = Number(multiplierText);
+      if (!customPath) {
+        toast.error(t("请输入自定义余额查询路径"));
+        return;
+      }
+      if (!remainingPath) {
+        toast.error(t("请输入余额字段路径"));
+        return;
+      }
+      if (!Number.isFinite(multiplier) || multiplier <= 0) {
+        toast.error(t("余额倍率必须大于 0"));
+        return;
+      }
+      const config: Record<string, string | number> = {
+        method: "GET",
+        path: customPath,
+        auth: balanceCustomAuth,
+        remainingPath,
+        unit: balanceCustomUnit.trim() || "USD",
+        multiplier,
+      };
+      const totalPath = balanceCustomTotalPath.trim();
+      const usedPath = balanceCustomUsedPath.trim();
+      const planPath = balanceCustomPlanPath.trim();
+      const validPath = balanceCustomValidPath.trim();
+      const invalidMessagePath = balanceCustomInvalidMessagePath.trim();
+      if (totalPath) config.totalPath = totalPath;
+      if (usedPath) config.usedPath = usedPath;
+      if (planPath) config.planPath = planPath;
+      if (validPath) config.validPath = validPath;
+      if (invalidMessagePath) {
+        config.invalidMessagePath = invalidMessagePath;
+      }
+      balanceQueryConfigJson = JSON.stringify(config);
+    }
     setIsLoading(true);
     try {
       if (aggregateApi?.id) {
@@ -282,6 +414,12 @@ export function AggregateApiModal({
           modelOverride: modelOverride.trim(),
           username: authType === "userpass" ? username.trim() || null : null,
           password: authType === "userpass" ? password.trim() || null : null,
+          balanceQueryEnabled,
+          balanceQueryTemplate,
+          balanceQueryBaseUrl: balanceQueryBaseUrl.trim(),
+          balanceQueryAccessToken: balanceQueryAccessToken.trim() || null,
+          balanceQueryUserId: balanceQueryUserId.trim(),
+          balanceQueryConfigJson,
         });
         toast.success(t("聚合 API 已更新"));
         await Promise.all([
@@ -307,6 +445,12 @@ export function AggregateApiModal({
         modelOverride: modelOverride.trim(),
         username: authType === "userpass" ? username.trim() : null,
         password: authType === "userpass" ? password.trim() : null,
+        balanceQueryEnabled,
+        balanceQueryTemplate,
+        balanceQueryBaseUrl: balanceQueryBaseUrl.trim(),
+        balanceQueryAccessToken: balanceQueryAccessToken.trim() || null,
+        balanceQueryUserId: balanceQueryUserId.trim(),
+        balanceQueryConfigJson,
       });
       setGeneratedKey(result.key);
       toast.success(t("聚合 API 已创建"));
@@ -713,6 +857,295 @@ export function AggregateApiModal({
                     </div>
                   ) : null}
                 </div>
+              </div>
+
+              <div className="grid gap-3 rounded-xl border border-border/60 bg-muted/20 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <Label className="text-sm">{t("余额检测")}</Label>
+                    <p className="text-[11px] text-muted-foreground">
+                      {t("开启后可在聚合 API 列表手动刷新并显示余额。")}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={balanceQueryEnabled}
+                    disabled={!isServiceReady}
+                    onCheckedChange={(checked) =>
+                      setBalanceQueryEnabled(Boolean(checked))
+                    }
+                  />
+                </div>
+
+                {balanceQueryEnabled ? (
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="grid gap-2">
+                      <Label className="text-xs">{t("查询模板")}</Label>
+                      <Select
+                        value={balanceQueryTemplate}
+                        disabled={!isServiceReady}
+                        onValueChange={(value) =>
+                          setBalanceQueryTemplate(
+                            value === "new_api"
+                              ? "new_api"
+                              : value === "custom"
+                                ? "custom"
+                                : "generic"
+                          )
+                        }
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue>
+                            {(value) =>
+                              String(value || "") === "new_api"
+                                ? "New API"
+                                : String(value || "") === "custom"
+                                  ? "Custom"
+                                : t("通用余额")
+                            }
+                          </SelectValue>
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="generic">{t("通用余额")}</SelectItem>
+                          <SelectItem value="new_api">New API</SelectItem>
+                          <SelectItem value="custom">Custom</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="aggregate-api-balance-base-url">
+                        {t("余额接口基础地址")}
+                      </Label>
+                      <Input
+                        id="aggregate-api-balance-base-url"
+                        value={balanceQueryBaseUrl}
+                        disabled={!isServiceReady}
+                        placeholder={
+                          balanceQueryTemplate === "new_api"
+                            ? t("留空则从 URL 推断服务根地址")
+                            : t("留空则使用上方 URL")
+                        }
+                        onChange={(event) =>
+                          setBalanceQueryBaseUrl(event.target.value)
+                        }
+                      />
+                    </div>
+
+                    {balanceQueryTemplate === "custom" ? (
+                      <>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-custom-path">
+                            Custom path
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-custom-path"
+                            value={balanceCustomPath}
+                            disabled={!isServiceReady}
+                            placeholder="/v1/usage"
+                            onChange={(event) =>
+                              setBalanceCustomPath(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label>Auth</Label>
+                          <Select
+                            value={balanceCustomAuth}
+                            disabled={!isServiceReady}
+                            onValueChange={(value) =>
+                              setBalanceCustomAuth(
+                                normalizeBalanceCustomAuth(value)
+                              )
+                            }
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="provider_bearer">
+                                Provider key
+                              </SelectItem>
+                              <SelectItem value="balance_bearer">
+                                Balance token
+                              </SelectItem>
+                              <SelectItem value="none">None</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-remaining-path">
+                            Remaining path
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-remaining-path"
+                            value={balanceCustomRemainingPath}
+                            disabled={!isServiceReady}
+                            placeholder="data.remaining"
+                            onChange={(event) =>
+                              setBalanceCustomRemainingPath(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-multiplier">
+                            Multiplier
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-multiplier"
+                            value={balanceCustomMultiplier}
+                            disabled={!isServiceReady}
+                            placeholder="1"
+                            onChange={(event) =>
+                              setBalanceCustomMultiplier(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-unit">
+                            Unit
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-unit"
+                            value={balanceCustomUnit}
+                            disabled={!isServiceReady}
+                            placeholder="USD"
+                            onChange={(event) =>
+                              setBalanceCustomUnit(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-total-path">
+                            Total path
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-total-path"
+                            value={balanceCustomTotalPath}
+                            disabled={!isServiceReady}
+                            placeholder="data.total"
+                            onChange={(event) =>
+                              setBalanceCustomTotalPath(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-used-path">
+                            Used path
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-used-path"
+                            value={balanceCustomUsedPath}
+                            disabled={!isServiceReady}
+                            placeholder="data.used"
+                            onChange={(event) =>
+                              setBalanceCustomUsedPath(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-plan-path">
+                            Plan path
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-plan-path"
+                            value={balanceCustomPlanPath}
+                            disabled={!isServiceReady}
+                            placeholder="data.plan"
+                            onChange={(event) =>
+                              setBalanceCustomPlanPath(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-valid-path">
+                            Valid path
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-valid-path"
+                            value={balanceCustomValidPath}
+                            disabled={!isServiceReady}
+                            placeholder="data.active"
+                            onChange={(event) =>
+                              setBalanceCustomValidPath(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-error-path">
+                            Error path
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-error-path"
+                            value={balanceCustomInvalidMessagePath}
+                            disabled={!isServiceReady}
+                            placeholder="message"
+                            onChange={(event) =>
+                              setBalanceCustomInvalidMessagePath(
+                                event.target.value
+                              )
+                            }
+                          />
+                        </div>
+                        {balanceCustomAuth === "balance_bearer" ? (
+                          <div className="grid gap-2">
+                            <Label htmlFor="aggregate-api-balance-custom-token">
+                              Balance access token
+                            </Label>
+                            <Input
+                              id="aggregate-api-balance-custom-token"
+                              type="password"
+                              value={balanceQueryAccessToken}
+                              disabled={!isServiceReady}
+                              placeholder={
+                                aggregateApi?.id ? "Keep current" : "Optional"
+                              }
+                              onChange={(event) =>
+                                setBalanceQueryAccessToken(event.target.value)
+                              }
+                            />
+                          </div>
+                        ) : null}
+                      </>
+                    ) : null}
+
+                    {balanceQueryTemplate === "new_api" ? (
+                      <>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-access-token">
+                            {t("余额 Access Token")}
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-access-token"
+                            type="password"
+                            value={balanceQueryAccessToken}
+                            disabled={!isServiceReady}
+                            placeholder={
+                              aggregateApi?.id
+                                ? t("留空则保持原值或使用密钥")
+                                : t("留空则使用密钥")
+                            }
+                            onChange={(event) =>
+                              setBalanceQueryAccessToken(event.target.value)
+                            }
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="aggregate-api-balance-user-id">
+                            {t("New API 用户 ID")}
+                          </Label>
+                          <Input
+                            id="aggregate-api-balance-user-id"
+                            value={balanceQueryUserId}
+                            disabled={!isServiceReady}
+                            onChange={(event) =>
+                              setBalanceQueryUserId(event.target.value)
+                            }
+                          />
+                        </div>
+                      </>
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
 
               {generatedKey ? (

--- a/apps/src/lib/api/account-client.ts
+++ b/apps/src/lib/api/account-client.ts
@@ -1,6 +1,7 @@
 import { invoke, withAddr } from "./transport";
 import {
   normalizeAccountList,
+  normalizeAggregateApiBalanceRefreshResult,
   normalizeAggregateApiCreateResult,
   normalizeAggregateApiList,
   normalizeAggregateApiSecretResult,
@@ -41,6 +42,7 @@ import {
   AccountListResult,
   AccountUsage,
   AggregateApi,
+  AggregateApiBalanceRefreshResult,
   AggregateApiCreateResult,
   AggregateApiSecretResult,
   AggregateApiTestResult,
@@ -136,6 +138,12 @@ interface AggregateApiPayload {
   modelOverride?: string | null;
   username?: string | null;
   password?: string | null;
+  balanceQueryEnabled?: boolean | null;
+  balanceQueryTemplate?: string | null;
+  balanceQueryBaseUrl?: string | null;
+  balanceQueryAccessToken?: string | null;
+  balanceQueryUserId?: string | null;
+  balanceQueryConfigJson?: string | null;
 }
 
 const MAX_IMPORT_RPC_BODY_BYTES = 4 * 1024 * 1024;
@@ -521,6 +529,24 @@ export const accountClient = {
           typeof params.modelOverride === "string" ? params.modelOverride : null,
         username: params.username || null,
         password: params.password || null,
+        balanceQueryEnabled:
+          typeof params.balanceQueryEnabled === "boolean"
+            ? params.balanceQueryEnabled
+            : null,
+        balanceQueryTemplate: params.balanceQueryTemplate || null,
+        balanceQueryBaseUrl:
+          typeof params.balanceQueryBaseUrl === "string"
+            ? params.balanceQueryBaseUrl
+            : null,
+        balanceQueryAccessToken: params.balanceQueryAccessToken || null,
+        balanceQueryUserId:
+          typeof params.balanceQueryUserId === "string"
+            ? params.balanceQueryUserId
+            : null,
+        balanceQueryConfigJson:
+          typeof params.balanceQueryConfigJson === "string"
+            ? params.balanceQueryConfigJson
+            : null,
       })
     );
     return normalizeAggregateApiCreateResult(result);
@@ -551,6 +577,24 @@ export const accountClient = {
           typeof params.modelOverride === "string" ? params.modelOverride : null,
         username: params.username || null,
         password: params.password || null,
+        balanceQueryEnabled:
+          typeof params.balanceQueryEnabled === "boolean"
+            ? params.balanceQueryEnabled
+            : null,
+        balanceQueryTemplate: params.balanceQueryTemplate || null,
+        balanceQueryBaseUrl:
+          typeof params.balanceQueryBaseUrl === "string"
+            ? params.balanceQueryBaseUrl
+            : null,
+        balanceQueryAccessToken: params.balanceQueryAccessToken || null,
+        balanceQueryUserId:
+          typeof params.balanceQueryUserId === "string"
+            ? params.balanceQueryUserId
+            : null,
+        balanceQueryConfigJson:
+          typeof params.balanceQueryConfigJson === "string"
+            ? params.balanceQueryConfigJson
+            : null,
       })
     ),
   deleteAggregateApi: (apiId: string) =>
@@ -568,6 +612,13 @@ export const accountClient = {
       withAddr({ id: apiId })
     );
     return normalizeAggregateApiTestResult(result);
+  },
+  async refreshAggregateApiBalance(apiId: string): Promise<AggregateApiBalanceRefreshResult> {
+    const result = await invoke<unknown>(
+      "service_aggregate_api_refresh_balance",
+      withAddr({ id: apiId })
+    );
+    return normalizeAggregateApiBalanceRefreshResult(result);
   },
 
   async listApiKeys(): Promise<ApiKey[]> {

--- a/apps/src/lib/api/normalize.ts
+++ b/apps/src/lib/api/normalize.ts
@@ -5,6 +5,8 @@ import {
   AccountListResult,
   AccountUsage,
   AggregateApi,
+  AggregateApiBalanceRefreshResult,
+  AggregateApiBalanceSnapshot,
   AggregateApiCreateResult,
   AggregateApiSecretResult,
   AggregateApiTestResult,
@@ -779,6 +781,27 @@ export function normalizeAggregateApi(item: unknown): AggregateApi | null {
     lastTestAt: toNullableNumber(source.lastTestAt ?? source.last_test_at),
     lastTestStatus: asString(source.lastTestStatus ?? source.last_test_status) || null,
     lastTestError: asString(source.lastTestError ?? source.last_test_error) || null,
+    balanceQueryEnabled: asBoolean(
+      source.balanceQueryEnabled ?? source.balance_query_enabled,
+      false
+    ),
+    balanceQueryTemplate:
+      asString(source.balanceQueryTemplate ?? source.balance_query_template) || null,
+    balanceQueryBaseUrl:
+      asString(source.balanceQueryBaseUrl ?? source.balance_query_base_url) || null,
+    balanceQueryUserId:
+      asString(source.balanceQueryUserId ?? source.balance_query_user_id) || null,
+    balanceQueryConfigJson:
+      asString(
+        source.balanceQueryConfigJson ?? source.balance_query_config_json
+      ) || null,
+    lastBalanceAt: toNullableNumber(source.lastBalanceAt ?? source.last_balance_at),
+    lastBalanceStatus:
+      asString(source.lastBalanceStatus ?? source.last_balance_status) || null,
+    lastBalanceError:
+      asString(source.lastBalanceError ?? source.last_balance_error) || null,
+    lastBalanceJson:
+      asString(source.lastBalanceJson ?? source.last_balance_json) || null,
   };
 }
 
@@ -856,6 +879,44 @@ export function normalizeAggregateApiTestResult(payload: unknown): AggregateApiT
     statusCode: toNullableNumber(source.statusCode ?? source.status_code),
     message: asString(source.message) || null,
     testedAt: asInteger(source.testedAt ?? source.tested_at, 0, 0),
+    latencyMs: asInteger(source.latencyMs ?? source.latency_ms, 0, 0),
+  };
+}
+
+export function normalizeAggregateApiBalanceSnapshot(
+  payload: unknown
+): AggregateApiBalanceSnapshot | null {
+  const source = asObject(payload);
+  const hasBalanceFields =
+    "remaining" in source ||
+    "used" in source ||
+    "total" in source ||
+    "isValid" in source ||
+    "is_valid" in source;
+  if (!hasBalanceFields) return null;
+  return {
+    isValid: asBoolean(source.isValid ?? source.is_valid, true),
+    invalidMessage:
+      asString(source.invalidMessage ?? source.invalid_message) || null,
+    remaining: toNullableNumber(source.remaining),
+    unit: asString(source.unit) || null,
+    planName: asString(source.planName ?? source.plan_name) || null,
+    total: toNullableNumber(source.total),
+    used: toNullableNumber(source.used),
+    extra: toNullableObject(source.extra),
+  };
+}
+
+export function normalizeAggregateApiBalanceRefreshResult(
+  payload: unknown
+): AggregateApiBalanceRefreshResult {
+  const source = asObject(payload);
+  return {
+    id: asString(source.id),
+    ok: asBoolean(source.ok),
+    balance: normalizeAggregateApiBalanceSnapshot(source.balance),
+    message: asString(source.message) || null,
+    queriedAt: asInteger(source.queriedAt ?? source.queried_at, 0, 0),
     latencyMs: asInteger(source.latencyMs ?? source.latency_ms, 0, 0),
   };
 }

--- a/apps/src/lib/api/transport-runtime.ts
+++ b/apps/src/lib/api/transport-runtime.ts
@@ -19,6 +19,15 @@ const CONFIGURED_WEB_RPC_BASE_URL = normalizeRpcBaseUrl(
 let runtimeCapabilitiesCache: RuntimeCapabilities | null = null;
 let runtimeCapabilitiesPromise: Promise<RuntimeCapabilities> | null = null;
 
+function runtimeProbeUrl(): string {
+  if (typeof window === "undefined") {
+    return DEFAULT_RUNTIME_PROBE_URL;
+  }
+  const probeUrl = new URL(DEFAULT_RUNTIME_PROBE_URL, window.location.origin);
+  probeUrl.searchParams.set("_", String(Date.now()));
+  return probeUrl.toString();
+}
+
 async function probeRuntimeCapabilities(): Promise<RuntimeCapabilities | null> {
   if (typeof window === "undefined") {
     return null;
@@ -26,16 +35,18 @@ async function probeRuntimeCapabilities(): Promise<RuntimeCapabilities | null> {
 
   try {
     const response = await fetchWithRetry(
-      DEFAULT_RUNTIME_PROBE_URL,
+      runtimeProbeUrl(),
       {
         method: "GET",
+        cache: "no-store",
         headers: {
           Accept: "application/json",
         },
       },
       {
-        timeoutMs: 1500,
-        retries: 0,
+        timeoutMs: 2500,
+        retries: 2,
+        retryDelayMs: 250,
         shouldRetryStatus: () => false,
       }
     );

--- a/apps/src/lib/api/transport-web-commands.ts
+++ b/apps/src/lib/api/transport-web-commands.ts
@@ -265,6 +265,9 @@ export function createWebCommandMap(
     service_aggregate_api_test_connection: {
       rpcMethod: "aggregateApi/testConnection",
     },
+    service_aggregate_api_refresh_balance: {
+      rpcMethod: "aggregateApi/refreshBalance",
+    },
     service_login_start: {
       rpcMethod: "account/login/start",
       mapParams: (params) => ({

--- a/apps/src/lib/i18n/messages/en.ts
+++ b/apps/src/lib/i18n/messages/en.ts
@@ -1400,4 +1400,35 @@ export const EN_MESSAGES: MessageCatalog = {
     "This affects runtime configuration. After changing it, monitor whether the request path remains stable.",
   "上游 Originator": "Upstream Originator",
   "区域驻留要求": "Residency requirement",
+  余额: "Balance",
+  余额检测: "Balance query",
+  "开启后可在聚合 API 列表手动刷新并显示余额。":
+    "Enable manual balance refresh and display in the aggregate API list.",
+  查询模板: "Query template",
+  通用余额: "Generic balance",
+  余额接口基础地址: "Balance API base URL",
+  "留空则从 URL 推断服务根地址":
+    "Leave blank to infer the service root from URL",
+  "留空则使用上方 URL": "Leave blank to use the URL above",
+  "余额 Access Token": "Balance access token",
+  "留空则保持原值或使用密钥": "Leave blank to keep the old value or use the key",
+  "留空则使用密钥": "Leave blank to use the key",
+  "New API 用户 ID": "New API user ID",
+  未启用: "Disabled",
+  未查询: "Not queried",
+  查询失败: "Query failed",
+  套餐: "Plan",
+  已用: "Used",
+  总额: "Total",
+  余额已刷新: "Balance refreshed",
+  "余额查询失败 {reason}": "Balance query failed: {reason}",
+  余额查询失败: "Balance query failed",
+  "余额刷新完成：{count} 个成功":
+    "Balance refresh completed: {count} succeeded",
+  "余额刷新完成：{success} 个成功，{fail} 个失败":
+    "Balance refresh completed: {success} succeeded, {fail} failed",
+  批量刷新余额失败: "Batch balance refresh failed",
+  "暂无已启用余额检测的聚合 API":
+    "No aggregate APIs with balance query enabled",
+  刷新余额: "Refresh balance",
 };

--- a/apps/src/types/api-key.ts
+++ b/apps/src/types/api-key.ts
@@ -41,6 +41,15 @@ export interface AggregateApi {
   lastTestAt: number | null;
   lastTestStatus: string | null;
   lastTestError: string | null;
+  balanceQueryEnabled: boolean;
+  balanceQueryTemplate: string | null;
+  balanceQueryBaseUrl: string | null;
+  balanceQueryUserId: string | null;
+  balanceQueryConfigJson: string | null;
+  lastBalanceAt: number | null;
+  lastBalanceStatus: string | null;
+  lastBalanceError: string | null;
+  lastBalanceJson: string | null;
 }
 
 export interface AggregateApiCreateResult {
@@ -62,6 +71,26 @@ export interface AggregateApiTestResult {
   statusCode: number | null;
   message: string | null;
   testedAt: number;
+  latencyMs: number;
+}
+
+export interface AggregateApiBalanceSnapshot {
+  isValid: boolean;
+  invalidMessage: string | null;
+  remaining: number | null;
+  unit: string | null;
+  planName: string | null;
+  total: number | null;
+  used: number | null;
+  extra: Record<string, unknown> | null;
+}
+
+export interface AggregateApiBalanceRefreshResult {
+  id: string;
+  ok: boolean;
+  balance: AggregateApiBalanceSnapshot | null;
+  message: string | null;
+  queriedAt: number;
   latencyMs: number;
 }
 

--- a/crates/core/migrations/054_aggregate_api_balance_query.sql
+++ b/crates/core/migrations/054_aggregate_api_balance_query.sql
@@ -1,0 +1,19 @@
+ALTER TABLE aggregate_apis ADD COLUMN balance_query_enabled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE aggregate_apis ADD COLUMN balance_query_template TEXT;
+ALTER TABLE aggregate_apis ADD COLUMN balance_query_base_url TEXT;
+ALTER TABLE aggregate_apis ADD COLUMN balance_query_user_id TEXT;
+ALTER TABLE aggregate_apis ADD COLUMN balance_query_config_json TEXT;
+ALTER TABLE aggregate_apis ADD COLUMN last_balance_at INTEGER;
+ALTER TABLE aggregate_apis ADD COLUMN last_balance_status TEXT;
+ALTER TABLE aggregate_apis ADD COLUMN last_balance_error TEXT;
+ALTER TABLE aggregate_apis ADD COLUMN last_balance_json TEXT;
+
+CREATE TABLE IF NOT EXISTS aggregate_api_balance_secrets (
+  aggregate_api_id TEXT PRIMARY KEY REFERENCES aggregate_apis(id) ON DELETE CASCADE,
+  access_token TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_aggregate_api_balance_secrets_updated_at
+  ON aggregate_api_balance_secrets(updated_at);

--- a/crates/core/src/rpc/types.rs
+++ b/crates/core/src/rpc/types.rs
@@ -426,6 +426,15 @@ pub struct AggregateApiSummary {
     pub last_test_at: Option<i64>,
     pub last_test_status: Option<String>,
     pub last_test_error: Option<String>,
+    pub balance_query_enabled: bool,
+    pub balance_query_template: Option<String>,
+    pub balance_query_base_url: Option<String>,
+    pub balance_query_user_id: Option<String>,
+    pub balance_query_config_json: Option<String>,
+    pub last_balance_at: Option<i64>,
+    pub last_balance_status: Option<String>,
+    pub last_balance_error: Option<String>,
+    pub last_balance_json: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -552,6 +561,30 @@ pub struct AggregateApiTestResult {
     pub status_code: Option<i64>,
     pub message: Option<String>,
     pub tested_at: i64,
+    pub latency_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregateApiBalanceSnapshot {
+    pub is_valid: bool,
+    pub invalid_message: Option<String>,
+    pub remaining: Option<f64>,
+    pub unit: Option<String>,
+    pub plan_name: Option<String>,
+    pub total: Option<f64>,
+    pub used: Option<f64>,
+    pub extra: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregateApiBalanceRefreshResult {
+    pub id: String,
+    pub ok: bool,
+    pub balance: Option<AggregateApiBalanceSnapshot>,
+    pub message: Option<String>,
+    pub queried_at: i64,
     pub latency_ms: i64,
 }
 

--- a/crates/core/src/storage/aggregate_apis.rs
+++ b/crates/core/src/storage/aggregate_apis.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Result, Row};
+use rusqlite::{params, Result, Row};
 
 use super::{now_ts, AggregateApi, Storage};
 
@@ -17,7 +17,16 @@ const AGGREGATE_API_SELECT_SQL: &str = "SELECT
     updated_at,
     last_test_at,
     last_test_status,
-    last_test_error
+    last_test_error,
+    balance_query_enabled,
+    balance_query_template,
+    balance_query_base_url,
+    balance_query_user_id,
+    balance_query_config_json,
+    last_balance_at,
+    last_balance_status,
+    last_balance_error,
+    last_balance_json
  FROM aggregate_apis";
 
 impl Storage {
@@ -50,9 +59,18 @@ impl Storage {
                 updated_at,
                 last_test_at,
                 last_test_status,
-                last_test_error
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
-            (
+                last_test_error,
+                balance_query_enabled,
+                balance_query_template,
+                balance_query_base_url,
+                balance_query_user_id,
+                balance_query_config_json,
+                last_balance_at,
+                last_balance_status,
+                last_balance_error,
+                last_balance_json
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)",
+            params![
                 &api.id,
                 &api.provider_type,
                 &api.supplier_name,
@@ -68,7 +86,16 @@ impl Storage {
                 &api.last_test_at,
                 &api.last_test_status,
                 &api.last_test_error,
-            ),
+                api.balance_query_enabled,
+                &api.balance_query_template,
+                &api.balance_query_base_url,
+                &api.balance_query_user_id,
+                &api.balance_query_config_json,
+                &api.last_balance_at,
+                &api.last_balance_status,
+                &api.last_balance_error,
+                &api.last_balance_json,
+            ],
         )?;
         Ok(())
     }
@@ -258,6 +285,59 @@ impl Storage {
         Ok(())
     }
 
+    pub fn update_aggregate_api_balance_query(
+        &self,
+        api_id: &str,
+        enabled: bool,
+        template: Option<&str>,
+        base_url: Option<&str>,
+        user_id: Option<&str>,
+        config_json: Option<&str>,
+    ) -> Result<()> {
+        self.conn.execute(
+            "UPDATE aggregate_apis
+             SET balance_query_enabled = ?1,
+                 balance_query_template = ?2,
+                 balance_query_base_url = ?3,
+                 balance_query_user_id = ?4,
+                 balance_query_config_json = ?5,
+                 updated_at = ?6
+             WHERE id = ?7",
+            (
+                enabled,
+                template,
+                base_url,
+                user_id,
+                config_json,
+                now_ts(),
+                api_id,
+            ),
+        )?;
+        Ok(())
+    }
+
+    pub fn update_aggregate_api_balance_result(
+        &self,
+        api_id: &str,
+        ok: bool,
+        balance_json: Option<&str>,
+        error: Option<&str>,
+    ) -> Result<()> {
+        let now = now_ts();
+        let status = if ok { Some("success") } else { Some("failed") };
+        self.conn.execute(
+            "UPDATE aggregate_apis
+             SET last_balance_at = ?1,
+                 last_balance_status = ?2,
+                 last_balance_error = ?3,
+                 last_balance_json = ?4,
+                 updated_at = ?1
+             WHERE id = ?5",
+            (now, status, error, balance_json, api_id),
+        )?;
+        Ok(())
+    }
+
     /// 函数 `delete_aggregate_api`
     ///
     /// 作者: gaohongshun
@@ -271,6 +351,10 @@ impl Storage {
     /// # 返回
     /// 返回函数执行结果
     pub fn delete_aggregate_api(&self, api_id: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM aggregate_api_balance_secrets WHERE aggregate_api_id = ?1",
+            [api_id],
+        )?;
         self.conn.execute(
             "DELETE FROM aggregate_api_secrets WHERE aggregate_api_id = ?1",
             [api_id],
@@ -321,6 +405,43 @@ impl Storage {
     pub fn find_aggregate_api_secret_by_id(&self, api_id: &str) -> Result<Option<String>> {
         let mut stmt = self.conn.prepare(
             "SELECT secret_value FROM aggregate_api_secrets WHERE aggregate_api_id = ?1 LIMIT 1",
+        )?;
+        let mut rows = stmt.query([api_id])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(row.get(0)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn upsert_aggregate_api_balance_secret(
+        &self,
+        api_id: &str,
+        access_token: &str,
+    ) -> Result<()> {
+        let now = now_ts();
+        self.conn.execute(
+            "INSERT INTO aggregate_api_balance_secrets (aggregate_api_id, access_token, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?3)
+             ON CONFLICT(aggregate_api_id) DO UPDATE SET
+               access_token = excluded.access_token,
+               updated_at = excluded.updated_at",
+            (api_id, access_token, now),
+        )?;
+        Ok(())
+    }
+
+    pub fn delete_aggregate_api_balance_secret(&self, api_id: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM aggregate_api_balance_secrets WHERE aggregate_api_id = ?1",
+            [api_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn find_aggregate_api_balance_secret_by_id(&self, api_id: &str) -> Result<Option<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT access_token FROM aggregate_api_balance_secrets WHERE aggregate_api_id = ?1 LIMIT 1",
         )?;
         let mut rows = stmt.query([api_id])?;
         if let Some(row) = rows.next()? {
@@ -403,7 +524,16 @@ impl Storage {
                 updated_at INTEGER NOT NULL,
                 last_test_at INTEGER,
                 last_test_status TEXT,
-                last_test_error TEXT
+                last_test_error TEXT,
+                balance_query_enabled INTEGER NOT NULL DEFAULT 0,
+                balance_query_template TEXT,
+                balance_query_base_url TEXT,
+                balance_query_user_id TEXT,
+                balance_query_config_json TEXT,
+                last_balance_at INTEGER,
+                last_balance_status TEXT,
+                last_balance_error TEXT,
+                last_balance_json TEXT
             )",
             [],
         )?;
@@ -422,6 +552,19 @@ impl Storage {
         self.ensure_column("aggregate_apis", "auth_params_json", "TEXT")?;
         self.ensure_column("aggregate_apis", "action", "TEXT")?;
         self.ensure_column("aggregate_apis", "model_override", "TEXT")?;
+        self.ensure_column(
+            "aggregate_apis",
+            "balance_query_enabled",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
+        self.ensure_column("aggregate_apis", "balance_query_template", "TEXT")?;
+        self.ensure_column("aggregate_apis", "balance_query_base_url", "TEXT")?;
+        self.ensure_column("aggregate_apis", "balance_query_user_id", "TEXT")?;
+        self.ensure_column("aggregate_apis", "balance_query_config_json", "TEXT")?;
+        self.ensure_column("aggregate_apis", "last_balance_at", "INTEGER")?;
+        self.ensure_column("aggregate_apis", "last_balance_status", "TEXT")?;
+        self.ensure_column("aggregate_apis", "last_balance_error", "TEXT")?;
+        self.ensure_column("aggregate_apis", "last_balance_json", "TEXT")?;
         self.conn.execute(
             "UPDATE aggregate_apis
              SET provider_type = COALESCE(NULLIF(TRIM(provider_type), ''), 'codex')
@@ -470,6 +613,23 @@ impl Storage {
         )?;
         Ok(())
     }
+
+    pub(super) fn ensure_aggregate_api_balance_secrets_table(&self) -> Result<()> {
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS aggregate_api_balance_secrets (
+                aggregate_api_id TEXT PRIMARY KEY REFERENCES aggregate_apis(id) ON DELETE CASCADE,
+                access_token TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            )",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_aggregate_api_balance_secrets_updated_at ON aggregate_api_balance_secrets(updated_at)",
+            [],
+        )?;
+        Ok(())
+    }
 }
 
 /// 函数 `map_aggregate_api_row`
@@ -500,5 +660,14 @@ fn map_aggregate_api_row(row: &Row<'_>) -> Result<AggregateApi> {
         last_test_at: row.get(12)?,
         last_test_status: row.get(13)?,
         last_test_error: row.get(14)?,
+        balance_query_enabled: row.get(15)?,
+        balance_query_template: row.get(16)?,
+        balance_query_base_url: row.get(17)?,
+        balance_query_user_id: row.get(18)?,
+        balance_query_config_json: row.get(19)?,
+        last_balance_at: row.get(20)?,
+        last_balance_status: row.get(21)?,
+        last_balance_error: row.get(22)?,
+        last_balance_json: row.get(23)?,
     })
 }

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -249,6 +249,15 @@ pub struct AggregateApi {
     pub last_test_at: Option<i64>,
     pub last_test_status: Option<String>,
     pub last_test_error: Option<String>,
+    pub balance_query_enabled: bool,
+    pub balance_query_template: Option<String>,
+    pub balance_query_base_url: Option<String>,
+    pub balance_query_user_id: Option<String>,
+    pub balance_query_config_json: Option<String>,
+    pub last_balance_at: Option<i64>,
+    pub last_balance_status: Option<String>,
+    pub last_balance_error: Option<String>,
+    pub last_balance_json: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -675,9 +684,23 @@ impl Storage {
             include_str!("../../migrations/053_aggregate_api_model_override.sql"),
             |s| s.ensure_aggregate_apis_table(),
         )?;
+        self.apply_sql_or_compat_migration(
+            "053_api_key_quota_limits",
+            include_str!("../../migrations/053_api_key_quota_limits.sql"),
+            |s| s.ensure_api_key_quota_limits_table(),
+        )?;
+        self.apply_sql_or_compat_migration(
+            "054_aggregate_api_balance_query",
+            include_str!("../../migrations/054_aggregate_api_balance_query.sql"),
+            |s| {
+                s.ensure_aggregate_apis_table()?;
+                s.ensure_aggregate_api_balance_secrets_table()
+            },
+        )?;
         self.ensure_api_key_rotation_columns()?;
         self.ensure_aggregate_apis_table()?;
         self.ensure_aggregate_api_secrets_table()?;
+        self.ensure_aggregate_api_balance_secrets_table()?;
         self.ensure_api_key_quota_limits_table()?;
         self.ensure_request_token_stats_table()?;
         self.ensure_gateway_error_logs_table()?;

--- a/crates/core/tests/storage/migration_tests.rs
+++ b/crates/core/tests/storage/migration_tests.rs
@@ -259,6 +259,15 @@ fn init_tracks_schema_migrations_and_is_idempotent() {
         )
         .expect("count 053 migration");
     assert_eq!(applied_053, 1);
+    let applied_054: i64 = storage
+        .conn
+        .query_row(
+            "SELECT COUNT(1) FROM schema_migrations WHERE version = '054_aggregate_api_balance_query'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count 054 migration");
+    assert_eq!(applied_054, 1);
 
     assert!(!storage
         .has_column("accounts", "note")
@@ -344,6 +353,18 @@ fn init_tracks_schema_migrations_and_is_idempotent() {
     assert!(storage
         .has_column("api_key_quota_limits", "quota_limit_tokens")
         .expect("check api_key_quota_limits.quota_limit_tokens"));
+    assert!(storage
+        .has_column("aggregate_apis", "balance_query_enabled")
+        .expect("check aggregate_apis.balance_query_enabled"));
+    assert!(storage
+        .has_column("aggregate_apis", "balance_query_config_json")
+        .expect("check aggregate_apis.balance_query_config_json"));
+    assert!(storage
+        .has_column("aggregate_apis", "last_balance_json")
+        .expect("check aggregate_apis.last_balance_json"));
+    assert!(storage
+        .has_table("aggregate_api_balance_secrets")
+        .expect("check aggregate_api_balance_secrets table"));
     assert!(!storage
         .has_column("request_logs", "input_tokens")
         .expect("check request_logs.input_tokens"));

--- a/crates/service/src/aggregate_api.rs
+++ b/crates/service/src/aggregate_api.rs
@@ -1,5 +1,6 @@
 use codexmanager_core::rpc::types::{
-    AggregateApiCreateResult, AggregateApiSecretResult, AggregateApiSummary, AggregateApiTestResult,
+    AggregateApiBalanceRefreshResult, AggregateApiBalanceSnapshot, AggregateApiCreateResult,
+    AggregateApiSecretResult, AggregateApiSummary, AggregateApiTestResult,
 };
 use codexmanager_core::storage::{now_ts, AggregateApi};
 use reqwest::header::{HeaderName, HeaderValue};
@@ -17,6 +18,12 @@ pub(crate) const AGGREGATE_API_PROVIDER_CLAUDE: &str = "claude";
 pub(crate) const AGGREGATE_API_PROVIDER_GEMINI: &str = "gemini";
 pub(crate) const AGGREGATE_API_AUTH_APIKEY: &str = "apikey";
 pub(crate) const AGGREGATE_API_AUTH_USERPASS: &str = "userpass";
+const AGGREGATE_API_BALANCE_TEMPLATE_GENERIC: &str = "generic";
+const AGGREGATE_API_BALANCE_TEMPLATE_NEW_API: &str = "new_api";
+const AGGREGATE_API_BALANCE_TEMPLATE_CUSTOM: &str = "custom";
+const CUSTOM_BALANCE_AUTH_PROVIDER_BEARER: &str = "provider_bearer";
+const CUSTOM_BALANCE_AUTH_BALANCE_BEARER: &str = "balance_bearer";
+const CUSTOM_BALANCE_AUTH_NONE: &str = "none";
 const CLAUDE_DEFAULT_PROBE_MODEL: &str = "claude-haiku-4-5-20251001";
 const ALIBABA_CODING_PLAN_PROBE_MODEL: &str = "qwen3.5-plus";
 const MAX_DISCOVERED_CLAUDE_PROBE_MODELS: usize = 8;
@@ -26,6 +33,31 @@ const MAX_DISCOVERED_CLAUDE_PROBE_MODELS: usize = 8;
 struct UserPassSecret {
     username: String,
     password: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CustomBalanceQueryConfig {
+    #[serde(default)]
+    method: Option<String>,
+    path: String,
+    #[serde(default)]
+    auth: Option<String>,
+    remaining_path: String,
+    #[serde(default)]
+    unit: Option<String>,
+    #[serde(default)]
+    multiplier: Option<f64>,
+    #[serde(default)]
+    total_path: Option<String>,
+    #[serde(default)]
+    used_path: Option<String>,
+    #[serde(default)]
+    plan_path: Option<String>,
+    #[serde(default)]
+    valid_path: Option<String>,
+    #[serde(default)]
+    invalid_message_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -173,6 +205,210 @@ fn normalize_model_override(value: Option<String>) -> Result<Option<String>, Str
     Ok(Some(trimmed.to_string()))
 }
 
+fn normalize_balance_query_template(value: Option<String>) -> Result<Option<String>, String> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    let normalized = raw.trim().to_ascii_lowercase().replace('-', "_");
+    if normalized.is_empty() {
+        return Ok(None);
+    }
+    match normalized.as_str() {
+        AGGREGATE_API_BALANCE_TEMPLATE_GENERIC => {
+            Ok(Some(AGGREGATE_API_BALANCE_TEMPLATE_GENERIC.to_string()))
+        }
+        "newapi" | "new_api" => Ok(Some(AGGREGATE_API_BALANCE_TEMPLATE_NEW_API.to_string())),
+        "custom" | "custom_json" => Ok(Some(AGGREGATE_API_BALANCE_TEMPLATE_CUSTOM.to_string())),
+        other => Err(format!(
+            "unsupported aggregate api balance template: {other}"
+        )),
+    }
+}
+
+fn default_balance_query_template(template: Option<String>) -> String {
+    template.unwrap_or_else(|| AGGREGATE_API_BALANCE_TEMPLATE_GENERIC.to_string())
+}
+
+fn normalize_custom_balance_method(value: Option<String>) -> Result<String, String> {
+    let method = value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("GET")
+        .to_ascii_uppercase();
+    match method.as_str() {
+        "GET" | "POST" => Ok(method),
+        _ => Err("custom balance method must be GET or POST".to_string()),
+    }
+}
+
+fn normalize_custom_balance_auth(value: Option<String>) -> Result<String, String> {
+    let auth = value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(CUSTOM_BALANCE_AUTH_PROVIDER_BEARER)
+        .to_ascii_lowercase()
+        .replace('-', "_");
+    match auth.as_str() {
+        "provider" | "provider_bearer" | "api_key" | "apikey" => {
+            Ok(CUSTOM_BALANCE_AUTH_PROVIDER_BEARER.to_string())
+        }
+        "balance" | "balance_bearer" | "access_token" => {
+            Ok(CUSTOM_BALANCE_AUTH_BALANCE_BEARER.to_string())
+        }
+        "none" | "no_auth" => Ok(CUSTOM_BALANCE_AUTH_NONE.to_string()),
+        _ => Err("custom balance auth is invalid".to_string()),
+    }
+}
+
+fn normalize_custom_balance_endpoint_path(value: String) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("custom balance path is required".to_string());
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return Err("custom balance path must be relative, not a full url".to_string());
+    }
+    if trimmed.contains("://") {
+        return Err("custom balance path is invalid".to_string());
+    }
+    Ok(if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    })
+}
+
+fn normalize_custom_balance_json_path(
+    value: Option<String>,
+    field_name: &str,
+    required: bool,
+) -> Result<Option<String>, String> {
+    let Some(raw) = value else {
+        if required {
+            return Err(format!("custom balance {field_name} is required"));
+        }
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        if required {
+            return Err(format!("custom balance {field_name} is required"));
+        }
+        return Ok(None);
+    }
+    for segment in trimmed.split('.') {
+        if segment.is_empty() {
+            return Err(format!(
+                "custom balance {field_name} contains an empty segment"
+            ));
+        }
+        if !segment
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+        {
+            return Err(format!(
+                "custom balance {field_name} contains unsupported characters"
+            ));
+        }
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+fn normalize_custom_balance_unit(value: Option<String>) -> Result<Option<String>, String> {
+    let Some(raw) = value else {
+        return Ok(Some("USD".to_string()));
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(Some("USD".to_string()));
+    }
+    if trimmed.chars().count() > 16 {
+        return Err("custom balance unit is too long".to_string());
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+fn normalize_custom_balance_multiplier(value: Option<f64>) -> Result<Option<f64>, String> {
+    let multiplier = value.unwrap_or(1.0);
+    if !multiplier.is_finite() || multiplier <= 0.0 {
+        return Err("custom balance multiplier must be greater than 0".to_string());
+    }
+    Ok(Some(multiplier))
+}
+
+fn normalize_custom_balance_query_config(value: Option<String>) -> Result<Option<String>, String> {
+    let raw = normalize_optional_text(value)
+        .ok_or_else(|| "custom balance query config is required".to_string())?;
+    if raw.len() > 4096 {
+        return Err("custom balance query config is too large".to_string());
+    }
+    let mut config: CustomBalanceQueryConfig = serde_json::from_str(raw.as_str())
+        .map_err(|_| "custom balance query config is invalid JSON".to_string())?;
+    config.method = Some(normalize_custom_balance_method(config.method.take())?);
+    config.path = normalize_custom_balance_endpoint_path(config.path)?;
+    config.auth = Some(normalize_custom_balance_auth(config.auth.take())?);
+    config.remaining_path =
+        normalize_custom_balance_json_path(Some(config.remaining_path), "remainingPath", true)?
+            .expect("required remainingPath");
+    config.unit = normalize_custom_balance_unit(config.unit.take())?;
+    config.multiplier = normalize_custom_balance_multiplier(config.multiplier)?;
+    config.total_path =
+        normalize_custom_balance_json_path(config.total_path.take(), "totalPath", false)?;
+    config.used_path =
+        normalize_custom_balance_json_path(config.used_path.take(), "usedPath", false)?;
+    config.plan_path =
+        normalize_custom_balance_json_path(config.plan_path.take(), "planPath", false)?;
+    config.valid_path =
+        normalize_custom_balance_json_path(config.valid_path.take(), "validPath", false)?;
+    config.invalid_message_path = normalize_custom_balance_json_path(
+        config.invalid_message_path.take(),
+        "invalidMessagePath",
+        false,
+    )?;
+    serde_json::to_string(&config)
+        .map(Some)
+        .map_err(|_| "serialize custom balance query config failed".to_string())
+}
+
+fn normalize_balance_query_config_json(
+    template: Option<&str>,
+    value: Option<String>,
+) -> Result<Option<String>, String> {
+    if template == Some(AGGREGATE_API_BALANCE_TEMPLATE_CUSTOM) {
+        return normalize_custom_balance_query_config(value);
+    }
+    Ok(None)
+}
+
+fn normalize_optional_url(
+    value: Option<String>,
+    field_name: &str,
+) -> Result<Option<String>, String> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim().trim_end_matches('/').to_string();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let parsed =
+        reqwest::Url::parse(trimmed.as_str()).map_err(|_| format!("invalid {field_name}"))?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(format!("invalid {field_name} scheme"));
+    }
+    Ok(Some(trimmed))
+}
+
+fn normalize_optional_text(value: Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
 fn normalize_auth_params_json(
     auth_type: &str,
     enabled: Option<bool>,
@@ -276,9 +512,11 @@ mod tests {
 
     use super::{
         action_path_or_default, build_codex_models_probe_url, claude_probe_fallback_models_for_api,
-        extract_model_ids_from_models_response, normalize_action_override, normalize_provider_type,
-        normalize_provider_type_value, probe_claude_endpoint, probe_codex_endpoint,
-        provider_default_url, AGGREGATE_API_PROVIDER_CLAUDE, AGGREGATE_API_PROVIDER_GEMINI,
+        extract_custom_balance, extract_generic_balance, extract_model_ids_from_models_response,
+        extract_new_api_balance, normalize_action_override, normalize_custom_balance_query_config,
+        normalize_provider_type, normalize_provider_type_value, probe_claude_endpoint,
+        probe_codex_endpoint, provider_default_url, CustomBalanceQueryConfig,
+        AGGREGATE_API_PROVIDER_CLAUDE, AGGREGATE_API_PROVIDER_GEMINI,
         ALIBABA_CODING_PLAN_PROBE_MODEL, CLAUDE_DEFAULT_PROBE_MODEL,
     };
 
@@ -299,6 +537,15 @@ mod tests {
             last_test_at: None,
             last_test_status: None,
             last_test_error: None,
+            balance_query_enabled: false,
+            balance_query_template: None,
+            balance_query_base_url: None,
+            balance_query_user_id: None,
+            balance_query_config_json: None,
+            last_balance_at: None,
+            last_balance_status: None,
+            last_balance_error: None,
+            last_balance_json: None,
         }
     }
 
@@ -415,6 +662,103 @@ mod tests {
                 "provider-model-c".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn generic_balance_extractor_accepts_common_balance_shape() {
+        let body: Value = serde_json::from_str(
+            r#"{"is_active":true,"balance":12.5,"currency":"USD","used":1.25}"#,
+        )
+        .expect("parse balance body");
+
+        let snapshot = extract_generic_balance(&body).expect("extract balance");
+
+        assert!(snapshot.is_valid);
+        assert_eq!(snapshot.remaining, Some(12.5));
+        assert_eq!(snapshot.unit.as_deref(), Some("USD"));
+        assert_eq!(snapshot.used, Some(1.25));
+    }
+
+    #[test]
+    fn new_api_balance_extractor_converts_quota_to_usd() {
+        let body: Value = serde_json::from_str(
+            r#"{"success":true,"data":{"group":"default","quota":1000000,"used_quota":500000}}"#,
+        )
+        .expect("parse new api balance body");
+
+        let snapshot = extract_new_api_balance(&body).expect("extract balance");
+
+        assert!(snapshot.is_valid);
+        assert_eq!(snapshot.plan_name.as_deref(), Some("default"));
+        assert_eq!(snapshot.remaining, Some(2.0));
+        assert_eq!(snapshot.used, Some(1.0));
+        assert_eq!(snapshot.total, Some(3.0));
+    }
+
+    #[test]
+    fn generic_balance_extractor_accepts_usage_balance_shape() {
+        let body: Value = serde_json::from_str(
+            r#"{"mode":"quota_limited","status":"active","quota":{"limit":20,"used":7.5,"remaining":12.5}}"#,
+        )
+        .expect("parse usage body");
+
+        let snapshot = extract_generic_balance(&body).expect("extract usage balance");
+
+        assert!(snapshot.is_valid);
+        assert_eq!(snapshot.plan_name.as_deref(), Some("quota_limited"));
+        assert_eq!(snapshot.remaining, Some(12.5));
+        assert_eq!(snapshot.used, Some(7.5));
+        assert_eq!(snapshot.total, Some(20.0));
+        assert_eq!(snapshot.unit.as_deref(), Some("USD"));
+    }
+
+    #[test]
+    fn custom_balance_config_normalizes_and_extracts_paths() {
+        let normalized = normalize_custom_balance_query_config(Some(
+            r#"{
+                "method":"get",
+                "path":"v1/usage",
+                "auth":"balance-bearer",
+                "remainingPath":"data.available",
+                "totalPath":"data.limit",
+                "usedPath":"data.used",
+                "planPath":"data.plan",
+                "validPath":"data.valid",
+                "unit":"credits",
+                "multiplier":0.5
+            }"#
+            .to_string(),
+        ))
+        .expect("normalize custom balance config")
+        .expect("custom config present");
+        let config: CustomBalanceQueryConfig =
+            serde_json::from_str(normalized.as_str()).expect("parse normalized custom config");
+
+        assert_eq!(config.method.as_deref(), Some("GET"));
+        assert_eq!(config.path, "/v1/usage");
+        assert_eq!(config.auth.as_deref(), Some("balance_bearer"));
+
+        let body: Value = serde_json::from_str(
+            r#"{"data":{"available":4,"limit":10,"used":6,"plan":"pro","valid":true}}"#,
+        )
+        .expect("parse custom balance body");
+        let snapshot = extract_custom_balance(&body, &config).expect("extract custom balance");
+
+        assert!(snapshot.is_valid);
+        assert_eq!(snapshot.remaining, Some(2.0));
+        assert_eq!(snapshot.total, Some(5.0));
+        assert_eq!(snapshot.used, Some(3.0));
+        assert_eq!(snapshot.plan_name.as_deref(), Some("pro"));
+        assert_eq!(snapshot.unit.as_deref(), Some("credits"));
+    }
+
+    #[test]
+    fn custom_balance_config_rejects_absolute_request_path() {
+        let result = normalize_custom_balance_query_config(Some(
+            r#"{"path":"https://example.com/v1/usage","remainingPath":"balance"}"#.to_string(),
+        ));
+
+        assert!(result.is_err());
     }
 
     #[test]
@@ -890,6 +1234,496 @@ fn read_first_chunk(mut response: reqwest::blocking::Response) -> Result<(), Str
     } else {
         Err("No response data received".to_string())
     }
+}
+
+fn join_api_path(base_url: &str, path: &str) -> String {
+    let base = base_url.trim().trim_end_matches('/');
+    let suffix = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    format!("{base}{suffix}")
+}
+
+fn balance_query_base_url(api: &AggregateApi, template: &str) -> String {
+    let mut base = api
+        .balance_query_base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(api.url.as_str())
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    if template == AGGREGATE_API_BALANCE_TEMPLATE_NEW_API && api.balance_query_base_url.is_none() {
+        if let Some(stripped) = base.strip_suffix("/v1") {
+            base = stripped.to_string();
+        }
+    }
+    base
+}
+
+fn balance_query_usage_base_url(api: &AggregateApi) -> String {
+    let base = balance_query_base_url(api, AGGREGATE_API_BALANCE_TEMPLATE_GENERIC);
+    if api.balance_query_base_url.is_none() {
+        if let Some(stripped) = base.strip_suffix("/v1") {
+            return stripped.to_string();
+        }
+    }
+    base
+}
+
+fn apply_balance_auth(
+    client: &reqwest::blocking::Client,
+    url: String,
+    api: &AggregateApi,
+    secret: &str,
+) -> Result<reqwest::blocking::RequestBuilder, String> {
+    let builder = client.get(url.as_str());
+    let (builder, updated_url) = apply_probe_auth(builder, url.clone(), api, secret)?;
+    if updated_url == url {
+        return Ok(builder);
+    }
+    let rebuilt = client.get(updated_url.as_str());
+    let (rebuilt, _) = apply_probe_auth(rebuilt, updated_url, api, secret)?;
+    Ok(rebuilt)
+}
+
+fn short_error_body(body: &str) -> String {
+    let compact = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= 240 {
+        return compact;
+    }
+    compact.chars().take(240).collect::<String>()
+}
+
+fn read_json_response(response: reqwest::blocking::Response) -> Result<serde_json::Value, String> {
+    let status = response.status();
+    let bytes = response.bytes().map_err(|err| err.to_string())?;
+    let body = String::from_utf8_lossy(bytes.as_ref()).to_string();
+    if !status.is_success() {
+        let detail = short_error_body(body.as_str());
+        if detail.is_empty() {
+            return Err(format!("balance query http_status={}", status.as_u16()));
+        }
+        return Err(format!(
+            "balance query http_status={}; {detail}",
+            status.as_u16()
+        ));
+    }
+    serde_json::from_str(body.as_str())
+        .map_err(|_| "balance response is not valid JSON".to_string())
+}
+
+fn json_path<'a>(value: &'a serde_json::Value, path: &[&str]) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    Some(current)
+}
+
+fn json_path_dot<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        if let Ok(index) = segment.parse::<usize>() {
+            current = current.as_array()?.get(index)?;
+        } else {
+            current = current.get(segment)?;
+        }
+    }
+    Some(current)
+}
+
+fn json_number(value: Option<&serde_json::Value>) -> Option<f64> {
+    match value? {
+        serde_json::Value::Number(number) => number.as_f64(),
+        serde_json::Value::String(value) => value.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn repair_mojibake_utf8(value: &str) -> String {
+    let mut bytes = Vec::with_capacity(value.len());
+    for ch in value.chars() {
+        let code = ch as u32;
+        if code > u8::MAX as u32 {
+            return value.to_string();
+        }
+        bytes.push(code as u8);
+    }
+    match String::from_utf8(bytes) {
+        Ok(repaired)
+            if repaired
+                .chars()
+                .any(|ch| ('\u{4e00}'..='\u{9fff}').contains(&ch)) =>
+        {
+            repaired
+        }
+        _ => value.to_string(),
+    }
+}
+
+fn json_string(value: Option<&serde_json::Value>) -> Option<String> {
+    match value? {
+        serde_json::Value::String(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(repair_mojibake_utf8(trimmed))
+            }
+        }
+        serde_json::Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}
+
+fn json_bool(value: Option<&serde_json::Value>) -> Option<bool> {
+    match value? {
+        serde_json::Value::Bool(value) => Some(*value),
+        serde_json::Value::Number(number) => Some(number.as_i64().unwrap_or(0) != 0),
+        serde_json::Value::String(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "true" | "1" | "yes" | "on" | "active" => Some(true),
+                "false" | "0" | "no" | "off" | "disabled" | "inactive" => Some(false),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn first_number(value: &serde_json::Value, paths: &[&[&str]]) -> Option<f64> {
+    paths
+        .iter()
+        .find_map(|path| json_number(json_path(value, path)))
+}
+
+fn first_string(value: &serde_json::Value, paths: &[&[&str]]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| json_string(json_path(value, path)))
+}
+
+fn custom_number(value: &serde_json::Value, path: Option<&str>, multiplier: f64) -> Option<f64> {
+    path.and_then(|path| json_number(json_path_dot(value, path)))
+        .map(|value| value * multiplier)
+}
+
+fn custom_string(value: &serde_json::Value, path: Option<&str>) -> Option<String> {
+    path.and_then(|path| json_string(json_path_dot(value, path)))
+}
+
+fn custom_bool(value: &serde_json::Value, path: Option<&str>) -> Option<bool> {
+    path.and_then(|path| json_bool(json_path_dot(value, path)))
+}
+
+fn extract_generic_balance(
+    value: &serde_json::Value,
+) -> Result<AggregateApiBalanceSnapshot, String> {
+    let success = json_bool(json_path(value, &["success"])).unwrap_or(true);
+    let is_active = json_bool(json_path(value, &["is_active"]))
+        .or_else(|| json_bool(json_path(value, &["active"])))
+        .or_else(|| json_bool(json_path(value, &["data", "is_active"])))
+        .or_else(|| json_bool(json_path(value, &["data", "active"])))
+        .or_else(|| json_bool(json_path(value, &["isValid"])))
+        .or_else(|| json_bool(json_path(value, &["is_valid"])))
+        .or_else(|| json_bool(json_path(value, &["data", "isValid"])))
+        .or_else(|| json_bool(json_path(value, &["data", "is_valid"])))
+        .unwrap_or(true);
+    let status = first_string(value, &[&["status"], &["data", "status"]]);
+    let status_valid = status
+        .as_deref()
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            !matches!(
+                normalized.as_str(),
+                "expired" | "quota_exhausted" | "disabled"
+            )
+        })
+        .unwrap_or(true);
+    let invalid_message = first_string(
+        value,
+        &[
+            &["message"],
+            &["error"],
+            &["status"],
+            &["data", "message"],
+            &["data", "error"],
+        ],
+    );
+    let is_valid = success && is_active && status_valid;
+    let remaining = first_number(
+        value,
+        &[
+            &["remaining"],
+            &["balance"],
+            &["available"],
+            &["quota", "remaining"],
+            &["data", "remaining"],
+            &["data", "balance"],
+            &["data", "available"],
+            &["data", "quota", "remaining"],
+            &["credits", "balance"],
+        ],
+    );
+    if is_valid && remaining.is_none() {
+        return Err("balance response missing remaining field".to_string());
+    }
+    Ok(AggregateApiBalanceSnapshot {
+        is_valid,
+        invalid_message: if is_valid { None } else { invalid_message },
+        remaining,
+        unit: first_string(
+            value,
+            &[
+                &["unit"],
+                &["currency"],
+                &["data", "unit"],
+                &["data", "currency"],
+            ],
+        )
+        .or_else(|| Some("USD".to_string())),
+        plan_name: first_string(
+            value,
+            &[
+                &["planName"],
+                &["plan_name"],
+                &["mode"],
+                &["data", "planName"],
+                &["data", "plan_name"],
+                &["data", "group"],
+                &["data", "mode"],
+            ],
+        ),
+        total: first_number(
+            value,
+            &[
+                &["total"],
+                &["quota", "limit"],
+                &["data", "total"],
+                &["data", "quota", "limit"],
+            ],
+        ),
+        used: first_number(
+            value,
+            &[
+                &["used"],
+                &["used_quota"],
+                &["quota", "used"],
+                &["data", "used"],
+                &["data", "used_quota"],
+                &["data", "quota", "used"],
+            ],
+        ),
+        extra: None,
+    })
+}
+
+fn extract_new_api_balance(
+    value: &serde_json::Value,
+) -> Result<AggregateApiBalanceSnapshot, String> {
+    let success = json_bool(json_path(value, &["success"])).unwrap_or(true);
+    let data = json_path(value, &["data"]).unwrap_or(value);
+    let quota = json_number(data.get("quota"));
+    let used_quota = json_number(data.get("used_quota")).unwrap_or(0.0);
+    if success && quota.is_none() {
+        return Err("new api balance response missing data.quota".to_string());
+    }
+    let remaining = quota.map(|value| value / 500_000.0);
+    let used = Some(used_quota / 500_000.0);
+    let total = remaining.map(|value| value + used.unwrap_or(0.0));
+    Ok(AggregateApiBalanceSnapshot {
+        is_valid: success,
+        invalid_message: if success {
+            None
+        } else {
+            first_string(value, &[&["message"], &["error"]])
+        },
+        remaining,
+        unit: Some("USD".to_string()),
+        plan_name: json_string(data.get("group")).or_else(|| json_string(data.get("plan"))),
+        total,
+        used,
+        extra: None,
+    })
+}
+
+fn extract_custom_balance(
+    value: &serde_json::Value,
+    config: &CustomBalanceQueryConfig,
+) -> Result<AggregateApiBalanceSnapshot, String> {
+    let success = json_bool(json_path(value, &["success"])).unwrap_or(true);
+    let explicit_valid = custom_bool(value, config.valid_path.as_deref()).unwrap_or(true);
+    let is_valid = success && explicit_valid;
+    let multiplier = config.multiplier.unwrap_or(1.0);
+    let remaining = custom_number(value, Some(config.remaining_path.as_str()), multiplier);
+    if is_valid && remaining.is_none() {
+        return Err("custom balance response missing remaining field".to_string());
+    }
+    Ok(AggregateApiBalanceSnapshot {
+        is_valid,
+        invalid_message: if is_valid {
+            None
+        } else {
+            custom_string(value, config.invalid_message_path.as_deref()).or_else(|| {
+                first_string(
+                    value,
+                    &[
+                        &["message"],
+                        &["error"],
+                        &["data", "message"],
+                        &["data", "error"],
+                    ],
+                )
+            })
+        },
+        remaining,
+        unit: config.unit.clone().or_else(|| Some("USD".to_string())),
+        plan_name: custom_string(value, config.plan_path.as_deref()),
+        total: custom_number(value, config.total_path.as_deref(), multiplier),
+        used: custom_number(value, config.used_path.as_deref(), multiplier),
+        extra: None,
+    })
+}
+
+fn query_generic_balance_path(
+    client: &reqwest::blocking::Client,
+    api: &AggregateApi,
+    secret: &str,
+    base_url: &str,
+    path: &str,
+) -> Result<AggregateApiBalanceSnapshot, String> {
+    let url = join_api_path(base_url, path);
+    let response = apply_balance_auth(client, url, api, secret)?
+        .header("accept", "application/json")
+        .header("accept-encoding", "identity")
+        .header("user-agent", "codex-manager/aggregate-api-balance")
+        .send()
+        .map_err(|err| err.to_string())?;
+    let value = read_json_response(response)?;
+    extract_generic_balance(&value)
+}
+
+fn should_try_usage_balance_fallback(error: &str) -> bool {
+    error.contains("http_status=404")
+        || error.contains("http_status=405")
+        || error.contains("http_status=501")
+        || error.contains("balance response is not valid JSON")
+        || error.contains("balance response missing remaining field")
+}
+
+fn query_generic_balance(
+    client: &reqwest::blocking::Client,
+    api: &AggregateApi,
+    secret: &str,
+) -> Result<AggregateApiBalanceSnapshot, String> {
+    let base_url = balance_query_base_url(api, AGGREGATE_API_BALANCE_TEMPLATE_GENERIC);
+    match query_generic_balance_path(client, api, secret, base_url.as_str(), "/user/balance") {
+        Ok(snapshot) => Ok(snapshot),
+        Err(err) if should_try_usage_balance_fallback(err.as_str()) => {
+            let usage_base_url = balance_query_usage_base_url(api);
+            query_generic_balance_path(client, api, secret, usage_base_url.as_str(), "/v1/usage")
+                .map_err(|fallback_err| format!("{err}; fallback /v1/usage failed: {fallback_err}"))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn parse_custom_balance_query_config(
+    value: Option<&str>,
+) -> Result<CustomBalanceQueryConfig, String> {
+    let normalized = normalize_custom_balance_query_config(value.map(str::to_string))?
+        .ok_or_else(|| "custom balance query config is required".to_string())?;
+    serde_json::from_str(normalized.as_str())
+        .map_err(|_| "custom balance query config is invalid JSON".to_string())
+}
+
+fn query_custom_balance(
+    client: &reqwest::blocking::Client,
+    api: &AggregateApi,
+    provider_secret: &str,
+    balance_secret: Option<String>,
+) -> Result<AggregateApiBalanceSnapshot, String> {
+    let config = parse_custom_balance_query_config(api.balance_query_config_json.as_deref())?;
+    let base_url = balance_query_base_url(api, AGGREGATE_API_BALANCE_TEMPLATE_CUSTOM);
+    let url = join_api_path(base_url.as_str(), config.path.as_str());
+    let method = config.method.as_deref().unwrap_or("GET");
+    let mut builder = if method == "POST" {
+        client.post(url.as_str())
+    } else {
+        client.get(url.as_str())
+    }
+    .header("accept", "application/json")
+    .header("accept-encoding", "identity")
+    .header("user-agent", "codex-manager/aggregate-api-balance");
+    match config
+        .auth
+        .as_deref()
+        .unwrap_or(CUSTOM_BALANCE_AUTH_PROVIDER_BEARER)
+    {
+        CUSTOM_BALANCE_AUTH_NONE => {}
+        CUSTOM_BALANCE_AUTH_BALANCE_BEARER => {
+            let access_token = balance_secret
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| provider_secret.trim());
+            if access_token.is_empty() {
+                return Err("custom balance access token is required".to_string());
+            }
+            builder = builder.bearer_auth(access_token);
+        }
+        _ => {
+            let access_token = provider_secret.trim();
+            if access_token.is_empty() {
+                return Err("aggregate api secret is required".to_string());
+            }
+            builder = builder.bearer_auth(access_token);
+        }
+    }
+    let response = builder.send().map_err(|err| err.to_string())?;
+    let value = read_json_response(response)?;
+    extract_custom_balance(&value, &config)
+}
+
+fn query_new_api_balance(
+    client: &reqwest::blocking::Client,
+    api: &AggregateApi,
+    provider_secret: &str,
+    balance_secret: Option<String>,
+) -> Result<AggregateApiBalanceSnapshot, String> {
+    let base_url = balance_query_base_url(api, AGGREGATE_API_BALANCE_TEMPLATE_NEW_API);
+    let url = join_api_path(base_url.as_str(), "/api/user/self");
+    let access_token = balance_secret
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| provider_secret.trim());
+    if access_token.is_empty() {
+        return Err("balance access token is required".to_string());
+    }
+    let mut builder = client
+        .get(url.as_str())
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .header("accept-encoding", "identity")
+        .header("user-agent", "codex-manager/aggregate-api-balance")
+        .bearer_auth(access_token);
+    if let Some(user_id) = api
+        .balance_query_user_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        builder = builder.header("New-Api-User", user_id);
+    }
+    let response = builder.send().map_err(|err| err.to_string())?;
+    let value = read_json_response(response)?;
+    extract_new_api_balance(&value)
 }
 
 /// 函数 `build_claude_probe_body`
@@ -1465,6 +2299,15 @@ pub(crate) fn list_aggregate_apis() -> Result<Vec<AggregateApiSummary>, String> 
             last_test_at: item.last_test_at,
             last_test_status: item.last_test_status,
             last_test_error: item.last_test_error,
+            balance_query_enabled: item.balance_query_enabled,
+            balance_query_template: item.balance_query_template,
+            balance_query_base_url: item.balance_query_base_url,
+            balance_query_user_id: item.balance_query_user_id,
+            balance_query_config_json: item.balance_query_config_json,
+            last_balance_at: item.last_balance_at,
+            last_balance_status: item.last_balance_status,
+            last_balance_error: item.last_balance_error,
+            last_balance_json: item.last_balance_json,
         })
         .collect())
 }
@@ -1494,6 +2337,12 @@ pub(crate) fn create_aggregate_api(
     model_override: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    balance_query_enabled: Option<bool>,
+    balance_query_template: Option<String>,
+    balance_query_base_url: Option<String>,
+    balance_query_access_token: Option<String>,
+    balance_query_user_id: Option<String>,
+    balance_query_config_json: Option<String>,
 ) -> Result<AggregateApiCreateResult, String> {
     let storage = open_storage().ok_or_else(|| "storage unavailable".to_string())?;
     let normalized_provider_type = normalize_provider_type(provider_type)?;
@@ -1510,6 +2359,22 @@ pub(crate) fn create_aggregate_api(
     let normalized_action =
         normalize_action_override(action_custom_enabled, action)?.unwrap_or(None);
     let normalized_model_override = normalize_model_override(model_override)?;
+    let normalized_balance_query_enabled = balance_query_enabled.unwrap_or(false);
+    let normalized_balance_query_template = if normalized_balance_query_enabled {
+        Some(default_balance_query_template(
+            normalize_balance_query_template(balance_query_template)?,
+        ))
+    } else {
+        normalize_balance_query_template(balance_query_template)?
+    };
+    let normalized_balance_query_base_url =
+        normalize_optional_url(balance_query_base_url, "balanceQueryBaseUrl")?;
+    let normalized_balance_query_access_token = normalize_secret(balance_query_access_token);
+    let normalized_balance_query_user_id = normalize_optional_text(balance_query_user_id);
+    let normalized_balance_query_config_json = normalize_balance_query_config_json(
+        normalized_balance_query_template.as_deref(),
+        balance_query_config_json,
+    )?;
     let normalized_secret = if normalized_auth_type == AGGREGATE_API_AUTH_APIKEY {
         normalize_secret(key).ok_or_else(|| "key is required".to_string())?
     } else {
@@ -1545,6 +2410,15 @@ pub(crate) fn create_aggregate_api(
         last_test_at: None,
         last_test_status: None,
         last_test_error: None,
+        balance_query_enabled: normalized_balance_query_enabled,
+        balance_query_template: normalized_balance_query_template,
+        balance_query_base_url: normalized_balance_query_base_url,
+        balance_query_user_id: normalized_balance_query_user_id,
+        balance_query_config_json: normalized_balance_query_config_json,
+        last_balance_at: None,
+        last_balance_status: None,
+        last_balance_error: None,
+        last_balance_json: None,
     };
     storage
         .insert_aggregate_api(&record)
@@ -1552,6 +2426,14 @@ pub(crate) fn create_aggregate_api(
     if let Err(err) = storage.upsert_aggregate_api_secret(&id, &normalized_secret) {
         let _ = storage.delete_aggregate_api(&id);
         return Err(format!("persist aggregate api secret failed: {err}"));
+    }
+    if let Some(access_token) = normalized_balance_query_access_token {
+        if let Err(err) = storage.upsert_aggregate_api_balance_secret(&id, &access_token) {
+            let _ = storage.delete_aggregate_api(&id);
+            return Err(format!(
+                "persist aggregate api balance secret failed: {err}"
+            ));
+        }
     }
     Ok(AggregateApiCreateResult {
         id,
@@ -1590,6 +2472,12 @@ pub(crate) fn update_aggregate_api(
     model_override: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    balance_query_enabled: Option<bool>,
+    balance_query_template: Option<String>,
+    balance_query_base_url: Option<String>,
+    balance_query_access_token: Option<String>,
+    balance_query_user_id: Option<String>,
+    balance_query_config_json: Option<String>,
 ) -> Result<(), String> {
     if api_id.is_empty() {
         return Err("aggregate api id required".to_string());
@@ -1676,6 +2564,81 @@ pub(crate) fn update_aggregate_api(
         let normalized = normalize_model_override(model_override)?;
         storage
             .update_aggregate_api_model_override(api_id, normalized.as_deref())
+            .map_err(|err| err.to_string())?;
+    }
+
+    let balance_query_base_url_provided = balance_query_base_url.is_some();
+    let balance_query_user_id_provided = balance_query_user_id.is_some();
+    let balance_query_config_json_provided = balance_query_config_json.is_some();
+    let normalized_balance_query_template =
+        normalize_balance_query_template(balance_query_template)?;
+    let normalized_balance_query_base_url =
+        normalize_optional_url(balance_query_base_url, "balanceQueryBaseUrl")?;
+    let normalized_balance_query_access_token = normalize_secret(balance_query_access_token);
+    let normalized_balance_query_user_id = normalize_optional_text(balance_query_user_id);
+    let normalized_balance_query_config_json = if balance_query_config_json_provided {
+        normalize_balance_query_config_json(
+            normalized_balance_query_template
+                .as_deref()
+                .or(existing.balance_query_template.as_deref()),
+            balance_query_config_json,
+        )?
+    } else {
+        None
+    };
+    if balance_query_enabled.is_some()
+        || normalized_balance_query_template.is_some()
+        || balance_query_base_url_provided
+        || balance_query_user_id_provided
+        || balance_query_config_json_provided
+    {
+        let next_enabled = balance_query_enabled.unwrap_or(existing.balance_query_enabled);
+        let next_template = if next_enabled {
+            Some(default_balance_query_template(
+                normalized_balance_query_template.or(existing.balance_query_template.clone()),
+            ))
+        } else {
+            normalized_balance_query_template.or(existing.balance_query_template.clone())
+        };
+        let next_base_url = if balance_query_base_url_provided {
+            normalized_balance_query_base_url
+        } else {
+            existing.balance_query_base_url
+        };
+        let next_user_id = if balance_query_user_id_provided {
+            normalized_balance_query_user_id
+        } else {
+            existing.balance_query_user_id
+        };
+        let next_config_json = if balance_query_config_json_provided {
+            normalized_balance_query_config_json
+        } else if next_template.as_deref() == Some(AGGREGATE_API_BALANCE_TEMPLATE_CUSTOM) {
+            normalize_balance_query_config_json(
+                next_template.as_deref(),
+                existing.balance_query_config_json,
+            )?
+        } else {
+            None
+        };
+        storage
+            .update_aggregate_api_balance_query(
+                api_id,
+                next_enabled,
+                next_template.as_deref(),
+                next_base_url.as_deref(),
+                next_user_id.as_deref(),
+                next_config_json.as_deref(),
+            )
+            .map_err(|err| err.to_string())?;
+    }
+    if let Some(access_token) = normalized_balance_query_access_token {
+        storage
+            .upsert_aggregate_api_balance_secret(api_id, &access_token)
+            .map_err(|err| err.to_string())?;
+    }
+    if let Some(false) = balance_query_enabled {
+        storage
+            .delete_aggregate_api_balance_secret(api_id)
             .map_err(|err| err.to_string())?;
     }
 
@@ -1833,4 +2796,86 @@ pub(crate) fn test_aggregate_api_connection(
         tested_at: now_ts(),
         latency_ms: started_at.elapsed().as_millis() as i64,
     })
+}
+
+pub(crate) fn refresh_aggregate_api_balance(
+    api_id: &str,
+) -> Result<AggregateApiBalanceRefreshResult, String> {
+    if api_id.is_empty() {
+        return Err("aggregate api id required".to_string());
+    }
+    let storage = open_storage().ok_or_else(|| "storage unavailable".to_string())?;
+    let api = storage
+        .find_aggregate_api_by_id(api_id)
+        .map_err(|err| err.to_string())?
+        .ok_or_else(|| "aggregate api not found".to_string())?;
+    if !api.balance_query_enabled {
+        return Err("aggregate api balance query is disabled".to_string());
+    }
+    let provider_secret = storage
+        .find_aggregate_api_secret_by_id(api_id)
+        .map_err(|err| err.to_string())?
+        .ok_or_else(|| "aggregate api secret not found".to_string())?;
+    let balance_secret = storage
+        .find_aggregate_api_balance_secret_by_id(api_id)
+        .map_err(|err| err.to_string())?;
+    let template = default_balance_query_template(normalize_balance_query_template(
+        api.balance_query_template.clone(),
+    )?);
+    let client = gateway::fresh_upstream_client();
+    let started_at = Instant::now();
+    let result = match template.as_str() {
+        AGGREGATE_API_BALANCE_TEMPLATE_NEW_API => {
+            query_new_api_balance(&client, &api, &provider_secret, balance_secret)
+        }
+        AGGREGATE_API_BALANCE_TEMPLATE_CUSTOM => {
+            query_custom_balance(&client, &api, &provider_secret, balance_secret)
+        }
+        _ => query_generic_balance(&client, &api, &provider_secret),
+    };
+    let queried_at = now_ts();
+    let latency_ms = started_at.elapsed().as_millis() as i64;
+
+    match result {
+        Ok(snapshot) => {
+            let ok = snapshot.is_valid;
+            let message = if ok {
+                None
+            } else {
+                snapshot
+                    .invalid_message
+                    .clone()
+                    .or_else(|| Some("balance query returned invalid account".to_string()))
+            };
+            let balance_json = serde_json::to_string(&snapshot)
+                .map_err(|_| "serialize balance result failed".to_string())?;
+            let _ = storage.update_aggregate_api_balance_result(
+                api_id,
+                ok,
+                Some(balance_json.as_str()),
+                message.as_deref(),
+            );
+            Ok(AggregateApiBalanceRefreshResult {
+                id: api_id.to_string(),
+                ok,
+                balance: Some(snapshot),
+                message,
+                queried_at,
+                latency_ms,
+            })
+        }
+        Err(err) => {
+            let message = format!("template={template}; {err}");
+            let _ =
+                storage.update_aggregate_api_balance_result(api_id, false, None, Some(&message));
+            Ok(AggregateApiBalanceRefreshResult {
+                id: api_id.to_string(),
+                ok: false,
+                balance: None,
+                message: Some(message),
+                queried_at,
+                latency_ms,
+            })
+        }
+    }
 }

--- a/crates/service/src/gateway/upstream/protocol/aggregate_api.rs
+++ b/crates/service/src/gateway/upstream/protocol/aggregate_api.rs
@@ -1166,6 +1166,15 @@ mod bridge_tests {
             last_test_at: None,
             last_test_status: None,
             last_test_error: None,
+            balance_query_enabled: false,
+            balance_query_template: None,
+            balance_query_base_url: None,
+            balance_query_user_id: None,
+            balance_query_config_json: None,
+            last_balance_at: None,
+            last_balance_status: None,
+            last_balance_error: None,
+            last_balance_json: None,
         }
     }
 
@@ -1337,6 +1346,15 @@ mod tests {
             last_test_at: None,
             last_test_status: None,
             last_test_error: None,
+            balance_query_enabled: false,
+            balance_query_template: None,
+            balance_query_base_url: None,
+            balance_query_user_id: None,
+            balance_query_config_json: None,
+            last_balance_at: None,
+            last_balance_status: None,
+            last_balance_error: None,
+            last_balance_json: None,
         }
     }
 
@@ -1420,6 +1438,15 @@ mod tests {
                     last_test_at: None,
                     last_test_status: None,
                     last_test_error: None,
+                    balance_query_enabled: false,
+                    balance_query_template: None,
+                    balance_query_base_url: None,
+                    balance_query_user_id: None,
+                    balance_query_config_json: None,
+                    last_balance_at: None,
+                    last_balance_status: None,
+                    last_balance_error: None,
+                    last_balance_json: None,
                 })
                 .expect("insert aggregate api");
         }

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -31,7 +31,7 @@ pub(crate) use account::update as account_update;
 pub(crate) use account::warmup as account_warmup;
 pub(crate) use aggregate_api::{
     create_aggregate_api, delete_aggregate_api, list_aggregate_apis, read_aggregate_api_secret,
-    test_aggregate_api_connection, update_aggregate_api,
+    refresh_aggregate_api_balance, test_aggregate_api_connection, update_aggregate_api,
 };
 pub(crate) use apikey::create as apikey_create;
 pub(crate) use apikey::delete as apikey_delete;

--- a/crates/service/src/rpc_dispatch/aggregate_api.rs
+++ b/crates/service/src/rpc_dispatch/aggregate_api.rs
@@ -2,7 +2,7 @@ use codexmanager_core::rpc::types::{AggregateApiListResult, JsonRpcRequest, Json
 
 use crate::{
     create_aggregate_api, delete_aggregate_api, list_aggregate_apis, read_aggregate_api_secret,
-    test_aggregate_api_connection, update_aggregate_api,
+    refresh_aggregate_api_balance, test_aggregate_api_connection, update_aggregate_api,
 };
 
 /// 函数 `api_id_param`
@@ -54,6 +54,12 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
             let model_override = super::string_param(req, "modelOverride");
             let username = super::string_param(req, "username");
             let password = super::string_param(req, "password");
+            let balance_query_enabled = super::bool_param(req, "balanceQueryEnabled");
+            let balance_query_template = super::string_param(req, "balanceQueryTemplate");
+            let balance_query_base_url = super::string_param(req, "balanceQueryBaseUrl");
+            let balance_query_access_token = super::string_param(req, "balanceQueryAccessToken");
+            let balance_query_user_id = super::string_param(req, "balanceQueryUserId");
+            let balance_query_config_json = super::string_param(req, "balanceQueryConfigJson");
             super::value_or_error(create_aggregate_api(
                 url,
                 key,
@@ -68,6 +74,12 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
                 model_override,
                 username,
                 password,
+                balance_query_enabled,
+                balance_query_template,
+                balance_query_base_url,
+                balance_query_access_token,
+                balance_query_user_id,
+                balance_query_config_json,
             ))
         }
         "aggregateApi/update" => {
@@ -90,6 +102,12 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
             let model_override = super::string_param(req, "modelOverride");
             let username = super::string_param(req, "username");
             let password = super::string_param(req, "password");
+            let balance_query_enabled = super::bool_param(req, "balanceQueryEnabled");
+            let balance_query_template = super::string_param(req, "balanceQueryTemplate");
+            let balance_query_base_url = super::string_param(req, "balanceQueryBaseUrl");
+            let balance_query_access_token = super::string_param(req, "balanceQueryAccessToken");
+            let balance_query_user_id = super::string_param(req, "balanceQueryUserId");
+            let balance_query_config_json = super::string_param(req, "balanceQueryConfigJson");
             super::ok_or_error(update_aggregate_api(
                 api_id,
                 url,
@@ -106,6 +124,12 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
                 model_override,
                 username,
                 password,
+                balance_query_enabled,
+                balance_query_template,
+                balance_query_base_url,
+                balance_query_access_token,
+                balance_query_user_id,
+                balance_query_config_json,
             ))
         }
         "aggregateApi/readSecret" => {
@@ -119,6 +143,10 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
         "aggregateApi/testConnection" => {
             let api_id = api_id_param(req).unwrap_or("");
             super::value_or_error(test_aggregate_api_connection(api_id))
+        }
+        "aggregateApi/refreshBalance" => {
+            let api_id = api_id_param(req).unwrap_or("");
+            super::value_or_error(refresh_aggregate_api_balance(api_id))
         }
         _ => return None,
     };


### PR DESCRIPTION
## Summary
- add aggregate API balance query storage/RPC fields and refresh endpoint
- show balance status/actions in the aggregate API page
- add built-in generic, One API/New API panel, and custom balance query templates
- make generic balance checks fallback from `/user/balance` to `/v1/usage`
- harden web runtime probing so `/api/runtime` transient failures recover automatically

## Notes
- custom templates are restricted to relative paths and simple dot JSON paths

Closes qxcnm/Codex-Manager#163

## Validation
- `pnpm -C apps run build:desktop`
- `pnpm -C apps exec eslint src/components/modals/aggregate-api-modal.tsx`
- `pnpm -C apps run test:runtime`
- `cargo test -p codexmanager-service generic_balance_extractor_accepts_usage_balance_shape -- --nocapture`
- `cargo test -p codexmanager-core migrations -- --nocapture`
- `cargo check -p codexmanager-service`
- local RPC refresh verified through the generic fallback path