### PR TITLE
[codex] Fix ccswitch import protocol opening

### DIFF
--- a/apps/src-tauri/src/commands/registry.rs
+++ b/apps/src-tauri/src/commands/registry.rs
@@ -109,6 +109,7 @@ macro_rules! invoke_handler {
             crate::commands::apikey::service_apikey_enable,
             // system
             crate::commands::system::open_in_browser,
+            crate::commands::system::open_external_url,
             crate::commands::system::open_in_file_manager,
             crate::commands::system::app_window_unsaved_draft_sections_set,
             crate::commands::system::app_show_main_window,

--- a/apps/src-tauri/src/commands/shared.rs
+++ b/apps/src-tauri/src/commands/shared.rs
@@ -79,6 +79,83 @@ pub(crate) fn open_in_browser_blocking(url: &str) -> Result<(), String> {
     webbrowser::open(url).map(|_| ()).map_err(|e| e.to_string())
 }
 
+fn validate_external_url(url: &str) -> Result<&str, String> {
+    let normalized = url.trim();
+    if normalized.is_empty() {
+        return Err("缺少外部跳转地址".to_string());
+    }
+
+    let Some(separator_index) = normalized.find(':') else {
+        return Err("外部跳转地址缺少协议".to_string());
+    };
+    if separator_index == 0 {
+        return Err("外部跳转地址协议无效".to_string());
+    }
+
+    let scheme = &normalized[..separator_index];
+    if !scheme
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'.' | b'-'))
+    {
+        return Err("外部跳转地址协议无效".to_string());
+    }
+
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_external_url;
+
+    #[test]
+    fn validate_external_url_accepts_custom_protocols() {
+        assert_eq!(
+            validate_external_url(" ccswitch://v1/import?resource=provider ").unwrap(),
+            "ccswitch://v1/import?resource=provider"
+        );
+    }
+
+    #[test]
+    fn validate_external_url_rejects_missing_or_invalid_protocols() {
+        assert!(validate_external_url("").is_err());
+        assert!(validate_external_url("example.com").is_err());
+        assert!(validate_external_url("bad scheme://example.com").is_err());
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn open_external_url_blocking(url: &str) -> Result<(), String> {
+    open_url_with_shell(validate_external_url(url)?)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn open_external_url_blocking(url: &str) -> Result<(), String> {
+    let normalized = validate_external_url(url)?;
+    let status = std::process::Command::new("open")
+        .arg(normalized)
+        .status()
+        .map_err(|err| format!("启动 open 失败：{err}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("open 退出状态异常：{status}"))
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn open_external_url_blocking(url: &str) -> Result<(), String> {
+    let normalized = validate_external_url(url)?;
+    let status = std::process::Command::new("xdg-open")
+        .arg(normalized)
+        .status()
+        .map_err(|err| format!("启动 xdg-open 失败：{err}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("xdg-open 退出状态异常：{status}"))
+    }
+}
+
 /// 函数 `spawn_background_command`
 ///
 /// 作者: gaohongshun

--- a/apps/src-tauri/src/commands/system.rs
+++ b/apps/src-tauri/src/commands/system.rs
@@ -1,6 +1,8 @@
 use crate::{
     app_shell::{set_unsaved_settings_draft_sections, show_main_window},
-    commands::shared::{open_in_browser_blocking, open_in_file_manager_blocking},
+    commands::shared::{
+        open_external_url_blocking, open_in_browser_blocking, open_in_file_manager_blocking,
+    },
 };
 
 /// 函数 `open_in_browser`
@@ -19,6 +21,13 @@ pub async fn open_in_browser(url: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || open_in_browser_blocking(&url))
         .await
         .map_err(|err| format!("open_in_browser task failed: {err}"))?
+}
+
+#[tauri::command]
+pub async fn open_external_url(url: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || open_external_url_blocking(&url))
+        .await
+        .map_err(|err| format!("open_external_url task failed: {err}"))?
 }
 
 /// 函数 `open_in_file_manager`

--- a/apps/src/app/apikeys/page.tsx
+++ b/apps/src/app/apikeys/page.tsx
@@ -48,7 +48,6 @@ import { useRuntimeCapabilities } from "@/hooks/useRuntimeCapabilities";
 import { useI18n } from "@/lib/i18n/provider";
 import { accountClient } from "@/lib/api/account-client";
 import { appClient } from "@/lib/api/app-client";
-import { isTauriRuntime } from "@/lib/api/transport";
 import {
   buildGeminiGatewayEndpoint,
   buildOpenAiGatewayEndpoint,
@@ -395,11 +394,7 @@ export default function ApiKeysPage() {
   };
 
   const openCcSwitchImportUrl = async (url: string) => {
-    if (isTauriRuntime()) {
-      await appClient.openInBrowser(url);
-      return;
-    }
-    window.location.href = url;
+    await appClient.openExternalUrl(url);
   };
 
   const importToCcSwitch = async (key: (typeof apiKeys)[number]) => {

--- a/apps/src/lib/api/app-client.ts
+++ b/apps/src/lib/api/app-client.ts
@@ -37,6 +37,7 @@ export const appClient = {
     invoke("app_close_to_tray_on_close_set", { enabled }),
 
   openInBrowser: (url: string) => invoke("open_in_browser", { url }),
+  openExternalUrl: (url: string) => invoke("open_external_url", { url }),
   openInFileManager: (path: string) => invoke("open_in_file_manager", { path }),
   showMainWindow: () => invoke("app_show_main_window"),
   openUpdateLogsDir: (assetPath?: string) =>

--- a/apps/src/lib/api/transport-web-commands.ts
+++ b/apps/src/lib/api/transport-web-commands.ts
@@ -428,6 +428,19 @@ export function createWebCommandMap(
         return { ok: true };
       },
     },
+    open_external_url: {
+      direct: async (params) => {
+        const url = typeof params?.url === "string" ? params.url.trim() : "";
+        if (!url) {
+          throw new Error("缺少外部跳转地址");
+        }
+        if (typeof window === "undefined") {
+          throw new Error("当前环境不支持打开外部链接");
+        }
+        window.location.href = url;
+        return { ok: true };
+      },
+    },
     open_in_file_manager: {
       direct: async () => {
         throw new Error("当前环境不支持打开本地目录");

--- a/apps/tests/transport-web-commands.test.mjs
+++ b/apps/tests/transport-web-commands.test.mjs
@@ -95,3 +95,27 @@ test("createWebCommandMap 为显示主窗口提供 Web 回退", async () => {
     }
   }
 });
+
+test("createWebCommandMap 为外部协议跳转提供当前窗口回退", async () => {
+  const previousWindow = globalThis.window;
+  const location = { href: "/" };
+  globalThis.window = { location };
+
+  try {
+    const openExternalUrl = commandMap.open_external_url;
+    assert.ok(openExternalUrl.direct);
+    assert.deepEqual(
+      await openExternalUrl.direct({
+        url: " ccswitch://v1/import?resource=provider ",
+      }),
+      { ok: true }
+    );
+    assert.equal(location.href, "ccswitch://v1/import?resource=provider");
+  } finally {
+    if (previousWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = previousWindow;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Add a dedicated `open_external_url` desktop command for custom protocol links.
- Route the API Keys "Import to ccswitch" action through the external URL path instead of the browser opener.
- Keep the web fallback behavior and add coverage for external protocol navigation.

## Root Cause
The ccswitch import flow built a valid `ccswitch://...` URL, but the desktop UI opened it through `open_in_browser`. On macOS that path uses `webbrowser::open`, which resolves the default browser first and can hand the custom protocol to an empty browser window instead of the ccswitch protocol handler.

## Validation
- `pnpm --dir apps test:runtime`
- `cargo test --manifest-path apps/src-tauri/Cargo.toml validate_external_url`
- `pnpm --dir apps run build:desktop`
- `pnpm --dir apps lint` (passes with existing warnings outside this change)
- Manual desktop smoke test: `ccswitch://v1/import...` opens CC Switch instead of Chrome.

Fixes #223
