### PR TITLE
[codex] 修复 Chat Completions 兼容流式 tool_calls 桥接

### DIFF
--- a/crates/service/src/gateway/observability/http_bridge/stream_readers/chat_completions.rs
+++ b/crates/service/src/gateway/observability/http_bridge/stream_readers/chat_completions.rs
@@ -7,7 +7,7 @@ use super::{
     UpstreamSseFramePumpItem,
 };
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 pub(crate) struct ChatCompletionsFromResponsesSseReader {
@@ -18,7 +18,11 @@ pub(crate) struct ChatCompletionsFromResponsesSseReader {
     last_upstream_activity: Instant,
     saw_upstream_frame: bool,
     finished: bool,
+    emitted_assistant_role: bool,
     emitted_text: bool,
+    emitted_tool_calls: bool,
+    emitted_tool_call_indices: HashSet<usize>,
+    tool_call_arguments: HashMap<usize, String>,
     emitted_image_urls: HashSet<String>,
     id: Option<String>,
     model: Option<String>,
@@ -39,7 +43,11 @@ impl ChatCompletionsFromResponsesSseReader {
             last_upstream_activity: Instant::now(),
             saw_upstream_frame: false,
             finished: false,
+            emitted_assistant_role: false,
             emitted_text: false,
+            emitted_tool_calls: false,
+            emitted_tool_call_indices: HashSet::new(),
+            tool_call_arguments: HashMap::new(),
             emitted_image_urls: HashSet::new(),
             id: None,
             model: None,
@@ -162,9 +170,152 @@ impl ChatCompletionsFromResponsesSseReader {
                 "total_tokens": collector.usage.total_tokens.unwrap_or(0)
             })
         });
-        let mut out = self.chunk(serde_json::json!({}), Some("stop"), usage);
+        let finish_reason = if self.emitted_tool_calls {
+            "tool_calls"
+        } else {
+            "stop"
+        };
+        let mut out = self.chunk(serde_json::json!({}), Some(finish_reason), usage);
         out.extend_from_slice(b"data: [DONE]\n\n");
         out
