### PR TITLE
Add observability storage compaction migration

### DIFF
--- a/crates/core/src/storage/api_key_quota_limits.rs
+++ b/crates/core/src/storage/api_key_quota_limits.rs
@@ -61,7 +61,24 @@ impl Storage {
 
     pub fn api_key_total_token_usage(&self, key_id: &str) -> Result<i64> {
         let mut stmt = self.conn.prepare(
-            "SELECT
+            "WITH all_stats AS (
+                SELECT
+                    key_id,
+                    input_tokens,
+                    cached_input_tokens,
+                    output_tokens,
+                    total_tokens
+                FROM request_token_stats
+                UNION ALL
+                SELECT
+                    NULLIF(key_id, '') AS key_id,
+                    input_tokens,
+                    cached_input_tokens,
+                    output_tokens,
+                    total_tokens
+                FROM request_token_stat_rollups
+             )
+             SELECT
                 IFNULL(
                     SUM(
                         CASE
@@ -77,7 +94,7 @@ impl Storage {
                     ),
                     0
                 ) AS total_tokens
-             FROM request_token_stats
+             FROM all_stats
              WHERE key_id = ?1",
         )?;
         let mut rows = stmt.query([key_id])?;

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -785,6 +785,9 @@ impl Storage {
             include_str!("../../migrations/056_quota_pools.sql"),
             |s| s.ensure_quota_pool_tables(),
         )?;
+        self.apply_compat_migration("057_observability_storage_compaction", |s| {
+            s.compact_observability_storage_for_existing_databases()
+        })?;
         self.ensure_api_key_rotation_columns()?;
         self.ensure_aggregate_apis_table()?;
         self.ensure_aggregate_api_secrets_table()?;
@@ -799,6 +802,30 @@ impl Storage {
         self.ensure_model_catalog_models_table()?;
         self.ensure_account_subscriptions_table()?;
         self.ensure_quota_pool_tables()?;
+        Ok(())
+    }
+
+    fn compact_observability_storage_for_existing_databases(&self) -> Result<()> {
+        self.ensure_request_token_stats_table()?;
+        self.ensure_request_logs_table()?;
+        self.ensure_usage_secondary_columns()?;
+
+        let now = now_ts();
+        let mut touched = 0_usize;
+        if let Some(cutoff) = request_token_stats::retention_cutoff(
+            now,
+            request_token_stats::request_token_stats_retain_days(),
+        ) {
+            touched = touched.saturating_add(self.rollup_request_token_stats_before(cutoff)?);
+        }
+        touched = touched.saturating_add(self.prune_request_logs_by_retention(now)?);
+        touched = touched.saturating_add(
+            self.prune_usage_snapshots_all_accounts(usage::usage_snapshots_retain_per_account())?,
+        );
+
+        if touched > 0 {
+            let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE); VACUUM;");
+        }
         Ok(())
     }
 

--- a/crates/core/src/storage/request_logs.rs
+++ b/crates/core/src/storage/request_logs.rs
@@ -1,9 +1,19 @@
 use rusqlite::{params, params_from_iter, types::Value, Result, Row};
 
 use super::{
-    request_log_query, RequestLog, RequestLogQuerySummary, RequestLogTodaySummary,
-    RequestTokenStat, Storage,
+    request_log_query, RequestLog, RequestLogQuerySummary, RequestLogTodaySummary, RequestTokenStat,
+    Storage,
 };
+
+const DEFAULT_REQUEST_LOG_RETENTION_DAYS: i64 = 14;
+const REQUEST_LOG_RETENTION_DAYS_ENV: &str = "CODEXMANAGER_REQUEST_LOG_RETENTION_DAYS";
+
+fn request_log_retention_days() -> i64 {
+    std::env::var(REQUEST_LOG_RETENTION_DAYS_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<i64>().ok())
+        .unwrap_or(DEFAULT_REQUEST_LOG_RETENTION_DAYS)
+}
 
 impl Storage {
     /// 函数 `ensure_request_logs_indexes`
@@ -390,9 +400,27 @@ impl Storage {
     /// # 返回
     /// 返回函数执行结果
     pub fn clear_request_logs(&self) -> Result<()> {
-        // 只清理请求明细日志，保留 token 统计用于仪表盘历史用量与费用汇总。
+        // 中文注释：清空日志前先把 token 明细滚成长期汇总，避免 API Key 配额/累计统计归零。
+        let _ = self.rollup_all_request_token_stats()?;
         self.conn.execute("DELETE FROM request_logs", [])?;
+        let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE); VACUUM;");
         Ok(())
+    }
+
+    pub fn prune_request_logs_before(&self, cutoff_ts: i64) -> Result<usize> {
+        self.conn.execute(
+            "DELETE FROM request_logs WHERE created_at < ?1",
+            [cutoff_ts],
+        )
+    }
+
+    pub fn prune_request_logs_by_retention(&self, now: i64) -> Result<usize> {
+        let days = request_log_retention_days();
+        if days <= 0 {
+            return Ok(0);
+        }
+        let cutoff = now.saturating_sub(days.saturating_mul(86_400));
+        self.prune_request_logs_before(cutoff)
     }
 
     /// 函数 `summarize_request_logs_between`

--- a/crates/core/src/storage/request_token_stats.rs
+++ b/crates/core/src/storage/request_token_stats.rs
@@ -1,23 +1,51 @@
 use rusqlite::Result;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 use super::{
-    ApiKeyModelTokenUsageSummary, ApiKeyTokenUsageSummary, RequestLogTodaySummary,
+    now_ts, ApiKeyModelTokenUsageSummary, ApiKeyTokenUsageSummary, RequestLogTodaySummary,
     RequestTokenStat, Storage, TokenUsageSummary,
 };
 
+const DEFAULT_REQUEST_TOKEN_STATS_RETAIN_DAYS: i64 = 14;
+const DEFAULT_OBSERVABILITY_MAINTENANCE_INTERVAL_SECS: i64 = 900;
+const REQUEST_TOKEN_STATS_RETAIN_DAYS_ENV: &str = "CODEXMANAGER_REQUEST_TOKEN_STATS_RETAIN_DAYS";
+const OBSERVABILITY_MAINTENANCE_INTERVAL_SECS_ENV: &str =
+    "CODEXMANAGER_OBSERVABILITY_MAINTENANCE_INTERVAL_SECS";
+
+static LAST_OBSERVABILITY_MAINTENANCE_AT: AtomicI64 = AtomicI64::new(0);
+
+pub(super) fn request_token_stats_retain_days() -> i64 {
+    std::env::var(REQUEST_TOKEN_STATS_RETAIN_DAYS_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<i64>().ok())
+        .unwrap_or(DEFAULT_REQUEST_TOKEN_STATS_RETAIN_DAYS)
+}
+
+fn observability_maintenance_interval_secs() -> i64 {
+    std::env::var(OBSERVABILITY_MAINTENANCE_INTERVAL_SECS_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<i64>().ok())
+        .unwrap_or(DEFAULT_OBSERVABILITY_MAINTENANCE_INTERVAL_SECS)
+}
+
+pub(super) fn retention_cutoff(now: i64, days: i64) -> Option<i64> {
+    (days > 0).then(|| now.saturating_sub(days.saturating_mul(86_400)))
+}
+
+fn token_total_sql_expr() -> &'static str {
+    "CASE
+        WHEN total_tokens IS NOT NULL THEN
+            CASE WHEN total_tokens > 0 THEN total_tokens ELSE 0 END
+        ELSE
+            CASE
+                WHEN IFNULL(input_tokens, 0) - IFNULL(cached_input_tokens, 0) + IFNULL(output_tokens, 0) > 0
+                    THEN IFNULL(input_tokens, 0) - IFNULL(cached_input_tokens, 0) + IFNULL(output_tokens, 0)
+                ELSE 0
+            END
+     END"
+}
+
 impl Storage {
-    /// 函数 `insert_request_token_stat`
-    ///
-    /// 作者: gaohongshun
-    ///
-    /// 时间: 2026-04-02
-    ///
-    /// # 参数
-    /// - self: 参数 self
-    /// - stat: 参数 stat
-    ///
-    /// # 返回
-    /// 返回函数执行结果
     pub fn insert_request_token_stat(&self, stat: &RequestTokenStat) -> Result<()> {
         self.conn.execute(
             "INSERT INTO request_token_stats (
@@ -42,19 +70,91 @@ impl Storage {
         Ok(())
     }
 
-    /// 函数 `summarize_request_token_stats_between`
-    ///
-    /// 作者: gaohongshun
-    ///
-    /// 时间: 2026-04-02
-    ///
-    /// # 参数
-    /// - self: 参数 self
-    /// - start_ts: 参数 start_ts
-    /// - end_ts: 参数 end_ts
-    ///
-    /// # 返回
-    /// 返回函数执行结果
+    pub fn maybe_run_observability_maintenance(&self, now: i64) -> Result<()> {
+        let interval = observability_maintenance_interval_secs().max(60);
+        let last = LAST_OBSERVABILITY_MAINTENANCE_AT.load(Ordering::Relaxed);
+        if last != 0 && now.saturating_sub(last) < interval {
+            return Ok(());
+        }
+        if LAST_OBSERVABILITY_MAINTENANCE_AT
+            .compare_exchange(last, now, Ordering::SeqCst, Ordering::Relaxed)
+            .is_err()
+        {
+            return Ok(());
+        }
+
+        if let Err(err) = self.prune_observability_history(now) {
+            LAST_OBSERVABILITY_MAINTENANCE_AT.store(last, Ordering::Relaxed);
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    pub fn prune_observability_history(&self, now: i64) -> Result<()> {
+        let mut touched = 0_usize;
+        if let Some(cutoff) = retention_cutoff(now, request_token_stats_retain_days()) {
+            touched = touched.saturating_add(self.rollup_request_token_stats_before(cutoff)?);
+        }
+        touched = touched.saturating_add(self.prune_request_logs_by_retention(now)?);
+        if touched > 0 {
+            let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE);");
+        }
+        Ok(())
+    }
+
+    pub fn rollup_all_request_token_stats(&self) -> Result<usize> {
+        self.rollup_request_token_stats_before(i64::MAX)
+    }
+
+    pub fn rollup_request_token_stats_before(&self, cutoff_ts: i64) -> Result<usize> {
+        let now = now_ts();
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            &format!(
+                "INSERT INTO request_token_stat_rollups (
+                    key_id, account_id, model,
+                    input_tokens, cached_input_tokens, output_tokens, total_tokens,
+                    reasoning_output_tokens, estimated_cost_usd, source_rows, updated_at
+                 )
+                 SELECT
+                    COALESCE(NULLIF(TRIM(key_id), ''), ''),
+                    COALESCE(NULLIF(TRIM(account_id), ''), ''),
+                    COALESCE(NULLIF(TRIM(model), ''), ''),
+                    IFNULL(SUM(CASE WHEN input_tokens > 0 THEN input_tokens ELSE 0 END), 0),
+                    IFNULL(SUM(CASE WHEN cached_input_tokens > 0 THEN cached_input_tokens ELSE 0 END), 0),
+                    IFNULL(SUM(CASE WHEN output_tokens > 0 THEN output_tokens ELSE 0 END), 0),
+                    IFNULL(SUM({token_total}), 0),
+                    IFNULL(SUM(CASE WHEN reasoning_output_tokens > 0 THEN reasoning_output_tokens ELSE 0 END), 0),
+                    IFNULL(SUM(CASE WHEN estimated_cost_usd > 0 THEN estimated_cost_usd ELSE 0 END), 0.0),
+                    COUNT(1),
+                    ?2
+                 FROM request_token_stats
+                 WHERE created_at < ?1
+                 GROUP BY
+                    COALESCE(NULLIF(TRIM(key_id), ''), ''),
+                    COALESCE(NULLIF(TRIM(account_id), ''), ''),
+                    COALESCE(NULLIF(TRIM(model), ''), '')
+                 ON CONFLICT(key_id, account_id, model) DO UPDATE SET
+                    input_tokens = request_token_stat_rollups.input_tokens + excluded.input_tokens,
+                    cached_input_tokens = request_token_stat_rollups.cached_input_tokens + excluded.cached_input_tokens,
+                    output_tokens = request_token_stat_rollups.output_tokens + excluded.output_tokens,
+                    total_tokens = request_token_stat_rollups.total_tokens + excluded.total_tokens,
+                    reasoning_output_tokens = request_token_stat_rollups.reasoning_output_tokens + excluded.reasoning_output_tokens,
+                    estimated_cost_usd = request_token_stat_rollups.estimated_cost_usd + excluded.estimated_cost_usd,
+                    source_rows = request_token_stat_rollups.source_rows + excluded.source_rows,
+                    updated_at = excluded.updated_at",
+                token_total = token_total_sql_expr(),
+            ),
+            (cutoff_ts, now),
+        )?;
+        let deleted = tx.execute(
+            "DELETE FROM request_token_stats WHERE created_at < ?1",
+            [cutoff_ts],
+        )?;
+        tx.commit()?;
+        Ok(deleted)
+    }
+
     pub fn summarize_request_token_stats_between(
         &self,
         start_ts: i64,
@@ -89,42 +189,37 @@ impl Storage {
         })
     }
 
-    /// 函数 `summarize_request_token_stats_by_key`
-    ///
-    /// 作者: gaohongshun
-    ///
-    /// 时间: 2026-04-02
-    ///
-    /// # 参数
-    /// - self: 参数 self
-    ///
-    /// # 返回
-    /// 返回函数执行结果
     pub fn summarize_request_token_stats_by_key(&self) -> Result<Vec<ApiKeyTokenUsageSummary>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT
+        let mut stmt = self.conn.prepare(&format!(
+            "WITH all_stats AS (
+                SELECT
+                    key_id,
+                    input_tokens,
+                    cached_input_tokens,
+                    output_tokens,
+                    total_tokens,
+                    estimated_cost_usd
+                FROM request_token_stats
+                UNION ALL
+                SELECT
+                    NULLIF(key_id, '') AS key_id,
+                    input_tokens,
+                    cached_input_tokens,
+                    output_tokens,
+                    total_tokens,
+                    estimated_cost_usd
+                FROM request_token_stat_rollups
+             )
+             SELECT
                 key_id,
-                IFNULL(
-                    SUM(
-                        CASE
-                            WHEN total_tokens IS NOT NULL THEN
-                                CASE WHEN total_tokens > 0 THEN total_tokens ELSE 0 END
-                            ELSE
-                                CASE
-                                    WHEN IFNULL(input_tokens, 0) - IFNULL(cached_input_tokens, 0) + IFNULL(output_tokens, 0) > 0
-                                        THEN IFNULL(input_tokens, 0) - IFNULL(cached_input_tokens, 0) + IFNULL(output_tokens, 0)
-                                    ELSE 0
-                                END
-                        END
-                    ),
-                    0
-                ) AS total_tokens,
+                IFNULL(SUM({token_total}), 0) AS total_tokens,
                 IFNULL(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd
-             FROM request_token_stats
+             FROM all_stats
              WHERE key_id IS NOT NULL AND TRIM(key_id) <> ''
              GROUP BY key_id
              ORDER BY total_tokens DESC, key_id ASC",
-        )?;
+            token_total = token_total_sql_expr(),
+        ))?;
         let mut rows = stmt.query([])?;
         let mut items = Vec::new();
         while let Some(row) = rows.next()? {
@@ -142,36 +237,67 @@ impl Storage {
         start_ts: Option<i64>,
         end_ts: Option<i64>,
     ) -> Result<Vec<TokenUsageSummary>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT
-                COALESCE(NULLIF(TRIM(model), ''), 'unknown') AS normalized_model,
-                IFNULL(SUM(input_tokens), 0) AS input_tokens,
-                IFNULL(SUM(cached_input_tokens), 0) AS cached_input_tokens,
-                IFNULL(SUM(output_tokens), 0) AS output_tokens,
-                IFNULL(SUM(reasoning_output_tokens), 0) AS reasoning_output_tokens,
-                IFNULL(
-                    SUM(
-                        CASE
-                            WHEN total_tokens IS NOT NULL THEN
-                                CASE WHEN total_tokens > 0 THEN total_tokens ELSE 0 END
-                            ELSE
-                                CASE
-                                    WHEN IFNULL(input_tokens, 0) - IFNULL(cached_input_tokens, 0) + IFNULL(output_tokens, 0) > 0
-                                        THEN IFNULL(input_tokens, 0) - IFNULL(cached_input_tokens, 0) + IFNULL(output_tokens, 0)
-                                    ELSE 0
-                                END
-                        END
-                    ),
-                    0
-                ) AS total_tokens,
-                IFNULL(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd
-             FROM request_token_stats
-             WHERE (?1 IS NULL OR created_at >= ?1)
-               AND (?2 IS NULL OR created_at < ?2)
-             GROUP BY normalized_model
-             ORDER BY total_tokens DESC, normalized_model ASC",
-        )?;
-        let mut rows = stmt.query((start_ts, end_ts))?;
+        let include_rollups = start_ts.is_none() && end_ts.is_none();
+        let sql = if include_rollups {
+            format!(
+                "WITH all_stats AS (
+                    SELECT
+                        model,
+                        input_tokens,
+                        cached_input_tokens,
+                        output_tokens,
+                        reasoning_output_tokens,
+                        total_tokens,
+                        estimated_cost_usd
+                    FROM request_token_stats
+                    UNION ALL
+                    SELECT
+                        NULLIF(model, '') AS model,
+                        input_tokens,
+                        cached_input_tokens,
+                        output_tokens,
+                        reasoning_output_tokens,
+                        total_tokens,
+                        estimated_cost_usd
+                    FROM request_token_stat_rollups
+                 )
+                 SELECT
+                    COALESCE(NULLIF(TRIM(model), ''), 'unknown') AS normalized_model,
+                    IFNULL(SUM(input_tokens), 0) AS input_tokens,
+                    IFNULL(SUM(cached_input_tokens), 0) AS cached_input_tokens,
+                    IFNULL(SUM(output_tokens), 0) AS output_tokens,
+                    IFNULL(SUM(reasoning_output_tokens), 0) AS reasoning_output_tokens,
+                    IFNULL(SUM({token_total}), 0) AS total_tokens,
+                    IFNULL(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd
+                 FROM all_stats
+                 GROUP BY normalized_model
+                 ORDER BY total_tokens DESC, normalized_model ASC",
+                token_total = token_total_sql_expr(),
+            )
+        } else {
+            format!(
+                "SELECT
+                    COALESCE(NULLIF(TRIM(model), ''), 'unknown') AS normalized_model,
+                    IFNULL(SUM(input_tokens), 0) AS input_tokens,
+                    IFNULL(SUM(cached_input_tokens), 0) AS cached_input_tokens,
+                    IFNULL(SUM(output_tokens), 0) AS output_tokens,
+                    IFNULL(SUM(reasoning_output_tokens), 0) AS reasoning_output_tokens,
+                    IFNULL(SUM({token_total}), 0) AS total_tokens,
+                    IFNULL(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd
+                 FROM request_token_stats
+                 WHERE (?1 IS NULL OR created_at >= ?1)
+                   AND (?2 IS NULL OR created_at < ?2)
+                 GROUP BY normalized_model
+                 ORDER BY total_tokens DESC, normalized_model ASC",
+                token_total = token_total_sql_expr(),
+            )
+        };
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut rows = if include_rollups {
+            stmt.query([])?
+        } else {
+            stmt.query((start_ts, end_ts))?
+        };
         let mut items = Vec::new();
         while let Some(row) = rows.next()? {
             items.push(TokenUsageSummary {
@@ -192,38 +318,73 @@ impl Storage {
         start_ts: Option<i64>,
         end_ts: Option<i64>,
     ) -> Result<Vec<ApiKeyModelTokenUsageSummary>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT
-                key_id,
-                COALESCE(NULLIF(TRIM(model), ''), 'unknown') AS normalized_model,
-                IFNULL(SUM(input_tokens), 0) AS input_tokens,
-                IFNULL(SUM(cached_input_tokens), 0) AS cached_input_tokens,
-                IFNULL(SUM(output_tokens), 0) AS output_tokens,
-                IFNULL(SUM(reasoning_output_tokens), 0) AS reasoning_output_tokens,
-                IFNULL(
-                    SUM(
-                        CASE
-                            WHEN total_tokens IS NOT NULL THEN
-                                CASE WHEN total_tokens > 0 THEN total_tokens ELSE 0 END
-                            ELSE
-                                CASE
-                                    WHEN IFNULL(input_tokens, 0) - IFNULL(cached_input_tokens, 0) + IFNULL(output_tokens, 0) > 0
-                                        THEN IFNULL(input_tokens, 0) - IFNULL(cached_input_tokens, 0) + IFNULL(output_tokens, 0)
-                                    ELSE 0
-                                END
-                        END
-                    ),
-                    0
-                ) AS total_tokens,
-                IFNULL(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd
-             FROM request_token_stats
-             WHERE key_id IS NOT NULL AND TRIM(key_id) <> ''
-               AND (?1 IS NULL OR created_at >= ?1)
-               AND (?2 IS NULL OR created_at < ?2)
-             GROUP BY key_id, normalized_model
-             ORDER BY total_tokens DESC, key_id ASC, normalized_model ASC",
-        )?;
-        let mut rows = stmt.query((start_ts, end_ts))?;
+        let include_rollups = start_ts.is_none() && end_ts.is_none();
+        let sql = if include_rollups {
+            format!(
+                "WITH all_stats AS (
+                    SELECT
+                        key_id,
+                        model,
+                        input_tokens,
+                        cached_input_tokens,
+                        output_tokens,
+                        reasoning_output_tokens,
+                        total_tokens,
+                        estimated_cost_usd
+                    FROM request_token_stats
+                    UNION ALL
+                    SELECT
+                        NULLIF(key_id, '') AS key_id,
+                        NULLIF(model, '') AS model,
+                        input_tokens,
+                        cached_input_tokens,
+                        output_tokens,
+                        reasoning_output_tokens,
+                        total_tokens,
+                        estimated_cost_usd
+                    FROM request_token_stat_rollups
+                 )
+                 SELECT
+                    key_id,
+                    COALESCE(NULLIF(TRIM(model), ''), 'unknown') AS normalized_model,
+                    IFNULL(SUM(input_tokens), 0) AS input_tokens,
+                    IFNULL(SUM(cached_input_tokens), 0) AS cached_input_tokens,
+                    IFNULL(SUM(output_tokens), 0) AS output_tokens,
+                    IFNULL(SUM(reasoning_output_tokens), 0) AS reasoning_output_tokens,
+                    IFNULL(SUM({token_total}), 0) AS total_tokens,
+                    IFNULL(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd
+                 FROM all_stats
+                 WHERE key_id IS NOT NULL AND TRIM(key_id) <> ''
+                 GROUP BY key_id, normalized_model
+                 ORDER BY total_tokens DESC, key_id ASC, normalized_model ASC",
+                token_total = token_total_sql_expr(),
+            )
+        } else {
+            format!(
+                "SELECT
+                    key_id,
+                    COALESCE(NULLIF(TRIM(model), ''), 'unknown') AS normalized_model,
+                    IFNULL(SUM(input_tokens), 0) AS input_tokens,
+                    IFNULL(SUM(cached_input_tokens), 0) AS cached_input_tokens,
+                    IFNULL(SUM(output_tokens), 0) AS output_tokens,
+                    IFNULL(SUM(reasoning_output_tokens), 0) AS reasoning_output_tokens,
+                    IFNULL(SUM({token_total}), 0) AS total_tokens,
+                    IFNULL(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd
+                 FROM request_token_stats
+                 WHERE key_id IS NOT NULL AND TRIM(key_id) <> ''
+                   AND (?1 IS NULL OR created_at >= ?1)
+                   AND (?2 IS NULL OR created_at < ?2)
+                 GROUP BY key_id, normalized_model
+                 ORDER BY total_tokens DESC, key_id ASC, normalized_model ASC",
+                token_total = token_total_sql_expr(),
+            )
+        };
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut rows = if include_rollups {
+            stmt.query([])?
+        } else {
+            stmt.query((start_ts, end_ts))?
+        };
         let mut items = Vec::new();
         while let Some(row) = rows.next()? {
             items.push(ApiKeyModelTokenUsageSummary {
@@ -240,17 +401,6 @@ impl Storage {
         Ok(items)
     }
 
-    /// 函数 `ensure_request_token_stats_table`
-    ///
-    /// 作者: gaohongshun
-    ///
-    /// 时间: 2026-04-02
-    ///
-    /// # 参数
-    /// - super: 参数 super
-    ///
-    /// # 返回
-    /// 返回函数执行结果
     pub(super) fn ensure_request_token_stats_table(&self) -> Result<()> {
         self.conn.execute(
             "CREATE TABLE IF NOT EXISTS request_token_stats (
@@ -289,10 +439,36 @@ impl Storage {
              ON request_token_stats(key_id, created_at DESC)",
             [],
         )?;
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS request_token_stat_rollups (
+                key_id TEXT NOT NULL DEFAULT '',
+                account_id TEXT NOT NULL DEFAULT '',
+                model TEXT NOT NULL DEFAULT '',
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                total_tokens INTEGER NOT NULL DEFAULT 0,
+                reasoning_output_tokens INTEGER NOT NULL DEFAULT 0,
+                estimated_cost_usd REAL NOT NULL DEFAULT 0.0,
+                source_rows INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (key_id, account_id, model)
+            )",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_request_token_stat_rollups_key_id
+             ON request_token_stat_rollups(key_id)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_request_token_stat_rollups_model
+             ON request_token_stat_rollups(model)",
+            [],
+        )?;
         self.ensure_column("request_token_stats", "total_tokens", "INTEGER")?;
 
         if self.has_column("request_logs", "input_tokens")? {
-            // 中文注释：迁移历史 request_logs 里的 token 字段，避免升级后今日统计突然归零。
             self.conn.execute(
                 "INSERT OR IGNORE INTO request_token_stats (
                     request_log_id, key_id, account_id, model,

--- a/crates/core/src/storage/usage.rs
+++ b/crates/core/src/storage/usage.rs
@@ -2,6 +2,17 @@ use rusqlite::{Result, Row};
 
 use super::{Storage, UsageSnapshotRecord};
 
+const DEFAULT_USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT: usize = 1;
+const USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT_ENV: &str =
+    "CODEXMANAGER_USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT";
+
+pub(super) fn usage_snapshots_retain_per_account() -> usize {
+    std::env::var(USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT)
+}
+
 impl Storage {
     /// 函数 `insert_usage_snapshot`
     ///
@@ -66,6 +77,28 @@ impl Storage {
                )",
             (account_id, retain as i64),
         )
+    }
+
+    pub fn prune_usage_snapshots_all_accounts(&self, retain: usize) -> Result<usize> {
+        if retain == 0 {
+            return Ok(0);
+        }
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT account_id FROM usage_snapshots")?;
+        let mut rows = stmt.query([])?;
+        let mut account_ids = Vec::new();
+        while let Some(row) = rows.next()? {
+            account_ids.push(row.get::<_, String>(0)?);
+        }
+        drop(rows);
+        drop(stmt);
+        let mut removed = 0_usize;
+        for account_id in account_ids {
+            removed =
+                removed.saturating_add(self.prune_usage_snapshots_for_account(&account_id, retain)?);
+        }
+        Ok(removed)
     }
 
     /// 函数 `usage_snapshot_count_for_account`

--- a/crates/core/tests/storage.rs
+++ b/crates/core/tests/storage.rs
@@ -1213,7 +1213,7 @@ fn insert_request_log_with_token_stat_writes_both_tables_in_one_call() {
     assert_eq!(logs[0].reasoning_output_tokens, Some(1));
 }
 
-/// 函数 `clear_request_logs_keeps_token_stats_for_usage_summary`
+/// 函数 `clear_request_logs_rolls_token_stats_into_long_term_totals`
 ///
 /// 作者: gaohongshun
 ///
@@ -1225,7 +1225,7 @@ fn insert_request_log_with_token_stat_writes_both_tables_in_one_call() {
 /// # 返回
 /// 无
 #[test]
-fn clear_request_logs_keeps_token_stats_for_usage_summary() {
+fn clear_request_logs_rolls_token_stats_into_long_term_totals() {
     let storage = Storage::open_in_memory().expect("open in memory");
     storage.init().expect("init schema");
     let created_at = now_ts();
@@ -1284,11 +1284,19 @@ fn clear_request_logs_keeps_token_stats_for_usage_summary() {
     let summary = storage
         .summarize_request_logs_between(created_at - 1, created_at + 1)
         .expect("summarize");
-    assert_eq!(summary.input_tokens, 100);
-    assert_eq!(summary.cached_input_tokens, 30);
-    assert_eq!(summary.output_tokens, 20);
-    assert_eq!(summary.reasoning_output_tokens, 5);
-    assert!(summary.estimated_cost_usd > 0.11);
+    assert_eq!(summary.input_tokens, 0);
+    assert_eq!(summary.cached_input_tokens, 0);
+    assert_eq!(summary.output_tokens, 0);
+    assert_eq!(summary.reasoning_output_tokens, 0);
+    assert_eq!(summary.estimated_cost_usd, 0.0);
+
+    let usage_by_key = storage
+        .summarize_request_token_stats_by_key()
+        .expect("summarize by key");
+    assert_eq!(usage_by_key.len(), 1);
+    assert_eq!(usage_by_key[0].key_id, "key-clear");
+    assert_eq!(usage_by_key[0].total_tokens, 120);
+    assert!(usage_by_key[0].estimated_cost_usd > 0.11);
 }
 
 /// 函数 `request_token_stats_can_summarize_total_tokens_by_key`
@@ -1614,6 +1622,16 @@ fn storage_can_roundtrip_api_key_quota_limit_and_usage() {
         storage
             .api_key_total_token_usage("key-quota-1")
             .expect("read usage"),
+        1150
+    );
+
+    storage
+        .rollup_all_request_token_stats()
+        .expect("roll up request stats");
+    assert_eq!(
+        storage
+            .api_key_total_token_usage("key-quota-1")
+            .expect("read rolled usage"),
         1150
     );
 

--- a/crates/core/tests/storage/migration_tests.rs
+++ b/crates/core/tests/storage/migration_tests.rs
@@ -268,6 +268,15 @@ fn init_tracks_schema_migrations_and_is_idempotent() {
         )
         .expect("count 054 migration");
     assert_eq!(applied_054, 1);
+    let applied_057: i64 = storage
+        .conn
+        .query_row(
+            "SELECT COUNT(1) FROM schema_migrations WHERE version = '057_observability_storage_compaction'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count 057 migration");
+    assert_eq!(applied_057, 1);
 
     assert!(!storage
         .has_column("accounts", "note")
@@ -940,7 +949,7 @@ fn request_logs_compact_migration_drops_legacy_usage_columns_and_preserves_rows(
                 7, 'trc-legacy', 'gk_legacy', 'acc-legacy', '/v1/responses', '/v1/chat/completions',
                 '/v1/responses', 'POST', 'gpt-5.3-codex', 'high', 'OpenAIChatCompletionsJson',
                 'https://chatgpt.com/backend-api/codex/v1/responses', 200,
-                12, 5, 0.25, 3, 2, NULL, 1700000000
+                12, 5, 0.25, 3, 2, NULL, 4102444800
             );",
         )
         .expect("create legacy request_logs");
@@ -1012,6 +1021,246 @@ fn request_logs_compact_migration_drops_legacy_usage_columns_and_preserves_rows(
     assert_eq!(token_row.2, Some(0.25));
     assert_eq!(token_row.3, Some(3));
     assert_eq!(token_row.4, Some(2));
+}
+
+#[test]
+fn observability_storage_compaction_migration_rolls_up_and_prunes_legacy_rows() {
+    let path = temp_db_path("observability-compaction");
+    {
+        let storage = Storage::open(&path).expect("open file storage");
+        storage.init().expect("init schema");
+
+        for version in [
+            "001_init",
+            "002_login_sessions",
+            "003_api_keys",
+            "004_api_key_model",
+            "005_request_logs",
+            "006_usage_snapshots_latest_index",
+            "007_usage_secondary_columns",
+            "008_token_api_key_access_token",
+            "009_api_key_reasoning_effort",
+            "010_request_log_reasoning_effort",
+            "011_account_meta_columns",
+            "012_request_logs_search_indexes",
+            "013_drop_accounts_note_tags",
+            "014_drop_accounts_workspace_name",
+            "015_api_key_profiles",
+            "016_api_keys_key_hash_index",
+            "017_usage_snapshots_captured_id_index",
+            "018_accounts_sort_updated_at_index",
+            "019_api_key_secrets",
+            "020_request_logs_account_tokens_cost",
+            "021_request_logs_cached_reasoning_tokens",
+            "022_request_token_stats",
+            "023_request_token_stats_total_tokens",
+            "025_tokens_refresh_schedule",
+            "026_api_key_profiles_constraints_azure",
+            "027_request_logs_trace_context",
+            "028_request_logs_drop_legacy_usage_columns",
+            "029_app_settings",
+            "030_accounts_scale_indexes",
+            "031_request_logs_duration_ms",
+            "032_request_logs_attempt_chain",
+            "033_login_sessions_workspace_id",
+            "034_conversation_bindings",
+            "035_api_key_profiles_service_tier",
+            "036_accounts_metadata_and_drop_group_name",
+            "037_aggregate_api_routing",
+            "038_request_logs_aggregate_api_context",
+            "039_request_logs_aggregate_api_attempt_chain",
+            "040_plugins",
+            "041_gateway_error_logs",
+            "042_request_logs_request_type_service_tier",
+            "043_request_logs_effective_service_tier",
+            "044_api_keys_account_plan_filter",
+            "045_accounts_preferred",
+            "046_request_logs_gateway_mode",
+            "047_model_catalog_models",
+            "048_drop_model_options_cache",
+            "049_model_catalog_string_items",
+            "050_api_key_profiles_drop_azure_protocol",
+            "051_request_logs_first_response_ms",
+            "052_account_subscriptions",
+            "053_aggregate_api_model_override",
+            "053_api_key_quota_limits",
+            "054_aggregate_api_balance_query",
+            "055_model_price_rules",
+            "056_quota_pools",
+        ] {
+            storage
+                .conn
+                .execute(
+                    "INSERT OR REPLACE INTO schema_migrations (version, applied_at) VALUES (?1, 1)",
+                    [version],
+                )
+                .expect("seed migration marker");
+        }
+        storage
+            .conn
+            .execute(
+                "DELETE FROM schema_migrations WHERE version = '057_observability_storage_compaction'",
+                [],
+            )
+            .expect("remove 057 marker");
+
+        storage
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, label, issuer, chatgpt_account_id, workspace_id, sort, status, created_at, updated_at, preferred)
+                 VALUES ('acc-migrate', 'Legacy Account', 'openai', NULL, NULL, 0, 'active', 1, 1, 0)",
+                [],
+            )
+            .expect("insert account");
+
+        let old_ts = 1_000_000_i64;
+        let recent_ts = 9_999_999_999_i64;
+        for index in 0..3_i64 {
+            storage
+                .conn
+                .execute(
+                    "INSERT INTO request_logs (
+                        id, trace_id, key_id, account_id, initial_account_id, attempted_account_ids_json,
+                        initial_aggregate_api_id, attempted_aggregate_api_ids_json, request_path, original_path,
+                        adapted_path, method, request_type, gateway_mode, transparent_mode, enhanced_mode,
+                        model, reasoning_effort, service_tier, effective_service_tier, response_adapter,
+                        upstream_url, aggregate_api_supplier_name, aggregate_api_url, status_code, duration_ms,
+                        first_response_ms, error, created_at
+                     ) VALUES (?1, ?2, 'key-migrate', 'acc-migrate', 'acc-migrate', '[\"acc-migrate\"]',
+                        NULL, NULL, '/v1/responses', '/v1/responses', '/v1/responses', 'POST', 'http',
+                        NULL, NULL, NULL, 'gpt-5', 'medium', NULL, NULL, 'Passthrough',
+                        'https://chatgpt.com/backend-api/codex/responses', NULL, NULL, 200, 100,
+                        50, NULL, ?3)",
+                    (index + 1, format!("trace-{index}"), old_ts + index),
+                )
+                .expect("insert old request log");
+            storage
+                .conn
+                .execute(
+                    "INSERT INTO request_token_stats (
+                        request_log_id, key_id, account_id, model, input_tokens, cached_input_tokens,
+                        output_tokens, total_tokens, reasoning_output_tokens, estimated_cost_usd, created_at
+                     ) VALUES (?1, 'key-migrate', 'acc-migrate', 'gpt-5', 100, 10, 20, 110, 5, 0.5, ?2)",
+                    (index + 1, old_ts + index),
+                )
+                .expect("insert old token stat");
+        }
+
+        storage
+            .conn
+            .execute(
+                "INSERT INTO request_logs (
+                    id, trace_id, key_id, account_id, initial_account_id, attempted_account_ids_json,
+                    initial_aggregate_api_id, attempted_aggregate_api_ids_json, request_path, original_path,
+                    adapted_path, method, request_type, gateway_mode, transparent_mode, enhanced_mode,
+                    model, reasoning_effort, service_tier, effective_service_tier, response_adapter,
+                    upstream_url, aggregate_api_supplier_name, aggregate_api_url, status_code, duration_ms,
+                    first_response_ms, error, created_at
+                 ) VALUES (
+                    10, 'trace-recent', 'key-migrate', 'acc-migrate', 'acc-migrate', '[\"acc-migrate\"]',
+                    NULL, NULL, '/v1/responses', '/v1/responses', '/v1/responses', 'POST', 'http',
+                    NULL, NULL, NULL, 'gpt-5', 'medium', NULL, NULL, 'Passthrough',
+                    'https://chatgpt.com/backend-api/codex/responses', NULL, NULL, 200, 100,
+                    50, NULL, ?1
+                 )",
+                [recent_ts],
+            )
+            .expect("insert recent request log");
+        storage
+            .conn
+            .execute(
+                "INSERT INTO request_token_stats (
+                    request_log_id, key_id, account_id, model, input_tokens, cached_input_tokens,
+                    output_tokens, total_tokens, reasoning_output_tokens, estimated_cost_usd, created_at
+                 ) VALUES (10, 'key-migrate', 'acc-migrate', 'gpt-5', 70, 5, 10, 75, 2, 0.25, ?1)",
+                [recent_ts],
+            )
+            .expect("insert recent token stat");
+
+        for index in 0..3_i64 {
+            storage
+                .conn
+                .execute(
+                    "INSERT INTO usage_snapshots (
+                        account_id, used_percent, window_minutes, resets_at, secondary_used_percent,
+                        secondary_window_minutes, secondary_resets_at, credits_json, captured_at
+                     ) VALUES ('acc-migrate', 20.0, 180, NULL, NULL, NULL, NULL, NULL, ?1)",
+                    [old_ts + index],
+                )
+                .expect("insert usage snapshot");
+        }
+    }
+
+    let storage = Storage::open(&path).expect("reopen file storage");
+    storage.init().expect("run compaction migration");
+
+    let applied_057: i64 = storage
+        .conn
+        .query_row(
+            "SELECT COUNT(1) FROM schema_migrations WHERE version = '057_observability_storage_compaction'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count 057 migration");
+    assert_eq!(applied_057, 1);
+
+    let remaining_old_logs: i64 = storage
+        .conn
+        .query_row(
+            "SELECT COUNT(1) FROM request_logs WHERE created_at < ?1",
+            [2_000_000_i64],
+            |row| row.get(0),
+        )
+        .expect("count old logs");
+    assert_eq!(remaining_old_logs, 0);
+
+    let remaining_recent_logs: i64 = storage
+        .conn
+        .query_row(
+            "SELECT COUNT(1) FROM request_logs WHERE id = 10",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count recent logs");
+    assert_eq!(remaining_recent_logs, 1);
+
+    let rolled_total_tokens: i64 = storage
+        .conn
+        .query_row(
+            "SELECT total_tokens FROM request_token_stat_rollups
+             WHERE key_id = 'key-migrate' AND account_id = 'acc-migrate' AND model = 'gpt-5'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("load rollup row");
+    assert_eq!(rolled_total_tokens, 330);
+
+    let remaining_recent_token_stats: i64 = storage
+        .conn
+        .query_row(
+            "SELECT COUNT(1) FROM request_token_stats WHERE request_log_id = 10",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count recent token stats");
+    assert_eq!(remaining_recent_token_stats, 1);
+
+    let usage_snapshot_count: i64 = storage
+        .conn
+        .query_row(
+            "SELECT COUNT(1) FROM usage_snapshots WHERE account_id = 'acc-migrate'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count usage snapshots");
+    assert_eq!(usage_snapshot_count, 1);
+
+    drop(storage);
+    let _ = fs::remove_file(&path);
+    let wal_path = PathBuf::from(format!("{}-wal", path.display()));
+    let shm_path = PathBuf::from(format!("{}-shm", path.display()));
+    let _ = fs::remove_file(wal_path);
+    let _ = fs::remove_file(shm_path);
 }
 
 #[test]

--- a/crates/service/src/app_settings/env_overrides/catalog/items.rs
+++ b/crates/service/src/app_settings/env_overrides/catalog/items.rs
@@ -362,6 +362,27 @@ pub(crate) const ENV_OVERRIDE_CATALOG: &[EnvOverrideCatalogItem] = &[
         "0",
     ),
     EnvOverrideCatalogItem::new(
+        "CODEXMANAGER_OBSERVABILITY_MAINTENANCE_INTERVAL_SECS",
+        "观测数据清理检查间隔（秒）",
+        ENV_OVERRIDE_SCOPE_SERVICE,
+        ENV_OVERRIDE_APPLY_MODE_RUNTIME,
+        "900",
+    ),
+    EnvOverrideCatalogItem::new(
+        "CODEXMANAGER_REQUEST_LOG_RETENTION_DAYS",
+        "请求日志明细保留天数",
+        ENV_OVERRIDE_SCOPE_SERVICE,
+        ENV_OVERRIDE_APPLY_MODE_RUNTIME,
+        "14",
+    ),
+    EnvOverrideCatalogItem::new(
+        "CODEXMANAGER_REQUEST_TOKEN_STATS_RETENTION_DAYS",
+        "请求 token 明细保留天数",
+        ENV_OVERRIDE_SCOPE_SERVICE,
+        ENV_OVERRIDE_APPLY_MODE_RUNTIME,
+        "14",
+    ),
+    EnvOverrideCatalogItem::new(
         "CODEXMANAGER_USAGE_BASE_URL",
         "用量接口基础地址",
         ENV_OVERRIDE_SCOPE_SERVICE,
@@ -394,7 +415,7 @@ pub(crate) const ENV_OVERRIDE_CATALOG: &[EnvOverrideCatalogItem] = &[
         "每账号保留用量快照数",
         ENV_OVERRIDE_SCOPE_SERVICE,
         ENV_OVERRIDE_APPLY_MODE_RUNTIME,
-        "0",
+        "1",
     ),
     EnvOverrideCatalogItem::new(
         "CODEXMANAGER_WEB_ADDR",

--- a/crates/service/src/gateway/observability/request_log.rs
+++ b/crates/service/src/gateway/observability/request_log.rs
@@ -525,6 +525,16 @@ pub(crate) fn write_request_log_with_attempts(
         );
     }
 
+    if let Err(err) = storage.maybe_run_observability_maintenance(created_at) {
+        let err_text = err.to_string();
+        super::metrics::record_db_error(err_text.as_str());
+        log::warn!(
+            "event=gateway_observability_maintenance_failed request_log_id={} err={}",
+            request_log_id,
+            err_text
+        );
+    }
+
     if should_write_gateway_error_fallback(status_code, error) {
         crate::gateway::write_gateway_error_log(GatewayErrorLogInput {
             trace_id: trace_context.trace_id,

--- a/crates/service/src/usage/usage_snapshot_store.rs
+++ b/crates/service/src/usage/usage_snapshot_store.rs
@@ -3,7 +3,7 @@ use crate::account_status::set_account_status;
 use codexmanager_core::storage::{now_ts, Storage, UsageSnapshotRecord};
 use codexmanager_core::usage::parse_usage_snapshot;
 
-const DEFAULT_USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT: usize = 0;
+const DEFAULT_USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT: usize = 1;
 const USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT_ENV: &str =
     "CODEXMANAGER_USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT";
 


### PR DESCRIPTION
## 变更摘要

- 为旧数据库增加一次性 observability 存储瘦身迁移，避免 `request_logs`、`request_token_stats`、`usage_snapshots` 持续膨胀
- 将旧的逐请求 token 统计滚入长期汇总表，保证清理历史明细后 API Key 累计额度仍然正确
- 为请求日志、逐请求 token 统计、用量快照增加默认保留策略与周期性维护，降低低配置机器上的数据库增长风险

## 改动范围

- [ ] Frontend
- [x] Desktop / Tauri
- [x] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/core/src/storage/request_token_stats.rs`
- `crates/core/src/storage/request_logs.rs`
- `crates/core/src/storage/usage.rs`
- `crates/core/src/storage/mod.rs`
- `crates/core/tests/storage.rs`
- `crates/core/tests/storage/migration_tests.rs`
- `crates/service/src/gateway/observability/request_log.rs`
- `crates/service/src/app_settings/env_overrides/catalog/items.rs`
- `crates/service/src/usage/usage_snapshot_store.rs`

## 验证

- [ ] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
cargo test -p codexmanager-core storage -- --nocapture
cargo test -p codexmanager-core migration_tests -- --nocapture
cargo test -p codexmanager-core storage_can_roundtrip_api_key_quota_limit_and_usage -- --nocapture
pnpm -C apps run build:desktop
cargo build --workspace --release
pnpm -C apps build
cargo build --manifest-path apps/src-tauri/Cargo.toml --release
本地使用已备份的旧数据库手动验证：数据库文件从 100M+ 收缩到约 5M
```

未执行的验证与原因：

```text
pnpm -C apps run test / pnpm -C apps run test:ui 未执行：本机缺少 Playwright 浏览器环境，且本次改动不涉及前端行为。
cargo test --workspace 未执行：本次主要改动集中在 core/service 存储层，已优先跑相关后端用例与构建验证。
```

## 风险与影响面

- 升级到该版本时会对现有数据库执行一次性 compaction，首次启动可能比平时更慢
- `clear_request_logs` 后，请求日志与短期逐请求统计会被清空，但 API Key 累计用量会通过长期汇总表保留
- 默认保留策略从“无限保留”收紧为有限保留，依赖长期全量明细的场景需要改为读取汇总结果

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
- 本 PR 不包含 `apps/test-results/.last-run.json` 之类的本地测试状态文件
