### PR TITLE
[codex] Fast-close Cloudflare stream challenges

### DIFF
--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -500,7 +500,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          owner="${{ github.repository_owner }}"
+          owner="$(printf '%s' "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
           tag="${{ github.event.inputs.tag }}"
 
           docker tag codexmanager-service:release "ghcr.io/${owner}/codexmanager-service:${tag}"
@@ -519,4 +519,3 @@ jobs:
           ref: ${{ github.event.inputs.ref || 'main' }}
           prerelease-input: ${{ github.event.inputs.prerelease || 'auto' }}
           assets-dir: release-assets
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,12 +17,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -241,6 +300,7 @@ dependencies = [
  "chrono",
  "codexmanager-core",
  "crossbeam-channel",
+ "env_logger",
  "eventsource-stream",
  "futures-util",
  "log",
@@ -291,6 +351,12 @@ dependencies = [
  "webbrowser",
  "winres",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -466,6 +532,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1011,10 +1100,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jni"
@@ -1406,6 +1525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1619,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1676,6 +1810,35 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2446,6 +2609,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/crates/core/src/storage/accounts.rs
+++ b/crates/core/src/storage/accounts.rs
@@ -470,6 +470,16 @@ impl Storage {
             "DELETE FROM conversation_bindings WHERE account_id = ?1",
             [account_id],
         )?;
+        tx.execute(
+            "DELETE FROM model_source_mappings
+             WHERE source_kind = 'openai_account' AND source_id = ?1",
+            [account_id],
+        )?;
+        tx.execute(
+            "DELETE FROM model_source_models
+             WHERE source_kind = 'openai_account' AND source_id = ?1",
+            [account_id],
+        )?;
         tx.execute("DELETE FROM accounts WHERE id = ?1", [account_id])?;
         tx.commit()?;
         Ok(())

--- a/crates/core/src/storage/model_sources.rs
+++ b/crates/core/src/storage/model_sources.rs
@@ -286,4 +286,25 @@ impl Storage {
         )?;
         Ok(())
     }
+
+    pub fn delete_model_source_routes_for_source(
+        &self,
+        source_kind: &str,
+        source_id: &str,
+    ) -> Result<()> {
+        let source_kind = normalize_text(source_kind);
+        let source_id = normalize_text(source_id);
+        if source_kind.is_empty() || source_id.is_empty() {
+            return Ok(());
+        }
+        self.conn.execute(
+            "DELETE FROM model_source_mappings WHERE source_kind = ?1 AND source_id = ?2",
+            params![&source_kind, &source_id],
+        )?;
+        self.conn.execute(
+            "DELETE FROM model_source_models WHERE source_kind = ?1 AND source_id = ?2",
+            params![&source_kind, &source_id],
+        )?;
+        Ok(())
+    }
 }

--- a/crates/core/tests/storage.rs
+++ b/crates/core/tests/storage.rs
@@ -183,6 +183,69 @@ fn storage_can_upsert_and_resolve_model_source_mappings() {
         .is_none());
 }
 