+    }
+
+    fn assistant_delta_chunk(&mut self, mut delta: Value) -> Vec<u8> {
+        if !self.emitted_assistant_role {
+            if let Some(object) = delta.as_object_mut() {
+                object.insert("role".to_string(), serde_json::json!("assistant"));
+            }
+            self.emitted_assistant_role = true;
+        }
+        self.chunk(delta, None, None)
+    }
+
+    fn output_index(value: &Value) -> usize {
+        value
+            .get("output_index")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize
+    }
+
+    fn function_call_item(value: &Value) -> Option<&Value> {
+        let item = value.get("item").or_else(|| value.get("output_item"))?;
+        if item.get("type").and_then(Value::as_str) == Some("function_call") {
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    fn tool_call_added_chunk(&mut self, value: &Value) -> Option<Vec<u8>> {
+        let item = Self::function_call_item(value)?;
+        let index = Self::output_index(value);
+        let call_id = item
+            .get("call_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let name = item.get("name").and_then(Value::as_str).unwrap_or_default();
+        let arguments = item
+            .get("arguments")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        self.emitted_tool_calls = true;
+        self.emitted_tool_call_indices.insert(index);
+        self.tool_call_arguments
+            .entry(index)
+            .or_insert_with(|| arguments.to_string());
+        Some(self.assistant_delta_chunk(serde_json::json!({
+            "tool_calls": [{
+                "index": index,
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": arguments
+                }
+            }]
+        })))
+    }
+
+    fn tool_call_arguments_delta_chunk(&mut self, value: &Value) -> Option<Vec<u8>> {
+        let delta = value.get("delta").and_then(Value::as_str)?;
+        let index = Self::output_index(value);
+        self.emitted_tool_calls = true;
+        self.tool_call_arguments
+            .entry(index)
+            .or_default()
+            .push_str(delta);
+        Some(self.assistant_delta_chunk(serde_json::json!({
+            "tool_calls": [{
+                "index": index,
+                "function": {
+                    "arguments": delta
+                }
+            }]
+        })))
+    }
+
+    fn tool_call_arguments_done_chunk(&mut self, value: &Value) -> Option<Vec<u8>> {
+        let arguments = value.get("arguments").and_then(Value::as_str)?;
+        let index = Self::output_index(value);
+        self.remaining_tool_call_arguments_chunk(index, arguments)
+    }
+
+    fn tool_call_done_chunk(&mut self, value: &Value) -> Option<Vec<u8>> {
+        let index = Self::output_index(value);
+        if self.emitted_tool_call_indices.contains(&index) {
+            let item = Self::function_call_item(value)?;
+            let arguments = item.get("arguments").and_then(Value::as_str)?;
+            return self.remaining_tool_call_arguments_chunk(index, arguments);
+        }
+        self.tool_call_added_chunk(value)
+    }
+
+    fn remaining_tool_call_arguments_chunk(
+        &mut self,
+        index: usize,
+        arguments: &str,
+    ) -> Option<Vec<u8>> {
+        let accumulated = self.tool_call_arguments.entry(index).or_default();
+        let remaining = arguments
+            .strip_prefix(accumulated.as_str())
+            .unwrap_or(arguments);
+        if remaining.is_empty() {
+            return None;
+        }
+        accumulated.push_str(remaining);
+        self.emitted_tool_calls = true;
+        Some(self.assistant_delta_chunk(serde_json::json!({
+            "tool_calls": [{
+                "index": index,
+                "function": {
+                    "arguments": remaining
+                }
+            }]
+        })))
+    }
+
+    fn completed_tool_calls_chunk(&mut self, response: &Value) -> Option<Vec<u8>> {
+        let output = response.get("output").and_then(Value::as_array)?;
+        let mut out = Vec::new();
+        for (index, item) in output.iter().enumerate() {
+            if item.get("type").and_then(Value::as_str) != Some("function_call") {
+                continue;
+            }
+            if self.emitted_tool_call_indices.contains(&index) {
+                continue;
+            }
+            if let Some(chunk) = self.tool_call_added_chunk(&serde_json::json!({
+                "output_index": index,
+                "item": item
+            })) {
+                out.extend(chunk);
+            }
+        }
+        if out.is_empty() {
+            None
+        } else {
+            Some(out)
+        }
     }
 
     fn image_delta_chunk(&mut self, value: &Value) -> Option<Vec<u8>> {
@@ -177,14 +328,7 @@ impl ChatCompletionsFromResponsesSseReader {
         if images.is_empty() {
             None
         } else {
-            Some(self.chunk(
-                serde_json::json!({
-                    "role": "assistant",
-                    "images": images
-                }),
-                None,
-                None,
-            ))
+            Some(self.assistant_delta_chunk(serde_json::json!({ "images": images })))
         }
     }
 
@@ -223,11 +367,14 @@ impl ChatCompletionsFromResponsesSseReader {
                     collect_response_output_text(response, &mut text);
                 }
                 if !text.is_empty() {
-                    out.extend(self.chunk(serde_json::json!({ "content": text }), None, None));
+                    out.extend(self.assistant_delta_chunk(serde_json::json!({ "content": text })));
                     self.emitted_text = true;
                 }
             }
             if let Some(response) = value.get("response") {
+                if let Some(tool_calls) = self.completed_tool_calls_chunk(response) {
+                    out.extend(tool_calls);
+                }
                 if let Some(images) = self.image_delta_chunk(response) {
                     out.extend(images);
                 }
@@ -238,8 +385,26 @@ impl ChatCompletionsFromResponsesSseReader {
             return Some(out);
         }
         if event_type.as_deref() == Some("response.output_item.done") {
+            if let Some(tool_call) = self.tool_call_done_chunk(&value) {
+                return Some(tool_call);
+            }
             if let Some(images) = self.image_delta_chunk(&value) {
                 return Some(images);
+            }
+        }
+        if event_type.as_deref() == Some("response.output_item.added") {
+            if let Some(tool_call) = self.tool_call_added_chunk(&value) {
+                return Some(tool_call);
+            }
+        }
+        if event_type.as_deref() == Some("response.function_call_arguments.delta") {
+            if let Some(tool_call) = self.tool_call_arguments_delta_chunk(&value) {
+                return Some(tool_call);
+            }
+        }
+        if event_type.as_deref() == Some("response.function_call_arguments.done") {
+            if let Some(tool_call) = self.tool_call_arguments_done_chunk(&value) {
+                return Some(tool_call);
             }
         }
         if event_type.as_deref() == Some("response.image_generation_call.partial_image") {
@@ -254,7 +419,7 @@ impl ChatCompletionsFromResponsesSseReader {
         }
         if !text.is_empty() {
             self.emitted_text = true;
-            return Some(self.chunk(serde_json::json!({ "content": text }), None, None));
+            return Some(self.assistant_delta_chunk(serde_json::json!({ "content": text })));
         }
         None
     }

--- a/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
+++ b/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
@@ -676,6 +676,7 @@ fn chat_completions_reader_converts_responses_sse_to_chat_sse() {
     let mut out = String::new();
     reader.read_to_string(&mut out).expect("read chat sse");
     assert!(out.contains("\"object\":\"chat.completion.chunk\""));
+    assert!(out.contains("\"role\":\"assistant\""));
     assert!(out.contains("\"content\":\"你\""));
     assert!(out.contains("\"content\":\"好\""));
     assert!(out.contains("\"finish_reason\":\"stop\""));
@@ -731,6 +732,57 @@ fn chat_completions_reader_dedupes_partial_image_and_done_image() {
 
     assert_eq!(out.matches("data:image/png;base64,aGVsbG8=").count(), 1);
     assert!(out.contains("data: [DONE]"));
+}
+
+#[test]
+fn chat_completions_reader_converts_function_call_to_tool_calls() {
+    let sse = concat!(
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"get_answer\",\"arguments\":\"\"}}\n\n",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{\\\"question\\\":\\\"2+2\\\"}\"}\n\n",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"get_answer\",\"arguments\":\"{\\\"question\\\":\\\"2+2\\\"}\"}}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_tool_1\",\"model\":\"gpt-5.4\",\"created\":1775900000,\"usage\":{\"input_tokens\":4,\"output_tokens\":1,\"total_tokens\":5}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let response = open_mock_http_response("text/event-stream", sse);
+    let collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = ChatCompletionsFromResponsesSseReader::new(
+        response,
+        Arc::clone(&collector),
+        std::time::Instant::now(),
+    );
+    let mut out = String::new();
+    reader.read_to_string(&mut out).expect("read chat sse");
+
+    assert!(out.contains("\"role\":\"assistant\""));
+    assert!(out.contains("\"tool_calls\""));
+    assert!(out.contains("\"id\":\"call_1\""));
+    assert!(out.contains("\"name\":\"get_answer\""));
+    assert!(out.contains("\"arguments\":\"{\\\"question\\\":\\\"2+2\\\"}\""));
+    assert!(out.contains("\"finish_reason\":\"tool_calls\""));
+    assert!(out.contains("data: [DONE]"));
+}
+
+#[test]
+fn chat_completions_reader_uses_done_arguments_when_delta_is_missing() {
+    let sse = concat!(
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"get_answer\",\"arguments\":\"\"}}\n\n",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"get_answer\",\"arguments\":\"{\\\"question\\\":\\\"2+2\\\"}\"}}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_tool_1\",\"model\":\"gpt-5.4\",\"created\":1775900000}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let response = open_mock_http_response("text/event-stream", sse);
+    let collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = ChatCompletionsFromResponsesSseReader::new(
+        response,
+        Arc::clone(&collector),
+        std::time::Instant::now(),
+    );
+    let mut out = String::new();
+    reader.read_to_string(&mut out).expect("read chat sse");
+
+    assert!(out.contains("\"id\":\"call_1\""));
+    assert!(out.contains("\"arguments\":\"{\\\"question\\\":\\\"2+2\\\"}\""));
+    assert!(out.contains("\"finish_reason\":\"tool_calls\""));
 }
 
 #[test]


### PR DESCRIPTION
## 改动内容

- 修复 OpenAI-compatible `/v1/chat/completions` 被适配到 `/v1/responses` 后，Responses API 的 `function_call` SSE 事件没有正确转回 Chat Completions `tool_calls` delta 的问题。
- 为首个 assistant delta 补充 `role: assistant`，保持 Chat Completions 流式响应兼容性。
- 当响应中包含 tool call 时，最终 chunk 使用 `finish_reason: "tool_calls"`，让客户端继续执行工具调用。
- 支持从 `response.output_item.added`、`response.function_call_arguments.delta`、`response.function_call_arguments.done`、`response.output_item.done` 中累计并补齐 tool call arguments。
- 补充回归测试，覆盖正常 arguments delta 和缺失 delta 时从 done 事件补齐 arguments 的场景。

## 问题背景

部分 OpenAI-compatible 客户端，例如 opencode 和 Trae 自定义模型，会通过 `/v1/chat/completions` 访问 Codex/Responses 后端。

修复前，上游实际返回了 Responses API 的 function call 流式事件，但桥接层没有把它们转换成 Chat Completions 兼容的 `delta.tool_calls`。客户端因此只能看到 step 结束和 token 统计，却拿不到可展示文本或可执行的 tool call，表现为模型有返回但界面不显示内容。

## 修复方式

在 `ChatCompletionsFromResponsesSseReader` 中补齐 Responses function call SSE 到 Chat Completions tool_calls SSE 的转换逻辑，使 OpenAI-compatible 客户端能正确识别并继续执行工具调用。

## 测试说明

- [x] `cargo test -p codexmanager-service chat_completions_reader_ -- --nocapture`
- [x] `pnpm run build:desktop`
