### PR TITLE
[codex] Auto-refresh usage after account add

### DIFF
--- a/apps/src/lib/api/usage-refresh-events.ts
+++ b/apps/src/lib/api/usage-refresh-events.ts
@@ -23,6 +23,20 @@ function readUsageRefreshEventPayload(event: Event): UsageRefreshCompletedPayloa
   return {};
 }
 
+function readUsageRefreshMessagePayload(event: MessageEvent): UsageRefreshCompletedPayload {
+  if (typeof event.data !== "string" || !event.data.trim()) {
+    return {};
+  }
+  try {
+    const payload = JSON.parse(event.data);
+    return typeof payload === "object" && payload
+      ? (payload as UsageRefreshCompletedPayload)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
 export async function listenUsageRefreshCompleted(
   handler: UsageRefreshCompletedHandler
 ): Promise<Unlisten> {
@@ -34,6 +48,23 @@ export async function listenUsageRefreshCompleted(
     handler(readUsageRefreshEventPayload(event));
   };
   window.addEventListener(USAGE_REFRESH_COMPLETED_EVENT, handleWindowEvent);
+
+  let eventSource: EventSource | null = null;
+  let handleEventSourceEvent: ((event: MessageEvent) => void) | null = null;
+  if (
+    !isTauriRuntime() &&
+    typeof EventSource !== "undefined" &&
+    window.location.protocol.startsWith("http")
+  ) {
+    eventSource = new EventSource("/api/events/usage-refresh");
+    handleEventSourceEvent = (event: MessageEvent) => {
+      handler(readUsageRefreshMessagePayload(event));
+    };
+    eventSource.addEventListener(
+      USAGE_REFRESH_COMPLETED_EVENT,
+      handleEventSourceEvent as EventListener
+    );
+  }
 
   let unlistenTauri: Unlisten | null = null;
   if (isTauriRuntime()) {
@@ -48,6 +79,13 @@ export async function listenUsageRefreshCompleted(
 
   return () => {
     window.removeEventListener(USAGE_REFRESH_COMPLETED_EVENT, handleWindowEvent);
+    if (eventSource && handleEventSourceEvent) {
+      eventSource.removeEventListener(
+        USAGE_REFRESH_COMPLETED_EVENT,
+        handleEventSourceEvent as EventListener
+      );
+    }
+    eventSource?.close();
     unlistenTauri?.();
   };
 }

--- a/crates/service/src/account/account_import.rs
+++ b/crates/service/src/account/account_import.rs
@@ -45,6 +45,12 @@ struct ImportTokenPayload {
     chatgpt_account_id_hint: Option<String>,
 }
 
+#[derive(Debug)]
+struct ImportedAccount {
+    account_id: String,
+    created: bool,
+}
+
 #[derive(Debug, Default)]
 struct ImportAccountMeta {
     label: Option<String>,
@@ -420,14 +426,17 @@ fn import_items_in_batches(
         for item in batch {
             result.total += 1;
             let current_index = result.total;
-            match import_single_item(storage, index, item, current_index) {
-                Ok(created) => {
-                    if created {
+            match import_single_item_with_account_id(storage, index, item, current_index) {
+                Ok(imported) => {
+                    if imported.created {
                         result.created += 1;
                     } else {
                         result.updated += 1;
                     }
-                    progress.on_item_success(created);
+                    progress.on_item_success(imported.created);
+                    let _ = crate::usage_refresh::enqueue_usage_refresh_after_account_add(
+                        &imported.account_id,
+                    );
                 }
                 Err(err) => {
                     result.failed += 1;
@@ -689,12 +698,23 @@ fn parse_items_from_content(content: &str) -> Result<Vec<Value>, String> {
 ///
 /// # 返回
 /// 返回函数执行结果
+#[cfg(test)]
 fn import_single_item(
     storage: &Storage,
     index: &mut ExistingAccountIndex,
     item: &Value,
     sequence: usize,
 ) -> Result<bool, String> {
+    import_single_item_with_account_id(storage, index, item, sequence)
+        .map(|imported| imported.created)
+}
+
+fn import_single_item_with_account_id(
+    storage: &Storage,
+    index: &mut ExistingAccountIndex,
+    item: &Value,
+    sequence: usize,
+) -> Result<ImportedAccount, String> {
     let payload = extract_token_payload(&item)?;
     let meta = extract_account_meta(item);
     let claims = parse_id_token_claims(&payload.id_token).ok();
@@ -868,7 +888,10 @@ fn import_single_item(
     storage.insert_token(&token).map_err(|e| e.to_string())?;
     index.upsert_index(&account);
     index.index_token_subject(&account, &token);
-    Ok(created)
+    Ok(ImportedAccount {
+        account_id,
+        created,
+    })
 }
 
 /// 函数 `extract_import_subject_account_id`

--- a/crates/service/src/auth/auth_account.rs
+++ b/crates/service/src/auth/auth_account.rs
@@ -211,6 +211,7 @@ pub(crate) fn login_with_chatgpt_auth_tokens(
 
     set_current_auth_account_id(Some(&account_id))?;
     set_current_auth_mode(Some(AUTH_MODE_CHATGPT_AUTH_TOKENS))?;
+    let _ = crate::usage_refresh::enqueue_usage_refresh_after_account_add(&account_id);
 
     Ok(LoginStartResult::ChatgptAuthTokens {})
 }

--- a/crates/service/src/auth/auth_tokens.rs
+++ b/crates/service/src/auth/auth_tokens.rs
@@ -1238,6 +1238,7 @@ pub(crate) fn complete_login_with_redirect(
         .map_err(|e| e.to_string())?;
     crate::auth_account::set_current_auth_account_id(Some(&account_key))?;
     crate::auth_account::set_current_auth_mode(Some("chatgpt"))?;
+    let _ = crate::usage_refresh::enqueue_usage_refresh_after_account_add(&account_key);
     Ok(())
 }
 

--- a/crates/service/src/http/backend_router.rs
+++ b/crates/service/src/http/backend_router.rs
@@ -4,6 +4,7 @@ use tiny_http::Request;
 pub(crate) enum BackendRoute {
     Rpc,
     AuthCallback,
+    UsageRefreshEvents,
     Metrics,
     Gateway,
 }
@@ -25,6 +26,9 @@ pub(crate) fn resolve_backend_route(method: &str, path: &str) -> BackendRoute {
     }
     if method == "GET" && path.starts_with("/auth/callback") {
         return BackendRoute::AuthCallback;
+    }
+    if method == "GET" && path == "/events/usage-refresh" {
+        return BackendRoute::UsageRefreshEvents;
     }
     if method == "GET" && path == "/metrics" {
         return BackendRoute::Metrics;
@@ -48,6 +52,9 @@ pub(crate) fn handle_backend_request(request: Request) {
     match route {
         BackendRoute::Rpc => crate::http::rpc_endpoint::handle_rpc(request),
         BackendRoute::AuthCallback => crate::http::callback_endpoint::handle_callback(request),
+        BackendRoute::UsageRefreshEvents => {
+            crate::http::usage_events::handle_usage_refresh_events(request)
+        }
         BackendRoute::Metrics => crate::http::gateway_endpoint::handle_metrics(request),
         BackendRoute::Gateway => crate::http::gateway_endpoint::handle_gateway(request),
     }

--- a/crates/service/src/http/mod.rs
+++ b/crates/service/src/http/mod.rs
@@ -2,6 +2,7 @@ pub mod callback_endpoint;
 pub mod gateway_endpoint;
 pub mod rpc_endpoint;
 pub mod server;
+pub(crate) mod usage_events;
 
 pub(crate) mod backend_router;
 pub(crate) mod backend_runtime;

--- a/crates/service/src/http/proxy_runtime.rs
+++ b/crates/service/src/http/proxy_runtime.rs
@@ -1,7 +1,7 @@
 use axum::body::{to_bytes, Body};
 use axum::extract::State;
 use axum::http::{header, Request as HttpRequest, Response, StatusCode};
-use axum::routing::{any, post};
+use axum::routing::{any, get, post};
 use axum::Router;
 use reqwest::Client;
 use std::io;
@@ -247,6 +247,10 @@ async fn responses_handler(
 fn build_front_proxy_app(state: ProxyState) -> Router {
     Router::new()
         .route("/rpc", post(crate::http::rpc_endpoint::handle_rpc_http))
+        .route(
+            "/events/usage-refresh",
+            get(crate::http::usage_events::handle_usage_refresh_events_http),
+        )
         .route("/v1/responses", any(responses_handler))
         .fallback(any(proxy_handler))
         .with_state(state)

--- a/crates/service/src/http/tests/backend_router_tests.rs
+++ b/crates/service/src/http/tests/backend_router_tests.rs
@@ -35,6 +35,14 @@ fn resolves_auth_callback_route() {
     );
 }
 
+#[test]
+fn resolves_usage_refresh_events_route() {
+    assert_eq!(
+        resolve_backend_route("GET", "/events/usage-refresh"),
+        BackendRoute::UsageRefreshEvents
+    );
+}
+
 /// 函数 `resolves_metrics_route`
 ///
 /// 作者: gaohongshun

--- a/crates/service/src/http/usage_events.rs
+++ b/crates/service/src/http/usage_events.rs
@@ -1,0 +1,208 @@
+use std::convert::Infallible;
+use std::io::{self, Read};
+use std::time::Duration;
+
+use axum::body::{Body, Bytes};
+use axum::http::{
+    HeaderMap as AxumHeaderMap, HeaderValue as AxumHeaderValue, StatusCode as AxumStatusCode,
+};
+use axum::response::{IntoResponse, Response as AxumResponse};
+use crossbeam_channel::{Receiver, RecvTimeoutError};
+use futures_util::stream;
+use tiny_http::{Header, Request, Response, StatusCode};
+
+const EVENT_NAME: &str = "usage-refresh-completed";
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+fn request_header_value<'a>(request: &'a Request, name: &str) -> Option<&'a str> {
+    request
+        .headers()
+        .iter()
+        .find(|header| header.field.as_str().as_str().eq_ignore_ascii_case(name))
+        .map(|header| header.value.as_str().trim())
+        .filter(|value| !value.is_empty())
+}
+
+fn rpc_token_valid(request: &Request) -> bool {
+    request_header_value(request, "X-CodexManager-Rpc-Token")
+        .is_some_and(crate::rpc_auth_token_matches)
+}
+
+fn axum_rpc_token_valid(headers: &AxumHeaderMap) -> bool {
+    headers
+        .get("X-CodexManager-Rpc-Token")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some_and(crate::rpc_auth_token_matches)
+}
+
+fn response_header(name: &'static str, value: &'static str) -> Header {
+    Header::from_bytes(name.as_bytes(), value.as_bytes()).expect("valid static header")
+}
+
+fn usage_refresh_event_data(event: &crate::UsageRefreshCompletedEvent) -> String {
+    serde_json::json!({
+        "source": event.source,
+        "processed": event.processed,
+        "total": event.total,
+        "completed_at": event.completed_at,
+    })
+    .to_string()
+}
+
+fn usage_refresh_sse_frame(event: &crate::UsageRefreshCompletedEvent) -> Vec<u8> {
+    format!(
+        "event: {EVENT_NAME}\ndata: {}\n\n",
+        usage_refresh_event_data(event)
+    )
+    .into_bytes()
+}
+
+fn next_usage_refresh_event_chunk(
+    receiver: Receiver<crate::UsageRefreshCompletedEvent>,
+) -> Option<(Receiver<crate::UsageRefreshCompletedEvent>, Vec<u8>)> {
+    let chunk = match receiver.recv_timeout(KEEPALIVE_INTERVAL) {
+        Ok(event) => usage_refresh_sse_frame(&event),
+        Err(RecvTimeoutError::Timeout) => b": keep-alive\n\n".to_vec(),
+        Err(RecvTimeoutError::Disconnected) => return None,
+    };
+    Some((receiver, chunk))
+}
+
+struct UsageRefreshEventStream {
+    receiver: Receiver<crate::UsageRefreshCompletedEvent>,
+    pending: Vec<u8>,
+    pending_offset: usize,
+    opened: bool,
+}
+
+impl UsageRefreshEventStream {
+    fn new(receiver: Receiver<crate::UsageRefreshCompletedEvent>) -> Self {
+        Self {
+            receiver,
+            pending: Vec::new(),
+            pending_offset: 0,
+            opened: false,
+        }
+    }
+
+    fn refill(&mut self) -> io::Result<bool> {
+        if !self.opened {
+            self.opened = true;
+            self.pending = b": connected\n\n".to_vec();
+            self.pending_offset = 0;
+            return Ok(true);
+        }
+
+        self.pending = match self.receiver.recv_timeout(KEEPALIVE_INTERVAL) {
+            Ok(event) => usage_refresh_sse_frame(&event),
+            Err(RecvTimeoutError::Timeout) => b": keep-alive\n\n".to_vec(),
+            Err(RecvTimeoutError::Disconnected) => return Ok(false),
+        };
+        self.pending_offset = 0;
+        Ok(true)
+    }
+}
+
+impl Read for UsageRefreshEventStream {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if out.is_empty() {
+            return Ok(0);
+        }
+
+        if self.pending_offset >= self.pending.len() && !self.refill()? {
+            return Ok(0);
+        }
+
+        let remaining = &self.pending[self.pending_offset..];
+        let count = remaining.len().min(out.len());
+        out[..count].copy_from_slice(&remaining[..count]);
+        self.pending_offset += count;
+        Ok(count)
+    }
+}
+
+pub(crate) fn handle_usage_refresh_events(request: Request) {
+    if request.method().as_str() != "GET" {
+        let _ = request.respond(Response::from_string("{}").with_status_code(405));
+        return;
+    }
+    if !rpc_token_valid(&request) {
+        let _ = request.respond(Response::from_string("{}").with_status_code(401));
+        return;
+    }
+
+    let receiver = crate::usage_refresh::subscribe_usage_refresh_completed();
+    let headers = vec![
+        response_header("Content-Type", "text/event-stream"),
+        response_header("Cache-Control", "no-cache"),
+        response_header("Connection", "keep-alive"),
+        response_header("X-Accel-Buffering", "no"),
+    ];
+    let response = Response::new(
+        StatusCode(200),
+        headers,
+        UsageRefreshEventStream::new(receiver),
+        None,
+        None,
+    );
+    let _ = request.respond(response);
+}
+
+pub(crate) async fn handle_usage_refresh_events_http(headers: AxumHeaderMap) -> AxumResponse {
+    if !axum_rpc_token_valid(&headers) {
+        return (AxumStatusCode::UNAUTHORIZED, "{}").into_response();
+    }
+
+    let receiver = crate::usage_refresh::subscribe_usage_refresh_completed();
+    let event_stream = stream::unfold((receiver, false), |(receiver, opened)| async move {
+        if !opened {
+            return Some((
+                Ok::<Bytes, Infallible>(Bytes::from_static(b": connected\n\n")),
+                (receiver, true),
+            ));
+        }
+
+        let next = tokio::task::spawn_blocking(move || next_usage_refresh_event_chunk(receiver))
+            .await
+            .ok()
+            .flatten()?;
+        Some((Ok(Bytes::from(next.1)), (next.0, true)))
+    });
+
+    let mut response = AxumResponse::new(Body::from_stream(event_stream));
+    *response.status_mut() = AxumStatusCode::OK;
+    response.headers_mut().insert(
+        "content-type",
+        AxumHeaderValue::from_static("text/event-stream"),
+    );
+    response
+        .headers_mut()
+        .insert("cache-control", AxumHeaderValue::from_static("no-cache"));
+    response
+        .headers_mut()
+        .insert("x-accel-buffering", AxumHeaderValue::from_static("no"));
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_refresh_sse_frame_uses_named_event() {
+        let event = crate::UsageRefreshCompletedEvent {
+            source: "single",
+            processed: 1,
+            total: 1,
+            completed_at: 1775900000,
+        };
+
+        let frame = String::from_utf8(usage_refresh_sse_frame(&event)).expect("utf8 frame");
+
+        assert!(frame.starts_with("event: usage-refresh-completed\n"));
+        assert!(frame.contains("\"source\":\"single\""));
+        assert!(frame.ends_with("\n\n"));
+    }
+}

--- a/crates/service/src/usage/refresh/mod.rs
+++ b/crates/service/src/usage/refresh/mod.rs
@@ -1,7 +1,7 @@
 use codexmanager_core::auth::{extract_token_exp, DEFAULT_CLIENT_ID, DEFAULT_ISSUER};
 use codexmanager_core::storage::{now_ts, Account, Storage, Token};
 use codexmanager_core::usage::parse_usage_snapshot;
-use crossbeam_channel::unbounded;
+use crossbeam_channel::{bounded, unbounded, Receiver, Sender, TrySendError};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -56,6 +56,8 @@ const ENV_USAGE_POLLING_ENABLED: &str = "CODEXMANAGER_USAGE_POLLING_ENABLED";
 const ENV_USAGE_POLL_INTERVAL_SECS: &str = "CODEXMANAGER_USAGE_POLL_INTERVAL_SECS";
 const ENV_USAGE_POLL_BATCH_LIMIT: &str = "CODEXMANAGER_USAGE_POLL_BATCH_LIMIT";
 const ENV_USAGE_POLL_CYCLE_BUDGET_SECS: &str = "CODEXMANAGER_USAGE_POLL_CYCLE_BUDGET_SECS";
+const ENV_AUTO_REFRESH_AFTER_ACCOUNT_ADD: &str =
+    "CODEXMANAGER_AUTO_USAGE_REFRESH_AFTER_ACCOUNT_ADD";
 const ENV_GATEWAY_KEEPALIVE_ENABLED: &str = "CODEXMANAGER_GATEWAY_KEEPALIVE_ENABLED";
 const ENV_GATEWAY_KEEPALIVE_INTERVAL_SECS: &str = "CODEXMANAGER_GATEWAY_KEEPALIVE_INTERVAL_SECS";
 const ENV_TOKEN_REFRESH_POLLING_ENABLED: &str = "CODEXMANAGER_TOKEN_REFRESH_POLLING_ENABLED";
@@ -141,6 +143,9 @@ type UsageRefreshCompletedHandler = Arc<dyn Fn(UsageRefreshCompletedEvent) + Sen
 
 static USAGE_REFRESH_COMPLETED_HANDLER: OnceLock<Mutex<Option<UsageRefreshCompletedHandler>>> =
     OnceLock::new();
+static USAGE_REFRESH_COMPLETED_SUBSCRIBERS: OnceLock<
+    Mutex<Vec<Sender<UsageRefreshCompletedEvent>>>,
+> = OnceLock::new();
 
 pub(crate) use self::batch::refresh_usage_for_all_accounts;
 use self::batch::refresh_usage_for_polling_batch;
@@ -168,18 +173,37 @@ where
     *guard = Some(Arc::new(handler));
 }
 
+pub(crate) fn subscribe_usage_refresh_completed() -> Receiver<UsageRefreshCompletedEvent> {
+    let (sender, receiver) = bounded(32);
+    let subscribers = USAGE_REFRESH_COMPLETED_SUBSCRIBERS.get_or_init(|| Mutex::new(Vec::new()));
+    let mut guard =
+        crate::lock_utils::lock_recover(subscribers, "usage_refresh_completed_subscribers");
+    guard.push(sender);
+    receiver
+}
+
 pub(crate) fn notify_usage_refresh_completed(source: &'static str, processed: usize, total: usize) {
+    let event = UsageRefreshCompletedEvent {
+        source,
+        processed,
+        total,
+        completed_at: now_ts(),
+    };
     let handler = USAGE_REFRESH_COMPLETED_HANDLER.get().and_then(|slot| {
         let guard = crate::lock_utils::lock_recover(slot, "usage_refresh_completed_handler");
         guard.clone()
     });
 
     if let Some(handler) = handler {
-        handler(UsageRefreshCompletedEvent {
-            source,
-            processed,
-            total,
-            completed_at: now_ts(),
+        handler(event.clone());
+    }
+
+    if let Some(subscribers) = USAGE_REFRESH_COMPLETED_SUBSCRIBERS.get() {
+        let mut guard =
+            crate::lock_utils::lock_recover(subscribers, "usage_refresh_completed_subscribers");
+        guard.retain(|sender| match sender.try_send(event.clone()) {
+            Ok(()) | Err(TrySendError::Full(_)) => true,
+            Err(TrySendError::Disconnected(_)) => false,
         });
     }
 }
@@ -290,6 +314,32 @@ pub(crate) fn enqueue_usage_refresh_for_account(account_id: &str) -> bool {
             );
         }
     })
+}
+
+pub(crate) fn enqueue_usage_refresh_after_account_add(account_id: &str) -> bool {
+    if !auto_refresh_after_account_add_enabled() {
+        return false;
+    }
+    let queued = enqueue_usage_refresh_for_account(account_id);
+    if queued {
+        log::info!("queued usage refresh after account add: account_id={account_id}");
+    }
+    queued
+}
+
+fn auto_refresh_after_account_add_enabled() -> bool {
+    env_bool_or(ENV_AUTO_REFRESH_AFTER_ACCOUNT_ADD, true)
+}
+
+fn env_bool_or(name: &str, default: bool) -> bool {
+    let Some(raw) = std::env::var(name).ok() else {
+        return default;
+    };
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => true,
+        "0" | "false" | "no" | "off" => false,
+        _ => default,
+    }
 }
 
 /// 函数 `reset_usage_poll_cursor_for_tests`

--- a/crates/service/src/usage/tests/usage_refresh_tests.rs
+++ b/crates/service/src/usage/tests/usage_refresh_tests.rs
@@ -2,8 +2,9 @@ use super::{
     clear_pending_usage_refresh_tasks_for_tests, enqueue_usage_refresh_with_worker,
     next_usage_poll_cursor, notify_usage_refresh_completed, reset_usage_poll_cursor_for_tests,
     resolve_token_refresh_issuer, run_token_refresh_task, set_usage_refresh_completed_handler,
-    should_retry_usage_refresh_with_token, token_refresh_access_exp_cutoff,
-    token_refresh_due_cutoff, token_refresh_schedule, usage_poll_batch_indices,
+    should_retry_usage_refresh_with_token, subscribe_usage_refresh_completed,
+    token_refresh_access_exp_cutoff, token_refresh_due_cutoff, token_refresh_schedule,
+    usage_poll_batch_indices,
 };
 use codexmanager_core::storage::{now_ts, Account, Storage, Token};
 use std::collections::HashSet;
@@ -25,6 +26,21 @@ fn usage_refresh_completed_handler_receives_notification() {
     assert_eq!(event.source, "test-notify");
     assert_eq!(event.processed, 2);
     assert_eq!(event.total, 3);
+    assert!(event.completed_at > 0);
+}
+
+#[test]
+fn usage_refresh_completed_subscriber_receives_notification() {
+    let _guard = crate::test_env_guard();
+    let rx = subscribe_usage_refresh_completed();
+
+    notify_usage_refresh_completed("test-subscribe", 1, 1);
+    let event = rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("usage refresh completed event");
+    assert_eq!(event.source, "test-subscribe");
+    assert_eq!(event.processed, 1);
+    assert_eq!(event.total, 1);
     assert!(event.completed_at > 0);
 }
 

--- a/crates/service/src/usage/usage_refresh.rs
+++ b/crates/service/src/usage/usage_refresh.rs
@@ -2,9 +2,10 @@
 mod refresh;
 
 pub(crate) use refresh::{
-    background_tasks_settings, enqueue_usage_refresh_for_account, ensure_gateway_keepalive,
-    ensure_token_refresh_polling, ensure_usage_polling, refresh_usage_for_account,
-    refresh_usage_for_all_accounts, reload_background_tasks_runtime_from_env,
-    set_background_tasks_settings, BackgroundTasksSettingsPatch,
+    background_tasks_settings, enqueue_usage_refresh_after_account_add,
+    enqueue_usage_refresh_for_account, ensure_gateway_keepalive, ensure_token_refresh_polling,
+    ensure_usage_polling, refresh_usage_for_account, refresh_usage_for_all_accounts,
+    reload_background_tasks_runtime_from_env, set_background_tasks_settings,
+    subscribe_usage_refresh_completed, BackgroundTasksSettingsPatch,
 };
 pub use refresh::{set_usage_refresh_completed_handler, UsageRefreshCompletedEvent};

--- a/crates/service/tests/rpc.rs
+++ b/crates/service/tests/rpc.rs
@@ -39,6 +39,7 @@ fn new_test_dir(prefix: &str) -> PathBuf {
 struct RpcTestContext {
     _env_lock: MutexGuard<'static, ()>,
     _db_path_guard: EnvGuard,
+    _auto_usage_refresh_guard: EnvGuard,
     dir: PathBuf,
 }
 
@@ -60,9 +61,12 @@ impl RpcTestContext {
         let db_path = dir.join("codexmanager.db");
         let db_path_guard =
             EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+        let auto_usage_refresh_guard =
+            EnvGuard::set("CODEXMANAGER_AUTO_USAGE_REFRESH_AFTER_ACCOUNT_ADD", "0");
         Self {
             _env_lock: env_lock,
             _db_path_guard: db_path_guard,
+            _auto_usage_refresh_guard: auto_usage_refresh_guard,
             dir,
         }
     }
@@ -1750,6 +1754,107 @@ fn rpc_chatgpt_auth_tokens_login_read_logout_roundtrip() {
         .expect("find account")
         .expect("account exists");
     assert_eq!(account.status, "inactive");
+}
+
+#[test]
+fn rpc_chatgpt_auth_tokens_login_enqueues_usage_refresh() {
+    let ctx = RpcTestContext::new("rpc-chatgpt-auth-tokens-login-auto-usage-refresh");
+    let access_token = build_access_token(
+        "sub-usage-refresh",
+        "usage-refresh@example.com",
+        "org-usage-refresh",
+        "pro",
+    );
+    let subscription_response = serde_json::json!({
+        "id": "sub-record-usage-refresh",
+        "plan_type": "plus",
+        "active_until": "2026-05-06T03:31:29Z",
+        "next_credit_grant_update": "2026-04-20T03:31:29Z",
+        "will_renew": true
+    });
+    let usage_response = serde_json::json!({
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 25.0,
+                "limit_window_seconds": 18000,
+                "reset_at": 1776655889
+            },
+            "secondary_window": {
+                "used_percent": 10.0,
+                "limit_window_seconds": 604800,
+                "reset_at": 1778038289
+            }
+        }
+    });
+    let (usage_base_url, request_rx, request_join) = start_mock_usage_refresh_server(
+        serde_json::to_string(&subscription_response)
+            .expect("serialize auto usage refresh subscription response"),
+        serde_json::to_string(&usage_response).expect("serialize auto usage response"),
+    );
+    let _auto_refresh_guard =
+        EnvGuard::set("CODEXMANAGER_AUTO_USAGE_REFRESH_AFTER_ACCOUNT_ADD", "1");
+    let _usage_base_url_guard = EnvGuard::set("CODEXMANAGER_USAGE_BASE_URL", &usage_base_url);
+
+    let login_req = JsonRpcRequest {
+        id: 46.into(),
+        method: "account/login/start".to_string(),
+        params: Some(serde_json::json!({
+            "type": "chatgptAuthTokens",
+            "accessToken": access_token.clone(),
+            "chatgptAccountId": "org-usage-refresh"
+        })),
+        trace: None,
+    };
+    let login_json = serde_json::to_string(&login_req).expect("serialize login");
+    let login_server = codexmanager_service::start_one_shot_server().expect("start server");
+    let login_resp = post_rpc(&login_server.addr, &login_json);
+    let login_result = login_resp.get("result").expect("login result");
+    assert_eq!(
+        login_result.get("type").and_then(|value| value.as_str()),
+        Some("chatgptAuthTokens")
+    );
+
+    let first_request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("receive auto subscription request");
+    let second_request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("receive auto usage request");
+    request_join.join().expect("join auto usage refresh server");
+
+    assert_eq!(
+        first_request.path,
+        "/subscriptions?account_id=org-usage-refresh"
+    );
+    assert_eq!(
+        first_request.authorization.as_deref(),
+        Some(format!("Bearer {access_token}").as_str())
+    );
+    assert_eq!(first_request.chatgpt_account_id, None);
+    assert_eq!(second_request.path, "/api/codex/usage");
+    assert_eq!(
+        second_request.authorization.as_deref(),
+        Some(format!("Bearer {access_token}").as_str())
+    );
+    assert_eq!(
+        second_request.chatgpt_account_id.as_deref(),
+        Some("org-usage-refresh")
+    );
+
+    let storage = Storage::open(ctx.db_path()).expect("open db");
+    let account_id = storage
+        .list_accounts()
+        .expect("list accounts")
+        .into_iter()
+        .find(|account| account.chatgpt_account_id.as_deref() == Some("org-usage-refresh"))
+        .map(|account| account.id)
+        .expect("account id");
+    let snapshot = storage
+        .latest_usage_snapshot_for_account(&account_id)
+        .expect("find usage snapshot")
+        .expect("usage snapshot exists");
+    assert_eq!(snapshot.used_percent, Some(25.0));
+    assert_eq!(snapshot.secondary_used_percent, Some(10.0));
 }
 
 /// 函数 `rpc_chatgpt_auth_tokens_refresh_updates_access_token`

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -506,6 +506,10 @@ async fn async_main() {
 
     let mut protected_app = Router::new()
         .route("/api/rpc", post(service_gateway::rpc_proxy))
+        .route(
+            "/api/events/usage-refresh",
+            get(service_gateway::usage_refresh_events),
+        )
         .route("/__quit", get(service_gateway::quit));
 
     let disk_ok = ensure_index_file(&index);

--- a/crates/web/src/service_gateway.rs
+++ b/crates/web/src/service_gateway.rs
@@ -374,6 +374,41 @@ pub(super) async fn author_content(State(state): State<Arc<AppState>>) -> Respon
     out
 }
 
+pub(super) async fn usage_refresh_events(State(state): State<Arc<AppState>>) -> Response {
+    let target_url = format!("http://{}/events/usage-refresh", state.service_addr.trim());
+    let resp = state
+        .client
+        .get(&target_url)
+        .header("accept", "text/event-stream")
+        .header("x-codexmanager-rpc-token", &state.rpc_token)
+        .send()
+        .await;
+    let resp = match resp {
+        Ok(value) => value,
+        Err(err) => {
+            let msg = format_upstream_error_message(state.service_addr.as_str(), &err);
+            return (StatusCode::BAD_GATEWAY, msg).into_response();
+        }
+    };
+
+    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let mut out = Response::new(Body::from_stream(resp.bytes_stream()));
+    *out.status_mut() = status;
+    out.headers_mut().insert(
+        "content-type",
+        axum::http::HeaderValue::from_static("text/event-stream"),
+    );
+    out.headers_mut().insert(
+        "cache-control",
+        axum::http::HeaderValue::from_static("no-cache"),
+    );
+    out.headers_mut().insert(
+        "x-accel-buffering",
+        axum::http::HeaderValue::from_static("no"),
+    );
+    out
+}
+
 const GATEWAY_PROXY_MAX_BODY_BYTES: usize = 256 * 1024 * 1024;
 
 /// 函数 `gateway_proxy_target_url`


### PR DESCRIPTION
## Summary

Fixes #187.

This PR keeps account add/import/login fast, then refreshes account usage in the background so newly authorized or imported ChatGPT accounts get quota and availability state populated without a manual refresh.

## What changed

- Enqueue a deduplicated usage refresh after OAuth completion, `chatgptAuthTokens` login, and bulk import.
- Add an opt-out env flag: `CODEXMANAGER_AUTO_USAGE_REFRESH_AFTER_ACCOUNT_ADD=0`.
- Broadcast usage-refresh-completed events from the service and expose them to Web UI through SSE.
- Subscribe to the same event in the Web frontend so `/accounts` refetches usage/accounts when the background refresh finishes.
- Add focused tests for the auto-refresh enqueue path and event plumbing.

## Validation

- `cargo check -p codexmanager-service`
- `cargo check -p codexmanager-web`
- `pnpm run build:desktop`
- `cargo test -p codexmanager-service --test rpc rpc_chatgpt_auth_tokens_login_enqueues_usage_refresh -- --nocapture`
- `cargo test -p codexmanager-service usage_refresh_completed_subscriber_receives_notification`
- `cargo test -p codexmanager-service usage_refresh_sse_frame_uses_named_event`
- `cargo test -p codexmanager-service resolves_usage_refresh_events_route`