+#[test]
+fn delete_account_removes_openai_model_source_routes() {
+    let mut storage = Storage::open_in_memory().expect("open in memory");
+    storage.init().expect("init schema");
+    let now = now_ts();
+    storage
+        .insert_account(&Account {
+            id: "acc-routing-delete".to_string(),
+            label: "delete route".to_string(),
+            issuer: "https://auth.openai.com".to_string(),
+            chatgpt_account_id: None,
+            workspace_id: None,
+            group_name: None,
+            sort: 0,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("insert account");
+    storage
+        .upsert_model_source_model(&ModelSourceModel {
+            source_kind: "openai_account".to_string(),
+            source_id: "acc-routing-delete".to_string(),
+            upstream_model: "gpt-platform".to_string(),
+            display_name: Some("GPT Platform".to_string()),
+            status: "available".to_string(),
+            discovery_kind: "synced".to_string(),
+            last_synced_at: Some(now),
+            extra_json: "{}".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("upsert source model");
+    storage
+        .upsert_model_source_mapping(&ModelSourceMapping {
+            id: "map-routing-delete".to_string(),
+            platform_model_slug: "gpt-platform".to_string(),
+            source_kind: "openai_account".to_string(),
+            source_id: "acc-routing-delete".to_string(),
+            upstream_model: "gpt-platform".to_string(),
+            enabled: true,
+            priority: 0,
+            weight: 1,
+            billing_model_slug: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("upsert mapping");
+
+    storage
+        .delete_account("acc-routing-delete")
+        .expect("delete account");
+
+    assert!(storage
+        .list_model_source_models(Some("openai_account"), Some("acc-routing-delete"))
+        .expect("list source models")
+        .is_empty());
+    assert!(storage
+        .list_model_source_mappings(Some("gpt-platform"))
+        .expect("list mappings")
+        .is_empty());
+}
+
 /// 函数 `token_upsert_keeps_refresh_schedule_columns`
 ///
 /// 作者: gaohongshun

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -23,6 +23,7 @@ url = "2"
 webbrowser = "0.8"
 urlencoding = "2"
 log = "0.4"
+env_logger = "0.11"
 crossbeam-channel = "0.5"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 zstd = "0.13"

--- a/crates/service/src/apikey/apikey_models.rs
+++ b/crates/service/src/apikey/apikey_models.rs
@@ -479,6 +479,22 @@ fn sync_openai_account_source_models_with_options(
             None => true,
         })
         .collect::<Vec<_>>();
+    let active_source_ids = accounts
+        .iter()
+        .map(|account| account.id.clone())
+        .collect::<HashSet<_>>();
+    if let Some(source_id) = requested_source_id.as_deref() {
+        if !active_source_ids.contains(source_id) {
+            storage
+                .delete_model_source_routes_for_source(
+                    ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
+                    source_id,
+                )
+                .map_err(|err| format!("delete stale account source routes failed: {err}"))?;
+        }
+    } else {
+        prune_stale_openai_account_source_routes(storage, &active_source_ids)?;
+    }
     if accounts.is_empty() {
         return Ok(());
     }
@@ -506,6 +522,38 @@ fn sync_openai_account_source_models_with_options(
             account.id.as_str(),
             true,
         )?;
+    }
+    Ok(())
+}
+
+fn prune_stale_openai_account_source_routes(
+    storage: &Storage,
+    active_source_ids: &HashSet<String>,
+) -> Result<(), String> {
+    let mut known_source_ids = storage
+        .list_model_source_models(Some(ROUTING_SOURCE_KIND_OPENAI_ACCOUNT), None)
+        .map_err(|err| format!("list account source models failed: {err}"))?
+        .into_iter()
+        .map(|model| model.source_id)
+        .collect::<HashSet<_>>();
+    for mapping in storage
+        .list_model_source_mappings(None)
+        .map_err(|err| format!("list model mappings failed: {err}"))?
+        .into_iter()
+        .filter(|mapping| mapping.source_kind == ROUTING_SOURCE_KIND_OPENAI_ACCOUNT)
+    {
+        known_source_ids.insert(mapping.source_id);
+    }
+    for source_id in known_source_ids {
+        if active_source_ids.contains(source_id.as_str()) {
+            continue;
+        }
+        storage
+            .delete_model_source_routes_for_source(
+                ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
+                source_id.as_str(),
+            )
+            .map_err(|err| format!("delete stale account source routes failed: {err}"))?;
     }
     Ok(())
 }
@@ -594,14 +642,13 @@ fn auto_associate_source_models(
     source_id: &str,
     auto_create_platform_models: bool,
 ) -> Result<(), String> {
-    let existing_source_mappings = storage
+    let existing_source_platform_mappings = storage
         .list_model_source_mappings(None)
         .map_err(|err| format!("list model mappings failed: {err}"))?
         .into_iter()
-        .any(|mapping| mapping.source_kind == source_kind && mapping.source_id == source_id);
-    if existing_source_mappings {
-        return Ok(());
-    }
+        .filter(|mapping| mapping.source_kind == source_kind && mapping.source_id == source_id)
+        .map(|mapping| mapping.platform_model_slug)
+        .collect::<HashSet<_>>();
 
     let source_models = storage
         .list_model_source_models(Some(source_kind), Some(source_id))
@@ -667,6 +714,9 @@ fn auto_associate_source_models(
     let now = now_ts();
     for source_model in source_models {
         if !platform_slugs.contains(source_model.upstream_model.as_str()) {
+            continue;
+        }
+        if existing_source_platform_mappings.contains(source_model.upstream_model.as_str()) {
             continue;
         }
         let mapping = ModelSourceMapping {
@@ -2225,6 +2275,92 @@ mod tests {
     }
 
     #[test]
+    fn account_pool_bootstrap_links_new_account_after_initial_sync() {
+        let storage = Storage::open_in_memory().expect("open storage");
+        storage.init().expect("init storage");
+        insert_test_account(&storage, "acc-first");
+        seed_platform_catalog(&storage, &["gpt-auto"]);
+
+        bootstrap_account_pool_model_routes(&storage, false).expect("bootstrap first account");
+        insert_test_account(&storage, "acc-second");
+        bootstrap_account_pool_model_routes(&storage, false).expect("bootstrap second account");
+
+        let mut source_ids = storage
+            .list_enabled_model_source_mappings_for_platform("gpt-auto")
+            .expect("list mappings")
+            .into_iter()
+            .map(|mapping| mapping.source_id)
+            .collect::<Vec<_>>();
+        source_ids.sort();
+        assert_eq!(
+            source_ids,
+            vec!["acc-first".to_string(), "acc-second".to_string()]
+        );
+    }
+
+    #[test]
+    fn account_pool_bootstrap_fills_missing_mappings_for_existing_source() {
+        let storage = Storage::open_in_memory().expect("open storage");
+        storage.init().expect("init storage");
+        insert_test_account(&storage, "acc-expand");
+        seed_platform_catalog(&storage, &["gpt-old"]);
+
+        bootstrap_account_pool_model_routes(&storage, false).expect("bootstrap initial catalog");
+        seed_platform_catalog(&storage, &["gpt-old", "gpt-new"]);
+        bootstrap_account_pool_model_routes(&storage, false).expect("bootstrap expanded catalog");
+
+        let mappings = storage
+            .list_enabled_model_source_mappings_for_platform("gpt-new")
+            .expect("list new mappings");
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(mappings[0].source_kind, ROUTING_SOURCE_KIND_OPENAI_ACCOUNT);
+        assert_eq!(mappings[0].source_id, "acc-expand");
+        assert_eq!(mappings[0].upstream_model, "gpt-new");
+    }
+
+    #[test]
+    fn account_pool_bootstrap_prunes_stale_account_source_routes() {
+        let storage = Storage::open_in_memory().expect("open storage");
+        storage.init().expect("init storage");
+        seed_platform_catalog(&storage, &["gpt-stale"]);
+        storage
+            .upsert_discovered_model_source_models(
+                ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
+                "acc-stale",
+                &["gpt-stale".to_string()],
+                "synced",
+            )
+            .expect("seed stale source model");
+        let now = now_ts();
+        storage
+            .upsert_model_source_mapping(&ModelSourceMapping {
+                id: "mapping-stale".to_string(),
+                platform_model_slug: "gpt-stale".to_string(),
+                source_kind: ROUTING_SOURCE_KIND_OPENAI_ACCOUNT.to_string(),
+                source_id: "acc-stale".to_string(),
+                upstream_model: "gpt-stale".to_string(),
+                enabled: true,
+                priority: 0,
+                weight: 1,
+                billing_model_slug: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("seed stale mapping");
+
+        bootstrap_account_pool_model_routes(&storage, false).expect("bootstrap account routes");
+
+        assert!(storage
+            .list_model_source_models(Some(ROUTING_SOURCE_KIND_OPENAI_ACCOUNT), Some("acc-stale"))
+            .expect("list source models")
+            .is_empty());
+        assert!(storage
+            .list_model_source_mappings(Some("gpt-stale"))
+            .expect("list mappings")
+            .is_empty());
+    }
+
+    #[test]
     fn account_pool_auto_association_creates_missing_platform_model() {
         let storage = Storage::open_in_memory().expect("open storage");
         storage.init().expect("init storage");
@@ -2341,5 +2477,51 @@ mod tests {
         assert_eq!(mappings.len(), 1);
         assert!(!mappings[0].enabled);
         assert_eq!(mappings[0].id, "mapping-disabled");
+    }
+
+    #[test]
+    fn auto_association_preserves_existing_platform_mapping_override() {
+        let storage = Storage::open_in_memory().expect("open storage");
+        storage.init().expect("init storage");
+        seed_platform_catalog(&storage, &["gpt-platform"]);
+        storage
+            .upsert_discovered_model_source_models(
+                ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
+                "acc-override",
+                &["gpt-upstream".to_string(), "gpt-platform".to_string()],
+                "synced",
+            )
+            .expect("seed source models");
+        let now = now_ts();
+        storage
+            .upsert_model_source_mapping(&ModelSourceMapping {
+                id: "mapping-override".to_string(),
+                platform_model_slug: "gpt-platform".to_string(),
+                source_kind: ROUTING_SOURCE_KIND_OPENAI_ACCOUNT.to_string(),
+                source_id: "acc-override".to_string(),
+                upstream_model: "gpt-upstream".to_string(),
+                enabled: true,
+                priority: 0,
+                weight: 1,
+                billing_model_slug: None,
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("seed mapping override");
+
+        auto_associate_source_models(
+            &storage,
+            ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
+            "acc-override",
+            true,
+        )
+        .expect("auto associate");
+
+        let mappings = storage
+            .list_model_source_mappings(Some("gpt-platform"))
+            .expect("list mappings");
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(mappings[0].id, "mapping-override");
+        assert_eq!(mappings[0].upstream_model, "gpt-upstream");
     }
 }

--- a/crates/service/src/gateway/observability/http_bridge/delivery.rs
+++ b/crates/service/src/gateway/observability/http_bridge/delivery.rs
@@ -1370,7 +1370,16 @@ fn build_passthrough_non_success_message(
         auth_error,
         identity_error_code,
     );
-    if let Some(hint) = extract_error_hint_from_body(status_code, body) {
+    if let Some(hint) = extract_error_hint_from_body(status_code, body).or_else(|| {
+        header_only_cloudflare_challenge_hint(
+            status_code,
+            content_type,
+            body,
+            cf_ray,
+            auth_error,
+            identity_error_code,
+        )
+    }) {
         return format!(
             "upstream server error: {hint}{}",
             compact_debug_suffix(
@@ -1392,6 +1401,51 @@ fn build_passthrough_non_success_message(
             identity_error_code
         )
     )
+}
+
+fn header_only_cloudflare_challenge_hint(
+    status_code: u16,
+    content_type: Option<&str>,
+    body: &[u8],
+    cf_ray: Option<&str>,
+    auth_error: Option<&str>,
+    identity_error_code: Option<&str>,
+) -> Option<String> {
+    if status_code < 400 || !body.is_empty() {
+        return None;
+    }
+    if auth_error.is_some_and(looks_like_blocked_marker)
+        || identity_error_code.is_some_and(looks_like_blocked_marker)
+    {
+        return Some("Cloudflare 安全验证页".to_string());
+    }
+    let is_html = content_type
+        .map(crate::gateway::is_html_content_type)
+        .unwrap_or(false);
+    if cf_ray.is_some() || (is_html && matches!(status_code, 401 | 403)) {
+        return Some("Cloudflare 安全验证页".to_string());
+    }
+    None
+}
+
+fn extract_error_hint_from_body_or_headers(
+    status_code: u16,
+    content_type: Option<&str>,
+    body: &[u8],
+    cf_ray: Option<&str>,
+    auth_error: Option<&str>,
+    identity_error_code: Option<&str>,
+) -> Option<String> {
+    extract_error_hint_from_body(status_code, body).or_else(|| {
+        header_only_cloudflare_challenge_hint(
+            status_code,
+            content_type,
+            body,
+            cf_ray,
+            auth_error,
+            identity_error_code,
+        )
+    })
 }
 
 /// 函数 `respond_synthesized_compact_error_body`
@@ -1852,8 +1906,15 @@ pub(crate) fn respond_with_upstream(
             };
             let response_body = if status.0 >= 400 {
                 let message = with_upstream_debug_suffix(
-                    extract_error_hint_from_body(status.0, &body)
-                        .or_else(|| extract_error_message_from_json_bytes(&body)),
+                    extract_error_hint_from_body_or_headers(
+                        status.0,
+                        upstream_content_type.as_deref(),
+                        &body,
+                        upstream_cf_ray.as_deref(),
+                        upstream_auth_error.as_deref(),
+                        upstream_identity_error_code.as_deref(),
+                    )
+                    .or_else(|| extract_error_message_from_json_bytes(&body)),
                     None,
                     upstream_request_id.as_deref(),
                     upstream_cf_ray.as_deref(),
@@ -1910,8 +1971,15 @@ pub(crate) fn respond_with_upstream(
                 .bytes()
                 .map_err(|err| format!("read upstream body failed: {err}"))?;
             let message = with_upstream_debug_suffix(
-                extract_error_hint_from_body(status.0, upstream_body.as_ref())
-                    .or_else(|| extract_error_message_from_json_bytes(upstream_body.as_ref())),
+                extract_error_hint_from_body_or_headers(
+                    status.0,
+                    upstream_content_type.as_deref(),
+                    upstream_body.as_ref(),
+                    upstream_cf_ray.as_deref(),
+                    upstream_auth_error.as_deref(),
+                    upstream_identity_error_code.as_deref(),
+                )
+                .or_else(|| extract_error_message_from_json_bytes(upstream_body.as_ref())),
                 None,
                 upstream_request_id.as_deref(),
                 upstream_cf_ray.as_deref(),
@@ -2167,7 +2235,14 @@ pub(crate) fn respond_with_upstream(
                         merge_usage(&mut usage, parse_usage_from_json(&value));
                     }
                     let upstream_error_hint = with_upstream_debug_suffix(
-                        extract_error_hint_from_body(status.0, &body),
+                        extract_error_hint_from_body_or_headers(
+                            status.0,
+                            upstream_content_type.as_deref(),
+                            &body,
+                            upstream_cf_ray.as_deref(),
+                            upstream_auth_error.as_deref(),
+                            upstream_identity_error_code.as_deref(),
+                        ),
                         None,
                         upstream_request_id.as_deref(),
                         upstream_cf_ray.as_deref(),
@@ -2372,7 +2447,14 @@ pub(crate) fn respond_with_upstream(
                     ));
                 }
                 let upstream_error_hint = with_upstream_debug_suffix(
-                    extract_error_hint_from_body(status.0, upstream_body.as_ref()),
+                    extract_error_hint_from_body_or_headers(
+                        status.0,
+                        upstream_content_type.as_deref(),
+                        upstream_body.as_ref(),
+                        upstream_cf_ray.as_deref(),
+                        upstream_auth_error.as_deref(),
+                        upstream_identity_error_code.as_deref(),
+                    ),
                     None,
                     upstream_request_id.as_deref(),
                     upstream_cf_ray.as_deref(),
@@ -2470,7 +2552,14 @@ pub(crate) fn respond_with_upstream(
                     ));
                 }
                 let upstream_error_hint = with_upstream_debug_suffix(
-                    extract_error_hint_from_body(status.0, upstream_body.as_ref()),
+                    extract_error_hint_from_body_or_headers(
+                        status.0,
+                        upstream_content_type.as_deref(),
+                        upstream_body.as_ref(),
+                        upstream_cf_ray.as_deref(),
+                        upstream_auth_error.as_deref(),
+                        upstream_identity_error_code.as_deref(),
+                    ),
                     None,
                     upstream_request_id.as_deref(),
                     upstream_cf_ray.as_deref(),
@@ -2785,8 +2874,15 @@ pub(crate) fn respond_with_stream_upstream(
             };
             let response_body = if status.0 >= 400 {
                 let message = with_upstream_debug_suffix(
-                    extract_error_hint_from_body(status.0, &body)
-                        .or_else(|| extract_error_message_from_json_bytes(&body)),
+                    extract_error_hint_from_body_or_headers(
+                        status.0,
+                        upstream_content_type.as_deref(),
+                        &body,
+                        upstream_cf_ray.as_deref(),
+                        upstream_auth_error.as_deref(),
+                        upstream_identity_error_code.as_deref(),
+                    )
+                    .or_else(|| extract_error_message_from_json_bytes(&body)),
                     None,
                     upstream_request_id.as_deref(),
                     upstream_cf_ray.as_deref(),
@@ -2843,8 +2939,15 @@ pub(crate) fn respond_with_stream_upstream(
                 .read_all_bytes()
                 .map_err(|err| format!("read upstream body failed: {err}"))?;
             let message = with_upstream_debug_suffix(
-                extract_error_hint_from_body(status.0, upstream_body.as_ref())
-                    .or_else(|| extract_error_message_from_json_bytes(upstream_body.as_ref())),
+                extract_error_hint_from_body_or_headers(
+                    status.0,
+                    upstream_content_type.as_deref(),
+                    upstream_body.as_ref(),
+                    upstream_cf_ray.as_deref(),
+                    upstream_auth_error.as_deref(),
+                    upstream_identity_error_code.as_deref(),
+                )
+                .or_else(|| extract_error_message_from_json_bytes(upstream_body.as_ref())),
                 None,
                 upstream_request_id.as_deref(),
                 upstream_cf_ray.as_deref(),
@@ -3122,7 +3225,14 @@ pub(crate) fn respond_with_stream_upstream(
                         merge_usage(&mut usage, parse_usage_from_json(&value));
                     }
                     let upstream_error_hint = with_upstream_debug_suffix(
-                        extract_error_hint_from_body(status.0, &body),
+                        extract_error_hint_from_body_or_headers(
+                            status.0,
+                            upstream_content_type.as_deref(),
+                            &body,
+                            upstream_cf_ray.as_deref(),
+                            upstream_auth_error.as_deref(),
+                            upstream_identity_error_code.as_deref(),
+                        ),
                         None,
                         upstream_request_id.as_deref(),
                         upstream_cf_ray.as_deref(),
@@ -3290,7 +3400,14 @@ pub(crate) fn respond_with_stream_upstream(
                     ));
                 }
                 let upstream_error_hint = with_upstream_debug_suffix(
-                    extract_error_hint_from_body(status.0, upstream_body.as_ref()),
+                    extract_error_hint_from_body_or_headers(
+                        status.0,
+                        upstream_content_type.as_deref(),
+                        upstream_body.as_ref(),
+                        upstream_cf_ray.as_deref(),
+                        upstream_auth_error.as_deref(),
+                        upstream_identity_error_code.as_deref(),
+                    ),
                     None,
                     upstream_request_id.as_deref(),
                     upstream_cf_ray.as_deref(),
@@ -3382,7 +3499,14 @@ pub(crate) fn respond_with_stream_upstream(
                     ));
                 }
                 let upstream_error_hint = with_upstream_debug_suffix(
-                    extract_error_hint_from_body(status.0, upstream_body.as_ref()),
+                    extract_error_hint_from_body_or_headers(
+                        status.0,
+                        upstream_content_type.as_deref(),
+                        upstream_body.as_ref(),
+                        upstream_cf_ray.as_deref(),
+                        upstream_auth_error.as_deref(),
+                        upstream_identity_error_code.as_deref(),
+                    ),
                     None,
                     upstream_request_id.as_deref(),
                     upstream_cf_ray.as_deref(),
@@ -3659,9 +3783,9 @@ fn resolve_stream_keepalive_frame(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_compact_non_success_kind, compact_non_success_body_should_be_normalized,
-        compact_success_body_is_valid, convert_chat_completions_body_to_compact,
-        convert_responses_body_to_chat_completions,
+        build_passthrough_non_success_message, classify_compact_non_success_kind,
+        compact_non_success_body_should_be_normalized, compact_success_body_is_valid,
+        convert_chat_completions_body_to_compact, convert_responses_body_to_chat_completions,
         convert_responses_body_to_gemini_generate_content, convert_responses_body_to_images,
         force_openai_responses_stream_content_type, gemini_cli_wrap_response_envelope, Header,
         ImagesResponseFormat, ResponseAdapter,
@@ -3817,6 +3941,38 @@ mod tests {
         assert_eq!(value["output"][0]["role"], "assistant");
         assert_eq!(value["output"][0]["content"][0]["type"], "output_text");
         assert_eq!(value["output"][0]["content"][0]["text"], "压缩摘要");
+    }
+
+    #[test]
+    fn header_only_cloudflare_challenge_uses_stable_hint() {
+        let message = build_passthrough_non_success_message(
+            502,
+            Some("text/html; charset=utf-8"),
+            b"",
+            Some("req-header-only"),
+            Some("ray-header-only"),
+            None,
+            None,
+        );
+
+        assert!(message.contains("Cloudflare 安全验证页"));
+        assert!(message.contains("cf_ray=ray-header-only"));
+    }
+
+    #[test]
+    fn cloudflare_html_preview_keeps_title_hint() {
+        let message = build_passthrough_non_success_message(
+            502,
+            Some("text/html; charset=utf-8"),
+            b"<html><head><title>Just a moment...</title></head><body>Cloudflare</body></html>",
+            Some("req-preview"),
+            Some("ray-preview"),
+            None,
+            None,
+        );
+
+        assert!(message.contains("Cloudflare 安全验证页（title=Just a moment...）"));
+        assert!(message.contains("cf_ray=ray-preview"));
     }
 
     #[test]

--- a/crates/service/src/gateway/upstream/attempt_flow/transport.rs
+++ b/crates/service/src/gateway/upstream/attempt_flow/transport.rs
@@ -4,7 +4,7 @@ use futures_util::StreamExt;
 use rand::Rng;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tiny_http::Request;
 use tokio::runtime::Builder;
 
@@ -335,10 +335,128 @@ fn should_wrap_upstream_as_stream_response(request_path: &str, is_stream: bool) 
     is_stream && request_path.starts_with("/v1/responses") && !is_compact_request_path(request_path)
 }
 
+const STREAM_ERROR_PREVIEW_MAX_BYTES: usize = 64 * 1024;
+const STREAM_ERROR_PREVIEW_TIMEOUT: Duration = Duration::from_millis(250);
+
+fn first_header_value<'a>(headers: &'a reqwest::header::HeaderMap, name: &str) -> Option<&'a str> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn header_value_contains(headers: &reqwest::header::HeaderMap, name: &str, needle: &str) -> bool {
+    let needle = needle.to_ascii_lowercase();
+    first_header_value(headers, name)
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|value| value.contains(needle.as_str()))
+}
+
+fn content_type_is(headers: &reqwest::header::HeaderMap, needle: &str) -> bool {
+    header_value_contains(headers, reqwest::header::CONTENT_TYPE.as_str(), needle)
+}
+
+fn has_cloudflare_header_signal(headers: &reqwest::header::HeaderMap) -> bool {
+    first_header_value(headers, "cf-ray").is_some()
+        || header_value_contains(headers, "server", "cloudflare")
+        || header_value_contains(headers, "cf-mitigated", "challenge")
+}
+
+fn should_fast_close_non_sse_error_stream(
+    request_path: &str,
+    status: reqwest::StatusCode,
+    headers: &reqwest::header::HeaderMap,
+) -> bool {
+    if is_compact_request_path(request_path) || !request_path.starts_with("/v1/responses") {
+        return false;
+    }
+    if status.as_u16() < 400 {
+        return false;
+    }
+    if content_type_is(headers, "text/event-stream") || content_type_is(headers, "application/json")
+    {
+        return false;
+    }
+    content_type_is(headers, "text/html")
+        || header_value_contains(headers, "cf-mitigated", "challenge")
+        || (matches!(status.as_u16(), 401 | 403) && has_cloudflare_header_signal(headers))
+}
+
+async fn read_stream_error_preview(response: reqwest::Response) -> (Bytes, Option<String>, bool) {
+    let mut stream = response.bytes_stream();
+    let deadline = tokio::time::Instant::now() + STREAM_ERROR_PREVIEW_TIMEOUT;
+    let mut preview = Vec::new();
+    let mut read_error = None;
+    let mut timed_out = false;
+
+    while preview.len() < STREAM_ERROR_PREVIEW_MAX_BYTES {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            timed_out = true;
+            break;
+        }
+        match tokio::time::timeout(deadline - now, stream.next()).await {
+            Ok(Some(Ok(bytes))) => {
+                let remaining = STREAM_ERROR_PREVIEW_MAX_BYTES - preview.len();
+                let take = bytes.len().min(remaining);
+                preview.extend_from_slice(&bytes[..take]);
+                if take < bytes.len() {
+                    break;
+                }
+            }
+            Ok(Some(Err(err))) => {
+                read_error = Some(err.to_string());
+                break;
+            }
+            Ok(None) => break,
+            Err(_) => {
+                timed_out = true;
+                break;
+            }
+        }
+    }
+
+    (Bytes::from(preview), read_error, timed_out)
+}
+
+async fn fast_close_non_sse_error_stream(
+    request_path: &str,
+    status: reqwest::StatusCode,
+    headers: &reqwest::header::HeaderMap,
+    response: reqwest::Response,
+    body_tx: mpsc::SyncSender<super::super::GatewayByteStreamItem>,
+) {
+    let content_type =
+        first_header_value(headers, reqwest::header::CONTENT_TYPE.as_str()).unwrap_or("-");
+    let cf_ray = first_header_value(headers, "cf-ray").unwrap_or("-");
+    let (preview, read_error, timed_out) = read_stream_error_preview(response).await;
+    let preview_bytes = preview.len();
+    log::warn!(
+        "event=gateway_stream_non_sse_error_fast_closed path={} status={} content_type={} cf_ray={} preview_bytes={} timed_out={} read_error={}",
+        request_path,
+        status.as_u16(),
+        content_type,
+        cf_ray,
+        preview_bytes,
+        timed_out,
+        read_error.as_deref().unwrap_or("-")
+    );
+    if !preview.is_empty()
+        && body_tx
+            .send(super::super::GatewayByteStreamItem::Chunk(preview))
+            .is_err()
+    {
+        return;
+    }
+    let _ = body_tx.send(super::super::GatewayByteStreamItem::Eof);
+}
+
 fn send_async_stream_request(
     client: &reqwest::Client,
     method: &reqwest::Method,
     target_url: &str,
+    request_path: &str,
     request_deadline: Option<Instant>,
     request_headers: &[(String, String)],
     request_body: &Bytes,
@@ -347,8 +465,10 @@ fn send_async_stream_request(
     let client = client.clone();
     let method = method.clone();
     let target_url = target_url.to_string();
+    let request_path = request_path.to_string();
     let request_headers = request_headers.to_vec();
     let request_body = request_body.clone();
+    let send_timeout = super::super::support::deadline::send_timeout(request_deadline, is_stream);
     let (meta_tx, meta_rx) = mpsc::sync_channel::<
         Result<(reqwest::StatusCode, reqwest::header::HeaderMap), reqwest::Error>,
     >(1);
@@ -360,9 +480,7 @@ fn send_async_stream_request(
             .unwrap_or_else(|err| panic!("build gateway upstream runtime failed: {err}"));
         runtime.block_on(async move {
             let mut builder = client.request(method, target_url);
-            if let Some(timeout) =
-                super::super::support::deadline::send_timeout(request_deadline, is_stream)
-            {
+            if let Some(timeout) = send_timeout {
                 builder = builder.timeout(timeout);
             }
             for (name, value) in request_headers.iter() {
@@ -375,7 +493,20 @@ fn send_async_stream_request(
                 Ok(response) => {
                     let status = response.status();
                     let headers = response.headers().clone();
-                    if meta_tx.send(Ok((status, headers))).is_err() {
+                    let should_fast_close =
+                        should_fast_close_non_sse_error_stream(&request_path, status, &headers);
+                    if meta_tx.send(Ok((status, headers.clone()))).is_err() {
+                        return;
+                    }
+                    if should_fast_close {
+                        fast_close_non_sse_error_stream(
+                            &request_path,
+                            status,
+                            &headers,
+                            response,
+                            body_tx,
+                        )
+                        .await;
                         return;
                     }
                     let mut stream = response.bytes_stream();
@@ -777,6 +908,7 @@ fn send_upstream_request_with_compression_override(
             &async_client,
             method,
             target_url,
+            request_ctx.request_path,
             request_deadline,
             upstream_headers.as_slice(),
             &body_for_request,
@@ -804,6 +936,7 @@ fn send_upstream_request_with_compression_override(
                         &fresh_async,
                         method,
                         target_url,
+                        request_ctx.request_path,
                         request_deadline,
                         upstream_headers_uncompressed.as_slice(),
                         &body_for_transport,
@@ -835,6 +968,7 @@ fn send_upstream_request_with_compression_override(
                         &fresh_async,
                         method,
                         target_url,
+                        request_ctx.request_path,
                         request_deadline,
                         upstream_headers.as_slice(),
                         &body_for_request,
@@ -945,17 +1079,91 @@ fn send_upstream_request_with_compression_override(
 mod tests {
     use super::{
         apply_gemini_codex_compat_header_profile, encode_request_body, resolve_request_compression,
-        resolve_request_compression_with_flag, should_retry_transport_without_compression,
-        should_wrap_upstream_as_stream_response, strip_compact_service_tier_for_transport,
-        RequestCompression, CPA_GEMINI_CODEX_USER_AGENT,
+        resolve_request_compression_with_flag, send_async_stream_request,
+        should_retry_transport_without_compression, should_wrap_upstream_as_stream_response,
+        strip_compact_service_tier_for_transport, RequestCompression, CPA_GEMINI_CODEX_USER_AGENT,
     };
     use bytes::Bytes;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
         headers
             .iter()
             .find(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
             .map(|(_, value)| value.as_str())
+    }
+
+    fn spawn_raw_http_response(
+        status: &'static str,
+        headers: Vec<(&'static str, &'static str)>,
+        body: Vec<u8>,
+        hold_open: bool,
+    ) -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock upstream");
+        let addr = listener.local_addr().expect("mock upstream addr");
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept mock upstream");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set read timeout");
+            let mut request = Vec::new();
+            let mut buf = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                match stream.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(read) => request.extend_from_slice(&buf[..read]),
+                    Err(_) => break,
+                }
+            }
+
+            let mut response = format!("HTTP/1.1 {status}\r\n");
+            for (name, value) in headers {
+                response.push_str(name);
+                response.push_str(": ");
+                response.push_str(value);
+                response.push_str("\r\n");
+            }
+            if hold_open {
+                response.push_str("Connection: keep-alive\r\n\r\n");
+            } else {
+                response.push_str(&format!(
+                    "Content-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                ));
+            }
+            stream
+                .write_all(response.as_bytes())
+                .expect("write mock response headers");
+            stream.write_all(&body).expect("write mock response body");
+            stream.flush().expect("flush mock response");
+            if hold_open {
+                let _ = release_rx.recv_timeout(Duration::from_secs(5));
+            }
+        });
+        (format!("http://{addr}/v1/responses"), release_tx, handle)
+    }
+
+    fn send_mock_stream_request(url: &str) -> super::super::super::GatewayStreamResponse {
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(1))
+            .build()
+            .expect("build reqwest client");
+        send_async_stream_request(
+            &client,
+            &reqwest::Method::GET,
+            url,
+            "/v1/responses",
+            Some(Instant::now() + Duration::from_secs(5)),
+            &[],
+            &Bytes::new(),
+            true,
+        )
+        .expect("send stream request")
     }
 
     /// 函数 `request_compression_only_applies_to_streaming_chatgpt_responses`
@@ -1199,5 +1407,72 @@ mod tests {
             "/v1/responses",
             false
         ));
+    }
+
+    #[test]
+    fn stream_transport_fast_closes_html_challenge_without_waiting_for_eof() {
+        let body = b"<html><title>Just a moment...</title><body>Cloudflare</body></html>".to_vec();
+        let (url, release, handle) = spawn_raw_http_response(
+            "403 Forbidden",
+            vec![
+                ("Content-Type", "text/html; charset=utf-8"),
+                ("cf-ray", "ray-fast-close"),
+            ],
+            body,
+            true,
+        );
+
+        let started = Instant::now();
+        let response = send_mock_stream_request(url.as_str());
+        assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+        let body = response.read_all_bytes().expect("read fast-closed body");
+
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "fast-close path waited {:?}",
+            started.elapsed()
+        );
+        assert!(String::from_utf8_lossy(body.as_ref()).contains("Just a moment"));
+        let _ = release.send(());
+        handle.join().expect("join mock upstream");
+    }
+
+    #[test]
+    fn stream_transport_does_not_fast_close_json_error_body() {
+        let body = vec![b'a'; 70 * 1024];
+        let expected_len = body.len();
+        let (url, release, handle) = spawn_raw_http_response(
+            "403 Forbidden",
+            vec![("Content-Type", "application/json")],
+            body,
+            false,
+        );
+
+        let response = send_mock_stream_request(url.as_str());
+        assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+        let body = response.read_all_bytes().expect("read json error body");
+
+        assert_eq!(body.len(), expected_len);
+        let _ = release.send(());
+        handle.join().expect("join mock upstream");
+    }
+
+    #[test]
+    fn stream_transport_does_not_fast_close_successful_sse_body() {
+        let expected = b"data: {\"type\":\"response.completed\"}\n\n".to_vec();
+        let (url, release, handle) = spawn_raw_http_response(
+            "200 OK",
+            vec![("Content-Type", "text/event-stream")],
+            expected.clone(),
+            false,
+        );
+
+        let response = send_mock_stream_request(url.as_str());
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body = response.read_all_bytes().expect("read sse body");
+
+        assert_eq!(body.as_ref(), expected.as_slice());
+        let _ = release.send(());
+        handle.join().expect("join mock upstream");
     }
 }

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -11,6 +11,7 @@ mod errors;
 mod gateway;
 mod http;
 mod lifecycle;
+mod logging;
 mod model_groups;
 mod plugin;
 mod quota;
@@ -138,6 +139,7 @@ pub use auth::{rpc_auth_token, rpc_auth_token_matches};
 pub use lifecycle::bootstrap::{initialize_storage_if_needed, portable};
 pub use lifecycle::shutdown::{clear_shutdown_flag, request_shutdown, shutdown_requested};
 pub use lifecycle::startup::{start_one_shot_server, start_server, ServerHandle};
+pub use logging::init_logging;
 pub use rpc_actor::{RpcActor, ROLE_ADMIN, ROLE_MEMBER, ROLE_SYSTEM_ADMIN};
 pub use usage_refresh::{set_usage_refresh_completed_handler, UsageRefreshCompletedEvent};
 

--- a/crates/service/src/logging.rs
+++ b/crates/service/src/logging.rs
@@ -1,0 +1,29 @@
+use std::sync::Once;
+
+static LOGGER_INIT: Once = Once::new();
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+pub fn init_logging() {
+    LOGGER_INIT.call_once(|| {
+        let filter = non_empty_env("RUST_LOG")
+            .or_else(|| non_empty_env("CODEXMANAGER_LOG"))
+            .unwrap_or_else(|| "info".to_string());
+        let mut builder = env_logger::Builder::new();
+        builder.parse_filters(&filter);
+        builder.format_timestamp_secs();
+
+        if let Some(style) =
+            non_empty_env("RUST_LOG_STYLE").or_else(|| non_empty_env("CODEXMANAGER_LOG_STYLE"))
+        {
+            builder.parse_write_style(&style);
+        }
+
+        let _ = builder.try_init();
+    });
+}

--- a/crates/service/src/main.rs
+++ b/crates/service/src/main.rs
@@ -11,6 +11,7 @@
 /// 无
 fn main() {
     codexmanager_service::portable::bootstrap_current_process();
+    codexmanager_service::init_logging();
     let configured_addr = std::env::var("CODEXMANAGER_SERVICE_ADDR")
         .unwrap_or_else(|_| codexmanager_service::default_listener_bind_addr());
     let addr = codexmanager_service::listener_bind_addr(&configured_addr);

--- a/crates/service/tests/app_settings.rs
+++ b/crates/service/tests/app_settings.rs
@@ -78,7 +78,7 @@ fn reset_runtime_defaults() {
         "freeAccountMaxModel": "gpt-5.2",
         "modelForwardRules": "",
         "gatewayOriginator": "codex_cli_rs",
-        "gatewayUserAgentVersion": "0.101.0",
+        "gatewayUserAgentVersion": codexmanager_service::default_gateway_user_agent_version(),
         "gatewayResidencyRequirement": "",
         "appearancePreset": "classic",
         "lightweightModeOnCloseToTray": false,
@@ -819,7 +819,7 @@ fn app_settings_set_persists_snapshot_and_password_hash() {
             snapshot
                 .get("gatewayUserAgentVersionDefault")
                 .and_then(|value| value.as_str()),
-            Some("0.101.0")
+            Some(codexmanager_service::default_gateway_user_agent_version())
         );
         assert_eq!(
             snapshot
@@ -1163,7 +1163,7 @@ fn sync_runtime_settings_from_storage_applies_saved_runtime_values() {
             snapshot
                 .get("gatewayUserAgentVersionDefault")
                 .and_then(|value| value.as_str()),
-            Some("0.101.0")
+            Some(codexmanager_service::default_gateway_user_agent_version())
         );
         assert_eq!(
             snapshot
@@ -1370,13 +1370,13 @@ fn app_settings_get_loads_env_backed_dedicated_settings_when_storage_missing() {
             snapshot
                 .get("gatewayUserAgentVersion")
                 .and_then(|value| value.as_str()),
-            Some("0.101.0")
+            Some(codexmanager_service::default_gateway_user_agent_version())
         );
         assert_eq!(
             snapshot
                 .get("gatewayUserAgentVersionDefault")
                 .and_then(|value| value.as_str()),
-            Some("0.101.0")
+            Some(codexmanager_service::default_gateway_user_agent_version())
         );
         assert_eq!(
             snapshot
@@ -1474,7 +1474,7 @@ fn app_settings_get_loads_env_backed_dedicated_settings_when_storage_missing() {
             storage
                 .get_app_setting(codexmanager_service::APP_SETTING_GATEWAY_USER_AGENT_VERSION_KEY)
                 .expect("read gateway user agent version"),
-            Some("0.101.0".to_string())
+            Some(codexmanager_service::default_gateway_user_agent_version().to_string())
         );
         assert_eq!(
             storage

--- a/crates/service/tests/gateway_logs/anthropic.rs
+++ b/crates/service/tests/gateway_logs/anthropic.rs
@@ -413,10 +413,9 @@ fn gateway_claude_protocol_end_to_end_uses_codex_headers() {
         Some("text/event-stream")
     );
     assert!(
-        captured
-            .headers
-            .get("user-agent")
-            .is_some_and(|value| value.contains("0.101.0")),
+        captured.headers.get("user-agent").is_some_and(
+            |value| value.contains(codexmanager_service::default_gateway_user_agent_version())
+        ),
         "user-agent should carry codex client version"
     );
     assert_eq!(

--- a/crates/start/src/main.rs
+++ b/crates/start/src/main.rs
@@ -563,6 +563,7 @@ fn spawn_child(bin: &Path, service_bind_addr: Option<&str>) -> std::io::Result<C
 fn main() {
     // 让 start.exe 也支持同目录 env 文件，保持与 service/web 一致。
     load_env_from_exe_dir_best_effort();
+    codexmanager_service::init_logging();
     // 进一步对齐 service/web 的便携化初始化，确保 DB/RPC token 落点一致。
     codexmanager_service::portable::bootstrap_current_process();
     let _ = codexmanager_service::initialize_storage_if_needed();

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -602,6 +602,7 @@ async fn async_main() {
 /// 无
 fn main() {
     codexmanager_service::portable::bootstrap_current_process();
+    codexmanager_service::init_logging();
     let _ = codexmanager_service::initialize_storage_if_needed();
     codexmanager_service::sync_runtime_settings_from_storage();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  codexmanager:
+    container_name: codexmanager
+    image: registry.cn-hangzhou.aliyuncs.com/kilimiao/codex-manager:latest
+    pull_policy: always
+    restart: unless-stopped
+    init: true
+    # NAS Docker panels often create bind-mounted folders with host-only ownership
+    # and do not expose chown/chmod controls. Run as root so /data stays writable.
+    user: "0:0"
+    environment:
+      CODEXMANAGER_SERVICE_ADDR: 0.0.0.0:48760
+      CODEXMANAGER_WEB_ADDR: 0.0.0.0:48761
+      CODEXMANAGER_WEB_NO_OPEN: "1"
+      CODEXMANAGER_DB_PATH: /data/codexmanager.db
+      CODEXMANAGER_RPC_TOKEN_FILE: /data/codexmanager.rpc-token
+      # If the host machine provides an HTTP proxy, use:
+      # CODEXMANAGER_UPSTREAM_PROXY_URL: http://host.docker.internal:7890
+    volumes:
+      # For normal Linux servers you can also run as UID/GID 10001 and chown this
+      # folder, but NAS environments such as ZSpace are usually easier with root.
+      - ./data:/data
+    ports:
+      - "48761:48761"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    stop_grace_period: 20s


### PR DESCRIPTION
## Summary
- Fast-close non-SSE upstream stream errors for `/v1/responses` when Cloudflare/HTML challenge responses arrive and the upstream body stalls.
- Preserve stable bridge hints for header-only Cloudflare challenges while keeping existing status semantics.
- Keep OpenAI account-pool model routing synchronized when accounts are added/removed, prune stale source routes, and fill missing mappings without overriding manual platform mappings.
- Include all-in-one runtime logging bootstrap, Docker Compose entrypoint config, and GHCR owner normalization in the release workflow.

## Verification
- `git diff --check`
- `rustfmt --edition 2021 --check crates/service/src/apikey/apikey_models.rs crates/core/src/storage/model_sources.rs crates/core/src/storage/accounts.rs crates/core/tests/storage.rs`
- `cargo test -p codexmanager-core`
- `cargo test -p codexmanager-core model_source`
- `cargo test -p codexmanager-service account_pool_bootstrap -- --nocapture`
- `cargo test -p codexmanager-service auto_association -- --nocapture`
- `cargo test -p codexmanager-service --test gateway_logs basic::gateway_rewrites_account_pool_model_from_enabled_mapping -- --test-threads=1`
- `cargo test -p codexmanager-service gateway::upstream::attempt_flow::transport`
- `cargo test -p codexmanager-service cloudflare -- --nocapture`
- `cargo test -p codexmanager-service --test app_settings -- --test-threads=1`
- `cargo test -p codexmanager-service --test gateway_logs -- --test-threads=1`
- `cargo test -p codexmanager-service`
- `cd apps && pnpm install --frozen-lockfile && pnpm run build:desktop`
