### PR TITLE
fix(ui): Y-axis display for usage analysis

### DIFF
--- a/apps/src/app/account-manager/page.tsx
+++ b/apps/src/app/account-manager/page.tsx
@@ -75,6 +75,7 @@ import { useRuntimeCapabilities } from "@/hooks/useRuntimeCapabilities";
 import { appClient } from "@/lib/api/app-client";
 import { dashboardClient } from "@/lib/api/dashboard-client";
 import { getAppErrorMessage } from "@/lib/api/transport";
+import { estimateChartYAxisWidth } from "@/lib/dashboard/format";
 import { useI18n } from "@/lib/i18n/provider";
 import { cn } from "@/lib/utils";
 import { formatCompactNumber } from "@/lib/utils/usage";
@@ -224,6 +225,10 @@ function UserUsageTrendLine({ summary }: { summary: MemberDashboardSummary }) {
     totalTokens: item.totalTokens,
     estimatedCostUsd: item.estimatedCostUsd,
   }));
+  const yAxisWidth = estimateChartYAxisWidth(
+    [0, ...chartData.map((item) => item.totalTokens)],
+    formatTokenAmount,
+  );
 
   return (
     <ChartContainer
@@ -262,7 +267,7 @@ function UserUsageTrendLine({ summary }: { summary: MemberDashboardSummary }) {
           tickLine={false}
           axisLine={false}
           tickMargin={10}
-          width={44}
+          width={yAxisWidth}
           tickFormatter={(value) => formatTokenAmount(Number(value))}
         />
         <ChartTooltip

--- a/apps/src/app/page.tsx
+++ b/apps/src/app/page.tsx
@@ -58,6 +58,7 @@ import { useMemberDashboardSummary } from "@/hooks/useMemberDashboardSummary";
 import { usePageTransitionReady } from "@/hooks/usePageTransitionReady";
 import { useRuntimeCapabilities } from "@/hooks/useRuntimeCapabilities";
 import {
+  estimateChartYAxisWidth,
   formatCompactTokenAmount,
   formatPercent,
 } from "@/lib/dashboard/format";
@@ -357,6 +358,10 @@ function DailyTokenLineChart({
     estimatedCostUsd: item.usage.estimatedCostUsd,
     requestCount: item.usage.requestCount,
   }));
+  const yAxisWidth = estimateChartYAxisWidth(
+    [0, ...chartData.map((item) => item.totalTokens)],
+    formatCompactTokenAmount,
+  );
 
   return (
     <ChartContainer
@@ -395,7 +400,7 @@ function DailyTokenLineChart({
           tickLine={false}
           axisLine={false}
           tickMargin={10}
-          width={44}
+          width={yAxisWidth}
           tickFormatter={(value) => formatCompactTokenAmount(Number(value))}
         />
         <ChartTooltip

--- a/apps/src/lib/dashboard/format.ts
+++ b/apps/src/lib/dashboard/format.ts
@@ -17,3 +17,17 @@ export function formatCompactTokenAmount(value: number | null | undefined): stri
   }
   return formatCompactNumber(normalized, "0.00", 2, true);
 }
+
+export function estimateChartYAxisWidth(
+  values: Array<number | null | undefined>,
+  formatter: (value: number) => string,
+  minimumWidth = 44,
+): number {
+  const widestLabelLength = values.reduce<number>((maxLength, value) => {
+    const normalizedValue = typeof value === "number" && Number.isFinite(value) ? value : 0;
+    const normalized = Math.max(0, normalizedValue);
+    return Math.max(maxLength, formatter(normalized).length);
+  }, 0);
+
+  return Math.max(minimumWidth, Math.ceil(widestLabelLength * 8 + 16));
+}


### PR DESCRIPTION
## 变更摘要

- 修复首页“仪表盘”管理员用量分析图左侧 Y 轴刻度文本被裁切的问题
<img width="609" height="318" alt="截屏2026-05-19 08 26 36" src="https://github.com/user-attachments/assets/ab24cc3d-e4e6-48d1-9f9f-dfc4cebc7fc1" />
- 将图表 Y 轴宽度从固定值改为基于真实刻度文本动态估算，避免大数值 token 刻度显示不全
- 同步把同类逻辑应用到“账号管理”页的成员用量趋势图，保持图表表现一致

## 改动范围

- [x] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `apps/src/lib/dashboard/format.ts`
- `apps/src/app/page.tsx`
- `apps/src/app/account-manager/page.tsx`

## 主要改动

- 新增 `estimateChartYAxisWidth(values, formatter, minimumWidth)`，按格式化后的最长刻度文本估算图表 Y 轴所需宽度
- 首页管理员用量分析 `DailyTokenLineChart` 改为根据 `dailyUsage.totalTokens` 动态计算 `YAxis.width`
- 账号管理页成员用量趋势 `UserUsageTrendLine` 同步复用相同宽度估算逻辑
- 保留原有刻度格式化函数与图表布局，只修复左侧留白不足导致的裁切问题

## 实现效果

- 首页“仪表盘”管理员用量分析在 `10.00M`、`105.00M` 这类较宽刻度下不再截断首位数字
- 图表在不同数据量级下会自动扩展左侧轴宽，避免后续再次出现固定宽度不足
- “账号管理”页的 7 日用量趋势图也获得同样的刻度防裁切能力

## 验证

- [x] `npm_config_cache=/private/tmp/codex-npm-cache npx pnpm@10.30.3 -C apps run test:runtime`
- [x] `npm_config_cache=/private/tmp/codex-npm-cache npx pnpm@10.30.3 -C apps run build:desktop`
- [ ] `npm_config_cache=/private/tmp/codex-npm-cache npx @tauri-apps/cli@2.9.2 build --bundles app --no-sign`
- [x] 其他本地验证

已执行的实际验证：

- 前端 runtime 测试 58/58 通过
- `build:desktop` 静态导出通过

未执行的验证与原因：


补充说明：


## 风险与影响面

- 本次改动仅影响图表 Y 轴宽度计算，不改动接口、数据流和图表交互
- 轴宽估算基于格式化后文本长度，若未来更改刻度格式规则，宽度会自动随之调整

## 备注

- 提交前请确认未包含敏感 token、cookie、API key