### PR TITLE
Fix Chat Completions JSON mode on Responses backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /specs/
 
 # Logs & local data
+/data/
 *.log
 *.db
 *.sqlite

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,45 +1,98 @@
-# Frontend Engineering Standards (apps)
+# Repository Engineering Standards
 
-This document outlines the architectural constraints and coding conventions for the refactored Next.js frontend.
+This file applies to the whole CodexManager repository. For work under `apps/`,
+also read `apps/AGENTS.md`; that file contains the more specific frontend and
+Tauri rules.
 
-## 1. Tech Stack
-- **Framework**: Next.js 14+ (App Router).
-- **Language**: TypeScript (Strict mode).
-- **Styling**: Tailwind CSS v4.
-- **UI Components**: shadcn/ui (based on @base-ui/react).
-- **State Management**: Zustand.
-- **Data Fetching**: TanStack Query (React Query) v5.
-- **Runtime**: Tauri v2.
+## 1. Project Shape
+- `apps/`: Next.js frontend plus the Tauri desktop shell.
+- `apps/src/`: App Router UI, components, hooks, API clients, runtime helpers,
+  i18n, and Zustand state.
+- `apps/src-tauri/`: Tauri v2 application shell, desktop lifecycle, tray/window
+  behavior, native commands, and desktop RPC client code.
+- `crates/core/`: SQLite migrations, storage primitives, auth helpers, and core
+  usage/account data structures.
+- `crates/service/`: local HTTP/RPC service, gateway routing, protocol adapters,
+  account/API key/usage domains, plugins, app settings, and runtime sync.
+- `crates/web/`: service-mode Web UI shell, embedded static UI serving, and
+  `/api/runtime` / `/api/rpc` proxy behavior.
+- `crates/start/`: service-mode launcher that starts service + web together.
+- `scripts/`, `docker/`, `.github/`: build, release, probe, container, and CI
+  automation.
 
-## 2. Design Language: Glassmorphism & Themes
-- **Ambient Background**: Use vibrant mesh gradients defined in `globals.css` that sync with the active theme.
-- **Glass Material**: 
-  - Use `.glass-sidebar` for the navigation bar.
-  - Use `.glass-header` for the top bar.
-  - Use `.glass-card` for main content containers.
-- **Performance Mode**: Always respect the `low-transparency` class on the `body`. When active, all blurs and gradients MUST be disabled in favor of solid colors (`var(--card-solid)`).
-- **Themes**: Support all 11 core themes (Enterprise Blue, Pure Black, Dark One, etc.) using `next-themes`.
+## 2. Ownership Boundaries
+- Keep UI behavior in `apps/src/`, desktop shell behavior in `apps/src-tauri/`,
+  and service/gateway behavior in `crates/service/`.
+- Put schema and persistence foundation changes in `crates/core/`, especially
+  SQLite migrations and reusable storage helpers.
+- Avoid expanding central entrypoints with unrelated orchestration. Large files
+  should be treated as legacy surfaces; new substantial logic should move into
+  focused modules, hooks, or domain helpers.
+- Do not mix release/script changes with product behavior unless the task
+  explicitly requires it.
 
-## 3. Component Guidelines
-- **Logic Separation**: Keep components "dumb" by moving complex logic into custom hooks (e.g., `useAccounts`, `useDashboardStats`).
-- **Semantic HTML**: Avoid nested `<button>` elements. Use `render={<span />}` and `nativeButton={false}` on triggers (like DropdownMenuTrigger) to maintain accessibility without breaking HTML specs.
-- **Client Components**: Mark interactive components with `"use client"`. Prefer Server Components for static layouts where possible.
+## 3. API, RPC, and Command Sync
+- Frontend code must call backend capabilities through typed wrappers in
+  `apps/src/lib/api/`.
+- Desktop IPC should use the centralized `invoke` / `invokeFirst` helpers from
+  `@/lib/api/transport`; do not use raw `fetch()` for desktop commands.
+- Service commands that require a service address should pass parameters through
+  `withAddr()`. App-shell commands such as `app_*`, `open_*`, and window/update
+  helpers may omit it when no service address is needed.
+- Web/service-mode fallback is allowed only through the existing transport
+  stack: `transport.ts`, `transport-web-commands.ts`, `rpc-http.ts`, and
+  `fetchWithRetry`.
+- When adding or renaming a backend command, keep the chain synchronized:
+  Rust implementation, Tauri command registry when applicable, service RPC
+  dispatch/Web command mapping when applicable, and the frontend API wrapper.
+- Preserve the existing underscore command names and camelCase RPC method
+  mapping conventions.
 
-## 4. API & IPC Standards
-- **Transport**: Use the centralized `invoke` and `invokeFirst` helpers from `@/lib/api/transport`.
-- **Addressing**: Always use `withAddr()` to wrap IPC parameters ensuring the backend service address is correctly injected.
-- **Error Handling**: Standardize business error unwrapping in the transport layer to show consistent toast notifications.
-- **No Fetch for IPC**: Do not use `fetch()` for backend commands in the desktop environment; use Tauri's native `invoke` for maximum reliability and speed.
+## 4. Settings and Persistence
+- New persisted settings need explicit defaults, storage behavior, runtime sync
+  behavior, and UI/API exposure.
+- Check whether a setting affects desktop mode, service mode, web mode, or all
+  three before choosing where to implement it.
+- New `CODEXMANAGER_*` environment variables require documentation updates and
+  should not bypass existing app settings unless startup-time behavior requires
+  an environment-level setting.
+- SQLite schema changes belong in `crates/core/migrations/` and should include
+  storage-level tests when behavior is non-trivial.
 
-## 5. Directory Structure
-- `app/`: Routing and page layouts.
-- `components/ui/`: Atomic shadcn components.
-- `components/modals/`: Feature-specific dialogs.
-- `hooks/`: Business logic hooks.
-- `lib/api/`: Typed backend client wrappers.
-- `store/`: Zustand global state stores.
-- `types/`: Shared TypeScript interfaces.
+## 5. Frontend and Desktop Rules
+- Follow `apps/AGENTS.md` for Next.js, Tailwind, shadcn/Base UI, React Query,
+  Zustand, glass theme, static export, and Tauri-specific rules.
+- The frontend is statically exported for the desktop shell. Keep routing and
+  asset paths compatible with `output: "export"` and `trailingSlash: true`.
+- The Web UI must continue to work through `codexmanager-web`; a plain static
+  page or ordinary Next dev server is not the complete service-mode runtime.
 
-## 6. Development Workflow
-- **Validation**: Every significant change must be verified with `pnpm run build:desktop` to ensure static export compatibility.
-- **Sync**: Ensure all new backend commands are added to `lib/api/` with correct underscore/camelCase mapping.
+## 6. Rust Service Rules
+- Keep gateway/protocol changes localized under `crates/service/src/gateway/`
+  and `crates/service/src/http/` unless shared service state is genuinely needed.
+- Protocol adapter changes must consider `/v1/responses`, `/v1/chat/completions`,
+  streaming SSE, non-streaming JSON, tools, and `tool_calls`.
+- Prefer typed request/response structs and existing storage helpers over ad hoc
+  JSON or string manipulation.
+- Web access, roles, billing/account mode, and API key ownership are security
+  boundaries; do not weaken checks for UI convenience.
+
+## 7. Validation
+- Frontend-only changes: run at least `pnpm -C apps run build` and, when runtime
+  behavior is touched, `pnpm -C apps run test:runtime`.
+- Desktop/static-export changes: run `pnpm -C apps run build:desktop`.
+- Rust/service changes: run `cargo test --workspace`, or the narrowest relevant
+  package test only when the change is clearly isolated.
+- Web shell/transport changes: add `cargo test -p codexmanager-web` and the
+  relevant runtime probe scripts when available.
+- Gateway/protocol changes require targeted regression coverage for streaming,
+  non-streaming, tools, and both supported OpenAI-style endpoints.
+- If a validation step cannot run in the current environment, record the exact
+  command and the reason it was not executed.
+
+## 8. Documentation
+- Keep `README.md`, localized docs under `docs/`, and app-level docs aligned
+  with user-visible behavior, deployment modes, environment variables, and
+  release/build commands.
+- Root governance docs describe repository-level boundaries. App-specific
+  frontend rules belong in `apps/AGENTS.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,10 @@ cargo test --workspace
 
 ```bash
 pnpm -C apps run dev
-pnpm -C apps run test
-pnpm -C apps run test:ui
 pnpm -C apps run build
-pnpm -C apps run check
+pnpm -C apps run build:desktop
+pnpm -C apps run test:runtime
+pnpm -C apps run test:navigation
 ```
 
 Rust：
@@ -92,10 +92,13 @@ pwsh -NoLogo -NoProfile -File scripts/rebuild.ps1 -Bundle nsis -CleanDist -Porta
 
 以下文件已明显偏大，修改时必须克制追加总控逻辑：
 
-- `apps/src/main.js`
+- `apps/src/app/settings/page.tsx`
+- `apps/src/app/logs/page.tsx`
+- `apps/src/app/aggregate-api/page.tsx`
+- `apps/src/app/page.tsx`
 - `apps/src-tauri/src/lib.rs`
 - `crates/service/src/lib.rs`
-- `crates/service/src/gateway/protocol_adapter/response_conversion.rs`
+- `crates/service/src/gateway/`
 - `.github/workflows/release-all.yml`
 
 ### 3.3 大文件预警阈值
@@ -130,9 +133,9 @@ pwsh -NoLogo -NoProfile -File scripts/rebuild.ps1 -Bundle nsis -CleanDist -Porta
 前端改动：
 
 ```bash
-pnpm -C apps run test
 pnpm -C apps run build
-pnpm -C apps run test:ui
+pnpm -C apps run test:runtime
+pnpm -C apps run test:navigation
 ```
 
 Rust / 服务端改动：

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@
 ├─ apps/                # 前端与 Tauri 桌面端
 │  ├─ src/
 │  ├─ src-tauri/
-│  └─ dist/
+│  └─ out/
 ├─ crates/              # Rust core/service
 │  ├─ core
 │  ├─ service

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -1,45 +1,90 @@
-# Frontend Engineering Standards (apps)
+# Frontend and Desktop Engineering Standards
 
-This document outlines the architectural constraints and coding conventions for the refactored Next.js frontend.
+This file applies to `apps/`: the Next.js frontend, the Tauri desktop shell, and
+their tests/configuration.
 
 ## 1. Tech Stack
-- **Framework**: Next.js 14+ (App Router).
-- **Language**: TypeScript (Strict mode).
-- **Styling**: Tailwind CSS v4.
-- **UI Components**: shadcn/ui (based on @base-ui/react).
-- **State Management**: Zustand.
-- **Data Fetching**: TanStack Query (React Query) v5.
-- **Runtime**: Tauri v2.
+- **Framework**: Next.js 16 App Router with static export.
+- **Runtime UI**: React 19.
+- **Language**: TypeScript strict mode.
+- **Styling**: Tailwind CSS v4 via `src/app/globals.css`.
+- **UI Components**: shadcn/ui style components built on `@base-ui/react`.
+- **Icons**: `lucide-react`.
+- **State Management**: Zustand in `src/lib/store/`.
+- **Data Fetching**: TanStack Query v5.
+- **Desktop Runtime**: Tauri v2.
 
-## 2. Design Language: Glassmorphism & Themes
-- **Ambient Background**: Use vibrant mesh gradients defined in `globals.css` that sync with the active theme.
-- **Glass Material**: 
-  - Use `.glass-sidebar` for the navigation bar.
-  - Use `.glass-header` for the top bar.
-  - Use `.glass-card` for main content containers.
-- **Performance Mode**: Always respect the `low-transparency` class on the `body`. When active, all blurs and gradients MUST be disabled in favor of solid colors (`var(--card-solid)`).
-- **Themes**: Support all 11 core themes (Enterprise Blue, Pure Black, Dark One, etc.) using `next-themes`.
+## 2. Static Export and Routing
+- `next.config.ts` uses `output: "export"` and `trailingSlash: true`; keep new
+  routes, links, redirects, and asset paths compatible with static output.
+- Use `buildStaticRouteUrl()` and the top-level route helpers when adding shell
+  navigation entries.
+- The shell uses keep-alive page panels and lazy-loaded top-level routes. Add
+  new primary pages to the route config, sidebar icon map, and keep-alive map.
+- Validate significant frontend changes with `pnpm run build:desktop` from this
+  directory, or `pnpm -C apps run build:desktop` from the repository root.
 
-## 3. Component Guidelines
-- **Logic Separation**: Keep components "dumb" by moving complex logic into custom hooks (e.g., `useAccounts`, `useDashboardStats`).
-- **Semantic HTML**: Avoid nested `<button>` elements. Use `render={<span />}` and `nativeButton={false}` on triggers (like DropdownMenuTrigger) to maintain accessibility without breaking HTML specs.
-- **Client Components**: Mark interactive components with `"use client"`. Prefer Server Components for static layouts where possible.
+## 3. Design Language: Glassmorphism and Themes
+- Ambient backgrounds and theme tokens live in `src/app/globals.css`.
+- Use `.glass-sidebar` for the navigation bar, `.glass-header` for the top bar,
+  and `.glass-card` for main content surfaces.
+- Always respect `body.low-transparency`: when active, blur and mesh gradients
+  must be disabled in favor of solid colors using `var(--card-solid)`.
+- Theme handling uses `next-themes` with 12 supported themes:
+  `tech`, `dark`, `dark-one`, `business`, `mint`, `sunset`, `grape`, `ocean`,
+  `forest`, `rose`, `slate`, and `aurora`.
+- Keep theme labels, defaults, app settings, and CSS variables synchronized when
+  adding or renaming a theme.
 
-## 4. API & IPC Standards
-- **Transport**: Use the centralized `invoke` and `invokeFirst` helpers from `@/lib/api/transport`.
-- **Addressing**: Always use `withAddr()` to wrap IPC parameters ensuring the backend service address is correctly injected.
-- **Error Handling**: Standardize business error unwrapping in the transport layer to show consistent toast notifications.
-- **No Fetch for IPC**: Do not use `fetch()` for backend commands in the desktop environment; use Tauri's native `invoke` for maximum reliability and speed.
+## 4. Component Guidelines
+- Mark interactive components with `"use client"`. Prefer Server Components only
+  where the surrounding route/layout can remain static.
+- Move new non-trivial business logic into hooks under `src/hooks/` or focused
+  helpers under `src/lib/`. Existing large pages are legacy surfaces; do not add
+  more orchestration there unless the change is very small.
+- Avoid nested `<button>` elements. For Base UI triggers, use
+  `render={<span />}` / `nativeButton={false}` or an equivalent non-button
+  render target when the trigger wraps button-like children.
+- Reuse `components/ui/` primitives and `lucide-react` icons instead of adding
+  one-off SVG controls.
+- Keep lists, tables, dialogs, and settings forms dense and operational; this app
+  is a management tool, not a landing page.
 
-## 5. Directory Structure
-- `app/`: Routing and page layouts.
-- `components/ui/`: Atomic shadcn components.
-- `components/modals/`: Feature-specific dialogs.
-- `hooks/`: Business logic hooks.
-- `lib/api/`: Typed backend client wrappers.
-- `store/`: Zustand global state stores.
-- `types/`: Shared TypeScript interfaces.
+## 5. API, IPC, and Web Fallback
+- Import `invoke`, `invokeFirst`, and `withAddr` from `@/lib/api/transport`.
+- Service commands that talk to the running backend should use `withAddr()` so
+  the current service address is injected.
+- App-shell commands such as window, updater, file-manager, and external-open
+  helpers may call `invoke` without `withAddr()` when they do not target the
+  service.
+- Do not use raw `fetch()` for desktop IPC. Web/service-mode HTTP access should
+  go through `transport.ts`, `transport-web-commands.ts`, `rpc-http.ts`, and
+  `fetchWithRetry`.
+- When adding a new backend command, update the typed wrapper in `src/lib/api/`
+  and, if it must work in service-mode Web UI, update the web command map with
+  the correct underscore-to-camelCase RPC mapping.
+- Standardize displayed errors through `getAppErrorMessage()` and the existing
+  transport error unwrapping helpers.
 
-## 6. Development Workflow
-- **Validation**: Every significant change must be verified with `pnpm run build:desktop` to ensure static export compatibility.
-- **Sync**: Ensure all new backend commands are added to `lib/api/` with correct underscore/camelCase mapping.
+## 6. Directory Structure
+- `src/app/`: App Router pages and layout.
+- `src/components/ui/`: atomic shadcn/Base UI primitives.
+- `src/components/layout/`: shell, sidebar, header, bootstrapping, and page cache.
+- `src/components/modals/`: feature-specific dialogs.
+- `src/hooks/`: business/data hooks.
+- `src/lib/api/`: typed backend client wrappers and transport.
+- `src/lib/store/`: Zustand global state.
+- `src/lib/i18n/`: locale provider and message dictionaries.
+- `src/types/`: shared TypeScript interfaces.
+- `src-tauri/`: Tauri app shell, command registry, lifecycle, tray/window logic,
+  desktop RPC client, and packaging config.
+- `tests/`: runtime and Playwright regression coverage.
+
+## 7. Development Workflow
+- Frontend changes: run `pnpm run build` or `pnpm run build:desktop`.
+- Runtime/transport changes: also run `pnpm run test:runtime`.
+- Navigation/cache changes: run `pnpm run test:navigation` when practical.
+- UI-flow changes with meaningful behavior risk should include or update
+  Playwright coverage under `tests/`.
+- Tauri command/lifecycle changes usually need Rust validation from the repo
+  root with `cargo test --workspace`.

--- a/crates/service/src/gateway/local_validation/request.rs
+++ b/crates/service/src/gateway/local_validation/request.rs
@@ -351,6 +351,70 @@ fn chat_tool_choice_to_responses(value: &serde_json::Value) -> serde_json::Value
     serde_json::json!({ "type": "function", "name": name })
 }
 
+fn chat_response_format_to_responses_text_format(
+    value: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "response_format must be an object".to_string())?;
+    let format_type = obj
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "response_format.type is required".to_string())?;
+
+    match format_type {
+        "text" => Ok(serde_json::json!({ "type": "text" })),
+        "json_object" => Ok(serde_json::json!({ "type": "json_object" })),
+        "json_schema" => {
+            let schema = obj
+                .get("json_schema")
+                .and_then(serde_json::Value::as_object)
+                .ok_or_else(|| {
+                    "response_format.json_schema must be an object for json_schema".to_string()
+                })?;
+            let mut mapped = serde_json::Map::new();
+            mapped.insert(
+                "type".to_string(),
+                serde_json::Value::String("json_schema".to_string()),
+            );
+            for (key, value) in schema {
+                mapped.insert(key.clone(), value.clone());
+            }
+            Ok(serde_json::Value::Object(mapped))
+        }
+        other => Err(format!("unsupported response_format.type: {other}")),
+    }
+}
+
+fn chat_text_config_with_response_format(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Option<serde_json::Value>, String> {
+    let has_response_format = obj.contains_key("response_format");
+    let mut text = match obj.get("text") {
+        Some(serde_json::Value::Null) | None => serde_json::Map::new(),
+        Some(serde_json::Value::Object(existing)) => existing.clone(),
+        Some(_) if has_response_format => {
+            return Err("text must be an object when provided with response_format".to_string());
+        }
+        Some(_) => serde_json::Map::new(),
+    };
+
+    if let Some(response_format) = obj.get("response_format") {
+        text.insert(
+            "format".to_string(),
+            chat_response_format_to_responses_text_format(response_format)?,
+        );
+    }
+
+    if text.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(serde_json::Value::Object(text)))
+    }
+}
+
 fn adapt_openai_chat_completions_body_to_responses(body: Vec<u8>) -> Result<Vec<u8>, String> {
     let payload = serde_json::from_slice::<serde_json::Value>(&body)
         .map_err(|err| format!("invalid chat completions request json: {err}"))?;
@@ -475,6 +539,9 @@ fn adapt_openai_chat_completions_body_to_responses(body: Vec<u8>) -> Result<Vec<
     }
     if let Some(metadata) = obj.get("metadata") {
         rewritten.insert("metadata".to_string(), metadata.clone());
+    }
+    if let Some(text) = chat_text_config_with_response_format(obj)? {
+        rewritten.insert("text".to_string(), text);
     }
     serde_json::to_vec(&serde_json::Value::Object(rewritten))
         .map_err(|err| format!("serialize responses compatibility request failed: {err}"))

--- a/crates/service/src/gateway/local_validation/tests/request_tests.rs
+++ b/crates/service/src/gateway/local_validation/tests/request_tests.rs
@@ -614,6 +614,161 @@ fn openai_chat_completions_api_body_is_adapted_to_responses_for_codex_backend() 
 }
 
 #[test]
+fn openai_chat_completions_response_format_json_object_adapts_to_responses_text_format() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "return json" }],
+        "response_format": { "type": "json_object" }
+    });
+    let adapted = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect("adapt chat body");
+    let payload: Value = serde_json::from_slice(&adapted).expect("json body");
+
+    assert_eq!(
+        payload
+            .get("text")
+            .and_then(|text| text.get("format"))
+            .and_then(|format| format.get("type"))
+            .and_then(Value::as_str),
+        Some("json_object")
+    );
+}
+
+#[test]
+fn openai_chat_completions_response_format_json_schema_adapts_to_responses_text_format() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "return json" }],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer_schema",
+                "strict": true,
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "answer": { "type": "string" }
+                    },
+                    "required": ["answer"],
+                    "additionalProperties": false
+                }
+            }
+        }
+    });
+    let adapted = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect("adapt chat body");
+    let payload: Value = serde_json::from_slice(&adapted).expect("json body");
+    let format = payload
+        .get("text")
+        .and_then(|text| text.get("format"))
+        .expect("text format");
+
+    assert_eq!(
+        format.get("type").and_then(Value::as_str),
+        Some("json_schema")
+    );
+    assert_eq!(
+        format.get("name").and_then(Value::as_str),
+        Some("answer_schema")
+    );
+    assert_eq!(format.get("strict").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        format
+            .get("schema")
+            .and_then(|schema| schema.get("required"))
+            .and_then(Value::as_array)
+            .and_then(|required| required.first())
+            .and_then(Value::as_str),
+        Some("answer")
+    );
+}
+
+#[test]
+fn openai_chat_completions_response_format_preserves_existing_text_fields() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "return json" }],
+        "text": {
+            "verbosity": "low",
+            "format": { "type": "text" }
+        },
+        "response_format": { "type": "json_object" }
+    });
+    let adapted = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect("adapt chat body");
+    let payload: Value = serde_json::from_slice(&adapted).expect("json body");
+
+    assert_eq!(
+        payload
+            .get("text")
+            .and_then(|text| text.get("verbosity"))
+            .and_then(Value::as_str),
+        Some("low")
+    );
+    assert_eq!(
+        payload
+            .get("text")
+            .and_then(|text| text.get("format"))
+            .and_then(|format| format.get("type"))
+            .and_then(Value::as_str),
+        Some("json_object")
+    );
+}
+
+#[test]
+fn openai_chat_completions_ignores_non_object_text_without_response_format() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "hello" }],
+        "text": "legacy-client-noise"
+    });
+    let adapted = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect("adapt chat body");
+    let payload: Value = serde_json::from_slice(&adapted).expect("json body");
+
+    assert!(payload.get("text").is_none());
+}
+
+#[test]
+fn openai_chat_completions_response_format_rejects_non_object_text() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "return json" }],
+        "text": "legacy-client-noise",
+        "response_format": { "type": "json_object" }
+    });
+    let err = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect_err("response_format with non-object text should fail");
+
+    assert!(err.contains("text must be an object"));
+}
+
+#[test]
+fn openai_chat_completions_response_format_rejects_invalid_values() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "return json" }],
+        "response_format": { "type": "xml" }
+    });
+    let err = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect_err("unsupported response_format should fail");
+
+    assert!(err.contains("unsupported response_format.type"));
+}
+
+#[test]
 fn opencode_headers_with_only_session_id_are_not_treated_as_native_codex_clients() {
     let opencode_headers = sample_incoming_headers_with_session_id(
         None,

--- a/crates/service/src/gateway/observability/http_bridge/aggregate/openai_responses_event.rs
+++ b/crates/service/src/gateway/observability/http_bridge/aggregate/openai_responses_event.rs
@@ -1,8 +1,9 @@
 use serde_json::Value;
 
 use super::output_text::{
-    append_output_text, collect_output_text_from_event_fields, collect_response_output_text,
-    extract_error_message_from_json, parse_usage_from_json, UpstreamResponseUsage,
+    append_output_text, append_output_text_raw, collect_output_text_from_event_fields,
+    collect_response_output_text, extract_error_message_from_json, merge_usage,
+    parse_usage_from_json, UpstreamResponseUsage,
 };
 use super::{parse_sse_frame_json, SseTerminal};
 
@@ -22,6 +23,7 @@ pub(in super::super) enum OpenAIResponsesEventKind {
     OutputItemDone,
     ImageGenerationPartialImage,
     ContentPartAdded,
+    ContentPartDelta,
     ContentPartDone,
     Other,
 }
@@ -38,17 +40,31 @@ impl OpenAIResponsesEventKind {
             "response.output_item.added" => Self::OutputItemAdded,
             "response.output_item.done" => Self::OutputItemDone,
             "response.image_generation_call.partial_image" => Self::ImageGenerationPartialImage,
-            "response.content_part.added" | "response.content_part.delta" => Self::ContentPartAdded,
+            "response.content_part.added" => Self::ContentPartAdded,
+            "response.content_part.delta" => Self::ContentPartDelta,
             "response.content_part.done" => Self::ContentPartDone,
             _ => Self::Other,
         }
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpenAIResponsesOutputTextKind {
+    Delta,
+    Snapshot,
+    TerminalSnapshot,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(in super::super) struct OpenAIResponsesOutputTextState {
+    saw_delta: bool,
+}
+
 #[derive(Debug, Clone)]
 pub(in super::super) struct OpenAIResponsesEvent {
     pub(in super::super) event_type: Option<String>,
     pub(in super::super) usage: UpstreamResponseUsage,
+    output_text_kind: Option<OpenAIResponsesOutputTextKind>,
     pub(in super::super) terminal: Option<SseTerminal>,
     pub(in super::super) upstream_error_hint: Option<String>,
 }
@@ -72,17 +88,63 @@ impl OpenAIResponsesEvent {
             terminal_for_event(kind, event_type.as_deref(), upstream_error_hint.as_deref());
 
         let mut usage = parse_usage_from_json(&value);
-        if let Some(extra_output_text) = collect_extra_output_text(&value, kind) {
-            let target = usage.output_text.get_or_insert_with(String::new);
-            append_output_text(target, extra_output_text.as_str());
-        }
+        usage.output_text = None;
+        let output_text_kind =
+            collect_event_output_text(&value, kind).map(|(extra_output_text, output_text_kind)| {
+                usage.output_text = Some(extra_output_text);
+                output_text_kind
+            });
 
         Some(Self {
             event_type,
             usage,
+            output_text_kind,
             terminal,
             upstream_error_hint,
         })
+    }
+
+    pub(in super::super) fn merge_usage_into(
+        &self,
+        target: &mut UpstreamResponseUsage,
+        text_state: &mut OpenAIResponsesOutputTextState,
+    ) {
+        let mut usage = self.usage.clone();
+        let output_text = usage.output_text.take();
+        merge_usage(target, usage);
+
+        let Some(output_text) = output_text else {
+            return;
+        };
+        if output_text.trim().is_empty() {
+            return;
+        }
+
+        match self.output_text_kind {
+            Some(OpenAIResponsesOutputTextKind::Delta) => {
+                let target_text = target.output_text.get_or_insert_with(String::new);
+                append_output_text_raw(target_text, output_text.as_str());
+                text_state.saw_delta = true;
+            }
+            Some(OpenAIResponsesOutputTextKind::Snapshot) => {
+                if !text_state.saw_delta {
+                    let target_text = target.output_text.get_or_insert_with(String::new);
+                    append_output_text_raw(target_text, output_text.as_str());
+                }
+            }
+            Some(OpenAIResponsesOutputTextKind::TerminalSnapshot) => {
+                if !text_state.saw_delta
+                    && target
+                        .output_text
+                        .as_deref()
+                        .is_none_or(|text| text.trim().is_empty())
+                {
+                    let target_text = target.output_text.get_or_insert_with(String::new);
+                    append_output_text_raw(target_text, output_text.as_str());
+                }
+            }
+            None => {}
+        }
     }
 }
 
@@ -114,6 +176,7 @@ fn terminal_for_event(
         | OpenAIResponsesEventKind::OutputItemDone
         | OpenAIResponsesEventKind::ImageGenerationPartialImage
         | OpenAIResponsesEventKind::ContentPartAdded
+        | OpenAIResponsesEventKind::ContentPartDelta
         | OpenAIResponsesEventKind::ContentPartDone
         | OpenAIResponsesEventKind::Other => None,
     }
@@ -136,25 +199,57 @@ fn normalize_terminal_error_hint(raw: &str) -> String {
     trimmed.to_string()
 }
 
-fn collect_extra_output_text(value: &Value, kind: OpenAIResponsesEventKind) -> Option<String> {
+fn collect_completed_response_text(value: &Value, text_out: &mut String) {
+    let response = value.get("response").unwrap_or(value);
+    if let Some(output_text) = response.get("output_text").and_then(Value::as_str) {
+        append_output_text(text_out, output_text);
+        return;
+    }
+    if let Some(output) = response.get("output") {
+        collect_response_output_text(output, text_out);
+    }
+}
+
+fn collect_event_output_text(
+    value: &Value,
+    kind: OpenAIResponsesEventKind,
+) -> Option<(String, OpenAIResponsesOutputTextKind)> {
     let mut text_out = String::new();
+    let mut output_text_kind = None;
 
     match kind {
-        OpenAIResponsesEventKind::OutputTextDelta
-        | OpenAIResponsesEventKind::OutputTextDone
-        | OpenAIResponsesEventKind::ContentPartAdded
-        | OpenAIResponsesEventKind::ContentPartDone => {
+        OpenAIResponsesEventKind::OutputTextDelta | OpenAIResponsesEventKind::ContentPartDelta => {
             if let Some(delta) = value.get("delta") {
                 collect_response_output_text(delta, &mut text_out);
             }
+            output_text_kind = Some(OpenAIResponsesOutputTextKind::Delta);
+        }
+        OpenAIResponsesEventKind::OutputTextDone => {
+            if let Some(text) = value.get("text") {
+                collect_response_output_text(text, &mut text_out);
+            } else if let Some(delta) = value.get("delta") {
+                collect_response_output_text(delta, &mut text_out);
+            }
+            output_text_kind = Some(OpenAIResponsesOutputTextKind::Snapshot);
+        }
+        OpenAIResponsesEventKind::ContentPartAdded | OpenAIResponsesEventKind::ContentPartDone => {
             collect_output_text_from_event_fields(value, &mut text_out);
+            if text_out.trim().is_empty() {
+                if let Some(delta) = value.get("delta") {
+                    collect_response_output_text(delta, &mut text_out);
+                }
+            }
+            output_text_kind = Some(OpenAIResponsesOutputTextKind::Snapshot);
         }
         OpenAIResponsesEventKind::OutputItemAdded | OpenAIResponsesEventKind::OutputItemDone => {
             collect_output_text_from_event_fields(value, &mut text_out);
+            output_text_kind = Some(OpenAIResponsesOutputTextKind::Snapshot);
         }
-        OpenAIResponsesEventKind::Completed
-        | OpenAIResponsesEventKind::Done
-        | OpenAIResponsesEventKind::Failed
+        OpenAIResponsesEventKind::Completed | OpenAIResponsesEventKind::Done => {
+            collect_completed_response_text(value, &mut text_out);
+            output_text_kind = Some(OpenAIResponsesOutputTextKind::TerminalSnapshot);
+        }
+        OpenAIResponsesEventKind::Failed
         | OpenAIResponsesEventKind::Incomplete
         | OpenAIResponsesEventKind::ImageGenerationPartialImage
         | OpenAIResponsesEventKind::Other => {}
@@ -164,7 +259,7 @@ fn collect_extra_output_text(value: &Value, kind: OpenAIResponsesEventKind) -> O
     if text.is_empty() {
         None
     } else {
-        Some(text_out)
+        output_text_kind.map(|kind| (text_out, kind))
     }
 }
 

--- a/crates/service/src/gateway/observability/http_bridge/aggregate/openai_responses_event.rs
+++ b/crates/service/src/gateway/observability/http_bridge/aggregate/openai_responses_event.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::collections::BTreeSet;
 
 use super::output_text::{
     append_output_text, append_output_text_raw, collect_output_text_from_event_fields,
@@ -58,6 +59,7 @@ enum OpenAIResponsesOutputTextKind {
 #[derive(Debug, Clone, Default)]
 pub(in super::super) struct OpenAIResponsesOutputTextState {
     saw_delta: bool,
+    seen_snapshot_keys: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,6 +67,7 @@ pub(in super::super) struct OpenAIResponsesEvent {
     pub(in super::super) event_type: Option<String>,
     pub(in super::super) usage: UpstreamResponseUsage,
     output_text_kind: Option<OpenAIResponsesOutputTextKind>,
+    output_text_snapshot_key: Option<String>,
     pub(in super::super) terminal: Option<SseTerminal>,
     pub(in super::super) upstream_error_hint: Option<String>,
 }
@@ -89,16 +92,20 @@ impl OpenAIResponsesEvent {
 
         let mut usage = parse_usage_from_json(&value);
         usage.output_text = None;
-        let output_text_kind =
-            collect_event_output_text(&value, kind).map(|(extra_output_text, output_text_kind)| {
+        let mut output_text_snapshot_key = None;
+        let output_text_kind = collect_event_output_text(&value, kind).map(
+            |(extra_output_text, output_text_kind, snapshot_key)| {
                 usage.output_text = Some(extra_output_text);
+                output_text_snapshot_key = snapshot_key;
                 output_text_kind
-            });
+            },
+        );
 
         Some(Self {
             event_type,
             usage,
             output_text_kind,
+            output_text_snapshot_key,
             terminal,
             upstream_error_hint,
         })
@@ -127,7 +134,11 @@ impl OpenAIResponsesEvent {
                 text_state.saw_delta = true;
             }
             Some(OpenAIResponsesOutputTextKind::Snapshot) => {
-                if !text_state.saw_delta {
+                let snapshot_key = self
+                    .output_text_snapshot_key
+                    .clone()
+                    .unwrap_or_else(|| output_text.trim().to_string());
+                if !text_state.saw_delta && text_state.seen_snapshot_keys.insert(snapshot_key) {
                     let target_text = target.output_text.get_or_insert_with(String::new);
                     append_output_text_raw(target_text, output_text.as_str());
                 }
@@ -210,10 +221,47 @@ fn collect_completed_response_text(value: &Value, text_out: &mut String) {
     }
 }
 
+fn collect_event_string_field<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .or_else(|| {
+            value
+                .get("item")
+                .and_then(|item| item.get(field))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+        })
+        .or_else(|| {
+            value
+                .get("output_item")
+                .and_then(|item| item.get(field))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+        })
+}
+
+fn snapshot_dedupe_key(value: &Value, text: &str) -> String {
+    let text = text.trim();
+    if let Some(output_index) = value.get("output_index").and_then(Value::as_i64) {
+        return format!("output_index={output_index};text={text}");
+    }
+    if let Some(item_id) = collect_event_string_field(value, "item_id")
+        .or_else(|| collect_event_string_field(value, "id"))
+    {
+        return format!("item_id={item_id};text={text}");
+    }
+    format!("text={text}")
+}
+
 fn collect_event_output_text(
     value: &Value,
     kind: OpenAIResponsesEventKind,
-) -> Option<(String, OpenAIResponsesOutputTextKind)> {
+) -> Option<(String, OpenAIResponsesOutputTextKind, Option<String>)> {
     let mut text_out = String::new();
     let mut output_text_kind = None;
 
@@ -259,7 +307,12 @@ fn collect_event_output_text(
     if text.is_empty() {
         None
     } else {
-        output_text_kind.map(|kind| (text_out, kind))
+        let snapshot_key = matches!(
+            output_text_kind,
+            Some(OpenAIResponsesOutputTextKind::Snapshot)
+        )
+        .then(|| snapshot_dedupe_key(value, text));
+        output_text_kind.map(|kind| (text_out, kind, snapshot_key))
     }
 }
 

--- a/crates/service/src/gateway/observability/http_bridge/aggregate/output_text.rs
+++ b/crates/service/src/gateway/observability/http_bridge/aggregate/output_text.rs
@@ -501,13 +501,17 @@ pub(in super::super) fn collect_output_text_from_event_fields(value: &Value, out
 /// 返回函数执行结果
 fn extract_output_text_from_json(value: &Value) -> Option<String> {
     let mut output = String::new();
-    if let Some(text) = value.get("output_text").and_then(Value::as_str) {
-        append_output_text(&mut output, text);
-    }
     if let Some(response) = value.get("response") {
-        collect_response_output_text(response, &mut output);
-    }
-    if let Some(top_level_output) = value.get("output") {
+        if let Some(text) = response.get("output_text").and_then(Value::as_str) {
+            append_output_text(&mut output, text);
+        } else if let Some(response_output) = response.get("output") {
+            collect_response_output_text(response_output, &mut output);
+        } else {
+            collect_response_output_text(response, &mut output);
+        }
+    } else if let Some(text) = value.get("output_text").and_then(Value::as_str) {
+        append_output_text(&mut output, text);
+    } else if let Some(top_level_output) = value.get("output") {
         collect_response_output_text(top_level_output, &mut output);
     }
     if let Some(choices) = value.get("choices") {

--- a/crates/service/src/gateway/observability/http_bridge/aggregate/sse_aggregate.rs
+++ b/crates/service/src/gateway/observability/http_bridge/aggregate/sse_aggregate.rs
@@ -2,6 +2,7 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Cursor};
 
+use super::openai_responses_event::{OpenAIResponsesEvent, OpenAIResponsesOutputTextState};
 use super::{
     append_output_text_raw, collect_output_text_from_event_fields, collect_response_output_text,
     inspect_sse_frame, is_response_completed_event_name, merge_usage, parse_sse_frame_json,
@@ -372,21 +373,32 @@ fn update_responses_sse_synthesis(synthesis: &mut ResponsesSseSynthesis, value: 
     }
 
     let mut text_out = String::new();
-    collect_output_text_from_event_fields(value, &mut text_out);
-    if matches!(
-        event_type,
-        "response.output_text.delta"
-            | "response.output_text.done"
-            | "response.content_part.added"
-            | "response.content_part.delta"
-            | "response.content_part.done"
-    ) {
-        if let Some(delta) = value.get("delta") {
-            collect_response_output_text(delta, &mut text_out);
+    match event_type {
+        "response.output_text.delta" | "response.content_part.delta" => {
+            if let Some(delta) = value.get("delta") {
+                collect_response_output_text(delta, &mut text_out);
+            }
         }
-    }
-    if let Some(response) = value.get("response") {
-        collect_response_output_text(response, &mut text_out);
+        "response.output_text.done" => {
+            if synthesis.output_text.trim().is_empty() {
+                if let Some(text) = value.get("text") {
+                    collect_response_output_text(text, &mut text_out);
+                } else if let Some(delta) = value.get("delta") {
+                    collect_response_output_text(delta, &mut text_out);
+                }
+            }
+        }
+        "response.content_part.done" => {
+            if synthesis.output_text.trim().is_empty() {
+                collect_output_text_from_event_fields(value, &mut text_out);
+                if text_out.trim().is_empty() {
+                    if let Some(delta) = value.get("delta") {
+                        collect_response_output_text(delta, &mut text_out);
+                    }
+                }
+            }
+        }
+        _ => {}
     }
     if !text_out.trim().is_empty() {
         append_output_text_raw(&mut synthesis.output_text, text_out.as_str());
@@ -523,21 +535,25 @@ fn enrich_completed_response_with_sse_text(
         .get("output")
         .and_then(Value::as_array)
         .is_some_and(|items| !items.is_empty());
-    let has_effective_output = response_has_effective_output(&Value::Object(response_obj.clone()));
+    let had_effective_output = response_has_effective_output(&Value::Object(response_obj.clone()));
+    let mut inserted_output_from_delta_text = false;
     if !has_structured_output {
         if let Some(output_items) = build_response_output_items_from_sse(synthesis) {
             response_obj.insert("output".to_string(), output_items);
-        } else if !has_effective_output && !synthesis.output_text.trim().is_empty() {
+        } else if !had_effective_output && !synthesis.output_text.trim().is_empty() {
             response_obj.insert(
                 "output".to_string(),
                 build_response_output_items_from_text(synthesis.output_text.as_str()),
             );
+            inserted_output_from_delta_text = true;
         }
     }
-    if response_obj
-        .get("output_text")
-        .and_then(Value::as_str)
-        .is_none_or(|text| text.trim().is_empty())
+    let has_effective_output = response_has_effective_output(&Value::Object(response_obj.clone()));
+    if (inserted_output_from_delta_text || !has_effective_output)
+        && response_obj
+            .get("output_text")
+            .and_then(Value::as_str)
+            .is_none_or(|text| text.trim().is_empty())
         && !synthesis.output_text.trim().is_empty()
     {
         response_obj.insert(
@@ -562,6 +578,11 @@ fn enrich_completed_response_with_sse_text(
 /// 返回函数执行结果
 fn synthesize_response_body_from_sse(synthesis: &ResponsesSseSynthesis) -> Option<Vec<u8>> {
     let output_items = build_response_output_items_from_sse(synthesis);
+    let output_items_have_text = output_items.as_ref().is_some_and(|output_items| {
+        let mut response = serde_json::Map::new();
+        response.insert("output".to_string(), output_items.clone());
+        response_has_effective_output(&Value::Object(response))
+    });
     if !synthesis.saw_completed
         || (synthesis.output_text.trim().is_empty() && output_items.is_none())
     {
@@ -601,7 +622,7 @@ fn synthesize_response_body_from_sse(synthesis: &ResponsesSseSynthesis) -> Optio
         output_items
             .unwrap_or_else(|| build_response_output_items_from_text(synthesis.output_text.trim())),
     );
-    if !synthesis.output_text.trim().is_empty() {
+    if !output_items_have_text && !synthesis.output_text.trim().is_empty() {
         out.insert(
             "output_text".to_string(),
             Value::String(synthesis.output_text.trim().to_string()),
@@ -684,6 +705,28 @@ fn synthesize_chat_completion_body(synthesis: &ChatCompletionSseSynthesis) -> Op
     serde_json::to_vec(&Value::Object(out)).ok()
 }
 
+fn merge_sse_frame_usage(
+    usage: &mut UpstreamResponseUsage,
+    responses_text_state: &mut OpenAIResponsesOutputTextState,
+    frame: &[String],
+) {
+    if let Some(event) = OpenAIResponsesEvent::parse(frame) {
+        if event
+            .event_type
+            .as_deref()
+            .is_some_and(|event_type| event_type.starts_with("response."))
+        {
+            event.merge_usage_into(usage, responses_text_state);
+            return;
+        }
+    }
+
+    let inspection = inspect_sse_frame(frame);
+    if let Some(parsed_usage) = inspection.usage {
+        merge_usage(usage, parsed_usage);
+    }
+}
+
 /// 函数 `collect_non_stream_json_from_sse_bytes`
 ///
 /// 作者: gaohongshun
@@ -701,6 +744,7 @@ pub(in super::super) fn collect_non_stream_json_from_sse_bytes(
     let mut usage = UpstreamResponseUsage::default();
     let mut completed_response: Option<Value> = None;
     let mut responses_sse_synthesis = ResponsesSseSynthesis::default();
+    let mut responses_usage_text_state = OpenAIResponsesOutputTextState::default();
     let mut chat_completion_synthesis = ChatCompletionSseSynthesis::default();
     let mut frame_lines: Vec<String> = Vec::new();
 
@@ -719,10 +763,7 @@ pub(in super::super) fn collect_non_stream_json_from_sse_bytes(
                 continue;
             }
             let frame = std::mem::take(&mut frame_lines);
-            let inspection = inspect_sse_frame(&frame);
-            if let Some(parsed_usage) = inspection.usage {
-                merge_usage(&mut usage, parsed_usage);
-            }
+            merge_sse_frame_usage(&mut usage, &mut responses_usage_text_state, &frame);
             if let Some(value) = parse_sse_frame_json(&frame) {
                 update_responses_sse_synthesis(&mut responses_sse_synthesis, &value);
                 update_chat_completion_sse_synthesis(&mut chat_completion_synthesis, &value);
@@ -742,10 +783,7 @@ pub(in super::super) fn collect_non_stream_json_from_sse_bytes(
     }
 
     if !frame_lines.is_empty() {
-        let inspection = inspect_sse_frame(&frame_lines);
-        if let Some(parsed_usage) = inspection.usage {
-            merge_usage(&mut usage, parsed_usage);
-        }
+        merge_sse_frame_usage(&mut usage, &mut responses_usage_text_state, &frame_lines);
         if let Some(value) = parse_sse_frame_json(&frame_lines) {
             update_responses_sse_synthesis(&mut responses_sse_synthesis, &value);
             update_chat_completion_sse_synthesis(&mut chat_completion_synthesis, &value);

--- a/crates/service/src/gateway/observability/http_bridge/delivery.rs
+++ b/crates/service/src/gateway/observability/http_bridge/delivery.rs
@@ -3784,8 +3784,9 @@ fn resolve_stream_keepalive_frame(
 mod tests {
     use super::{
         build_passthrough_non_success_message, classify_compact_non_success_kind,
-        compact_non_success_body_should_be_normalized, compact_success_body_is_valid,
-        convert_chat_completions_body_to_compact, convert_responses_body_to_chat_completions,
+        collect_non_stream_json_from_sse_bytes, compact_non_success_body_should_be_normalized,
+        compact_success_body_is_valid, convert_chat_completions_body_to_compact,
+        convert_responses_body_to_chat_completions,
         convert_responses_body_to_gemini_generate_content, convert_responses_body_to_images,
         force_openai_responses_stream_content_type, gemini_cli_wrap_response_envelope, Header,
         ImagesResponseFormat, ResponseAdapter,
@@ -4068,6 +4069,33 @@ mod tests {
             value["usage"]["prompt_tokens"],
             serde_json::Value::Number(2.into())
         );
+    }
+
+    #[test]
+    fn non_stream_chat_responses_sse_json_mode_returns_single_parseable_content() {
+        let sse = concat!(
+            "event: response.output_text.delta\n",
+            "data: {\"response_id\":\"resp_non_stream_json\",\"delta\":\"{\\\"answer\\\":true}\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"response_id\":\"resp_non_stream_json\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}}\n\n",
+            "event: response.completed\n",
+            "data: {\"response\":{\"id\":\"resp_non_stream_json\",\"created\":3,\"model\":\"gpt-5.3-codex\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":2,\"total_tokens\":5}}}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let (body, _) = collect_non_stream_json_from_sse_bytes(sse.as_bytes());
+        let body = body.expect("synthesized response json");
+        let mapped = convert_responses_body_to_chat_completions(body.as_slice())
+            .expect("convert chat completion body");
+        let value: serde_json::Value =
+            serde_json::from_slice(&mapped).expect("parse chat completion body");
+        let content = value["choices"][0]["message"]["content"]
+            .as_str()
+            .expect("chat message content");
+
+        assert_eq!(content, r#"{"answer":true}"#);
+        let parsed: serde_json::Value =
+            serde_json::from_str(content).expect("chat content is a single json document");
+        assert_eq!(parsed["answer"], true);
     }
 
     #[test]

--- a/crates/service/src/gateway/observability/http_bridge/delivery.rs
+++ b/crates/service/src/gateway/observability/http_bridge/delivery.rs
@@ -618,6 +618,15 @@ fn extract_error_message_from_json_bytes(body: &[u8]) -> Option<String> {
     extract_error_message_from_json(&value)
 }
 
+fn merge_usage_from_body_without_output_text(usage: &mut UpstreamResponseUsage, body: &[u8]) {
+    let Ok(value) = serde_json::from_slice::<Value>(body) else {
+        return;
+    };
+    let mut parsed_usage = parse_usage_from_json(&value);
+    parsed_usage.output_text = None;
+    merge_usage(usage, parsed_usage);
+}
+
 fn replace_content_type_header(headers: &mut Vec<Header>, content_type: &str) {
     headers.retain(|header| {
         !header
@@ -1893,9 +1902,7 @@ pub(crate) fn respond_with_upstream(
                 let (synthesized, mut usage) =
                     collect_non_stream_json_from_sse_bytes(upstream_body.as_ref());
                 let body = synthesized.unwrap_or_else(|| upstream_body.to_vec());
-                if let Ok(value) = serde_json::from_slice::<Value>(&body) {
-                    merge_usage(&mut usage, parse_usage_from_json(&value));
-                }
+                merge_usage_from_body_without_output_text(&mut usage, &body);
                 (body, usage)
             } else {
                 let usage = serde_json::from_slice::<Value>(upstream_body.as_ref())
@@ -2231,9 +2238,7 @@ pub(crate) fn respond_with_upstream(
                         collect_non_stream_json_from_sse_bytes(upstream_body.as_ref());
                     let synthesized_response = synthesized_body.is_some();
                     let body = synthesized_body.unwrap_or_else(|| upstream_body.to_vec());
-                    if let Ok(value) = serde_json::from_slice::<Value>(&body) {
-                        merge_usage(&mut usage, parse_usage_from_json(&value));
-                    }
+                    merge_usage_from_body_without_output_text(&mut usage, &body);
                     let upstream_error_hint = with_upstream_debug_suffix(
                         extract_error_hint_from_body_or_headers(
                             status.0,
@@ -2861,9 +2866,7 @@ pub(crate) fn respond_with_stream_upstream(
                 let (synthesized, mut usage) =
                     collect_non_stream_json_from_sse_bytes(upstream_body.as_ref());
                 let body = synthesized.unwrap_or_else(|| upstream_body.to_vec());
-                if let Ok(value) = serde_json::from_slice::<Value>(&body) {
-                    merge_usage(&mut usage, parse_usage_from_json(&value));
-                }
+                merge_usage_from_body_without_output_text(&mut usage, &body);
                 (body, usage)
             } else {
                 let usage = serde_json::from_slice::<Value>(upstream_body.as_ref())
@@ -3044,9 +3047,7 @@ pub(crate) fn respond_with_stream_upstream(
                 let (synthesized, mut usage) =
                     collect_non_stream_json_from_sse_bytes(upstream_body.as_ref());
                 let body = synthesized.unwrap_or_else(|| upstream_body.to_vec());
-                if let Ok(value) = serde_json::from_slice::<Value>(&body) {
-                    merge_usage(&mut usage, parse_usage_from_json(&value));
-                }
+                merge_usage_from_body_without_output_text(&mut usage, &body);
                 let chat_body =
                     convert_responses_body_to_chat_completions(&body).unwrap_or_else(|| body);
                 let response_body = chat_completion_body_to_single_sse(&chat_body);
@@ -3097,9 +3098,7 @@ pub(crate) fn respond_with_stream_upstream(
                 let (synthesized, mut usage) =
                     collect_non_stream_json_from_sse_bytes(upstream_body.as_ref());
                 let body = synthesized.unwrap_or_else(|| upstream_body.to_vec());
-                if let Ok(value) = serde_json::from_slice::<Value>(&body) {
-                    merge_usage(&mut usage, parse_usage_from_json(&value));
-                }
+                merge_usage_from_body_without_output_text(&mut usage, &body);
                 let response_body = images_response_body_to_sse(&body, response_format);
                 let len = Some(response_body.len());
                 let response = Response::new(
@@ -3221,9 +3220,7 @@ pub(crate) fn respond_with_stream_upstream(
                         collect_non_stream_json_from_sse_bytes(upstream_body.as_ref());
                     let synthesized_response = synthesized_body.is_some();
                     let body = synthesized_body.unwrap_or_else(|| upstream_body.to_vec());
-                    if let Ok(value) = serde_json::from_slice::<Value>(&body) {
-                        merge_usage(&mut usage, parse_usage_from_json(&value));
-                    }
+                    merge_usage_from_body_without_output_text(&mut usage, &body);
                     let upstream_error_hint = with_upstream_debug_suffix(
                         extract_error_hint_from_body_or_headers(
                             status.0,
@@ -3788,8 +3785,8 @@ mod tests {
         compact_success_body_is_valid, convert_chat_completions_body_to_compact,
         convert_responses_body_to_chat_completions,
         convert_responses_body_to_gemini_generate_content, convert_responses_body_to_images,
-        force_openai_responses_stream_content_type, gemini_cli_wrap_response_envelope, Header,
-        ImagesResponseFormat, ResponseAdapter,
+        force_openai_responses_stream_content_type, gemini_cli_wrap_response_envelope,
+        merge_usage_from_body_without_output_text, Header, ImagesResponseFormat, ResponseAdapter,
     };
     use serde_json::json;
 
@@ -4096,6 +4093,26 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(content).expect("chat content is a single json document");
         assert_eq!(parsed["answer"], true);
+    }
+
+    #[test]
+    fn sse_synthesized_body_usage_merge_does_not_duplicate_output_text() {
+        let sse = concat!(
+            "event: response.output_text.delta\n",
+            "data: {\"response_id\":\"resp_usage_no_dup\",\"delta\":\"{\\\"answer\\\":true}\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"response\":{\"id\":\"resp_usage_no_dup\",\"created\":3,\"model\":\"gpt-5.3-codex\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":2,\"total_tokens\":5}}}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let (body, mut usage) = collect_non_stream_json_from_sse_bytes(sse.as_bytes());
+        let body = body.expect("synthesized response json");
+
+        merge_usage_from_body_without_output_text(&mut usage, body.as_slice());
+
+        assert_eq!(usage.output_text.as_deref(), Some(r#"{"answer":true}"#));
+        assert_eq!(usage.input_tokens, Some(3));
+        assert_eq!(usage.output_tokens, Some(2));
+        assert_eq!(usage.total_tokens, Some(5));
     }
 
     #[test]

--- a/crates/service/src/gateway/observability/http_bridge/mod.rs
+++ b/crates/service/src/gateway/observability/http_bridge/mod.rs
@@ -6,11 +6,12 @@ use serde_json::{json, Value};
 mod aggregate;
 #[cfg(test)]
 mod openai;
-use aggregate::openai_responses_event::OpenAIResponsesEvent;
+use aggregate::openai_responses_event::{OpenAIResponsesEvent, OpenAIResponsesOutputTextState};
 pub(crate) use aggregate::PassthroughSseProtocol;
 #[allow(unused_imports)]
 use aggregate::{
-    append_output_text, collect_output_text_from_event_fields, collect_response_output_text,
+    append_output_text, append_output_text_raw, collect_output_text_from_event_fields,
+    collect_response_output_text,
 };
 use aggregate::{
     collect_non_stream_json_from_sse_bytes, extract_error_hint_from_body,

--- a/crates/service/src/gateway/observability/http_bridge/stream_readers.rs
+++ b/crates/service/src/gateway/observability/http_bridge/stream_readers.rs
@@ -10,7 +10,7 @@ use super::{
     build_images_api_response, chat_image_payload, collect_image_generation_data_urls,
     collect_image_generation_results, image_generation_result_payload, images_usage_value,
     inspect_sse_frame_for_protocol, ImagesResponseFormat, OpenAIResponsesEvent,
-    PassthroughSseProtocol, SseTerminal, UpstreamResponseUsage,
+    OpenAIResponsesOutputTextState, PassthroughSseProtocol, SseTerminal, UpstreamResponseUsage,
 };
 #[path = "stream_readers/anthropic.rs"]
 mod anthropic;

--- a/crates/service/src/gateway/observability/http_bridge/stream_readers/chat_completions.rs
+++ b/crates/service/src/gateway/observability/http_bridge/stream_readers/chat_completions.rs
@@ -1,10 +1,10 @@
 use super::{
     chat_image_payload, classify_upstream_stream_read_error, collect_image_generation_data_urls,
-    collect_response_output_text, mark_first_response_ms, merge_usage, should_emit_keepalive,
-    stream_idle_timed_out, stream_idle_timeout_message, stream_reader_disconnected_message,
-    stream_wait_timeout, upstream_hint_or_stream_incomplete_message, Arc, Cursor, Mutex,
-    PassthroughSseCollector, Read, SseKeepAliveFrame, UpstreamSseFramePump,
-    UpstreamSseFramePumpItem,
+    collect_output_text_from_event_fields, collect_response_output_text, mark_first_response_ms,
+    merge_usage, should_emit_keepalive, stream_idle_timed_out, stream_idle_timeout_message,
+    stream_reader_disconnected_message, stream_wait_timeout,
+    upstream_hint_or_stream_incomplete_message, Arc, Cursor, Mutex, PassthroughSseCollector, Read,
+    SseKeepAliveFrame, UpstreamSseFramePump, UpstreamSseFramePumpItem,
 };
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -346,16 +346,32 @@ impl ChatCompletionsFromResponsesSseReader {
         self.remember_meta(&value);
         let event_type = Self::event_type(lines, &value);
         let mut text = String::new();
-        if matches!(
-            event_type.as_deref(),
-            Some("response.output_text.delta")
-                | Some("response.output_text.done")
-                | Some("response.content_part.delta")
-                | Some("response.content_part.done")
-        ) {
-            if let Some(delta) = value.get("delta") {
-                collect_response_output_text(delta, &mut text);
+        match event_type.as_deref() {
+            Some("response.output_text.delta") | Some("response.content_part.delta") => {
+                if let Some(delta) = value.get("delta") {
+                    collect_response_output_text(delta, &mut text);
+                }
             }
+            Some("response.output_text.done") => {
+                if !self.emitted_text {
+                    if let Some(done_text) = value.get("text") {
+                        collect_response_output_text(done_text, &mut text);
+                    } else if let Some(delta) = value.get("delta") {
+                        collect_response_output_text(delta, &mut text);
+                    }
+                }
+            }
+            Some("response.content_part.done") => {
+                if !self.emitted_text {
+                    collect_output_text_from_event_fields(&value, &mut text);
+                    if text.is_empty() {
+                        if let Some(delta) = value.get("delta") {
+                            collect_response_output_text(delta, &mut text);
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
         if matches!(
             event_type.as_deref(),
@@ -390,6 +406,9 @@ impl ChatCompletionsFromResponsesSseReader {
             }
             if let Some(images) = self.image_delta_chunk(&value) {
                 return Some(images);
+            }
+            if !self.emitted_text {
+                collect_output_text_from_event_fields(&value, &mut text);
             }
         }
         if event_type.as_deref() == Some("response.output_item.added") {

--- a/crates/service/src/gateway/observability/http_bridge/stream_readers/openai_responses.rs
+++ b/crates/service/src/gateway/observability/http_bridge/stream_readers/openai_responses.rs
@@ -1,8 +1,8 @@
 use super::{
-    classify_upstream_stream_read_error, mark_first_response_ms, merge_usage,
-    stream_idle_timed_out, stream_idle_timeout_message, stream_reader_disconnected_message,
-    stream_wait_timeout, upstream_hint_or_stream_incomplete_message, Arc, Cursor, Mutex,
-    OpenAIResponsesEvent, PassthroughSseCollector, Read, SseKeepAliveFrame, SseTerminal,
+    classify_upstream_stream_read_error, mark_first_response_ms, stream_idle_timed_out,
+    stream_idle_timeout_message, stream_reader_disconnected_message, stream_wait_timeout,
+    upstream_hint_or_stream_incomplete_message, Arc, Cursor, Mutex, OpenAIResponsesEvent,
+    OpenAIResponsesOutputTextState, PassthroughSseCollector, Read, SseKeepAliveFrame, SseTerminal,
 };
 use crate::gateway::upstream::{GatewayByteStream, GatewayByteStreamItem, GatewayStreamResponse};
 use eventsource_stream::{Event, Eventsource};
@@ -109,6 +109,7 @@ pub(crate) struct OpenAIResponsesPassthroughSseReader {
     observer: OpenAIResponsesSidecarObserver,
     out_cursor: Cursor<Vec<u8>>,
     usage_collector: Arc<Mutex<PassthroughSseCollector>>,
+    usage_text_state: OpenAIResponsesOutputTextState,
     keepalive_frame: SseKeepAliveFrame,
     request_started_at: Instant,
     last_upstream_activity: Instant,
@@ -142,6 +143,7 @@ impl OpenAIResponsesPassthroughSseReader {
             observer: OpenAIResponsesSidecarObserver::new(sidecar_upstream),
             out_cursor: Cursor::new(Vec::new()),
             usage_collector,
+            usage_text_state: OpenAIResponsesOutputTextState::default(),
             keepalive_frame,
             request_started_at,
             last_upstream_activity: Instant::now(),
@@ -149,25 +151,25 @@ impl OpenAIResponsesPassthroughSseReader {
         }
     }
 
-    fn update_usage_from_event(&self, event: OpenAIResponsesEvent) {
+    fn update_usage_from_event(&mut self, event: OpenAIResponsesEvent) {
         if let Ok(mut collector) = self.usage_collector.lock() {
-            if let Some(event_type) = event.event_type {
-                collector.last_event_type = Some(event_type);
+            if let Some(event_type) = event.event_type.as_ref() {
+                collector.last_event_type = Some(event_type.clone());
             }
-            merge_usage(&mut collector.usage, event.usage);
-            if let Some(upstream_error_hint) = event.upstream_error_hint {
-                collector.upstream_error_hint = Some(upstream_error_hint);
+            event.merge_usage_into(&mut collector.usage, &mut self.usage_text_state);
+            if let Some(upstream_error_hint) = event.upstream_error_hint.as_ref() {
+                collector.upstream_error_hint = Some(upstream_error_hint.clone());
             }
-            if let Some(terminal) = event.terminal {
+            if let Some(terminal) = event.terminal.as_ref() {
                 collector.saw_terminal = true;
                 if let SseTerminal::Err(message) = terminal {
-                    collector.terminal_error = Some(message);
+                    collector.terminal_error = Some(message.clone());
                 }
             }
         }
     }
 
-    fn drain_sidecar_events(&self) {
+    fn drain_sidecar_events(&mut self) {
         loop {
             match self.observer.try_recv() {
                 Ok(OpenAIResponsesSidecarItem::Event(event)) => {
@@ -187,7 +189,7 @@ impl OpenAIResponsesPassthroughSseReader {
         }
     }
 
-    fn drain_sidecar_with_deadline(&self, timeout: Duration) {
+    fn drain_sidecar_with_deadline(&mut self, timeout: Duration) {
         let deadline = Instant::now() + timeout;
         loop {
             self.drain_sidecar_events();

--- a/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
+++ b/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
@@ -148,6 +148,19 @@ fn open_streaming_mock_http_response(
     (response, server)
 }
 
+fn chat_sse_content_fragments(out: &str) -> Vec<String> {
+    out.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter(|data| data.trim() != "[DONE]")
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .filter_map(|value| {
+            value["choices"][0]["delta"]["content"]
+                .as_str()
+                .map(str::to_string)
+        })
+        .collect()
+}
+
 /// 函数 `parse_usage_from_json_reads_cached_and_reasoning_details`
 ///
 /// 作者: gaohongshun
@@ -275,6 +288,29 @@ fn parse_usage_from_json_merges_response_usage_over_top_level_usage() {
     assert_eq!(usage.output_tokens, Some(9));
     assert_eq!(usage.total_tokens, Some(22));
     assert_eq!(usage.reasoning_output_tokens, None);
+}
+
+#[test]
+fn parse_usage_from_json_prefers_output_text_over_duplicate_output() {
+    let payload = json!({
+        "response": {
+            "output_text": "{\"answer\":true}",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "text": "{\"answer\":true}" }]
+            }],
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 2,
+                "total_tokens": 5
+            }
+        }
+    });
+
+    let usage = parse_usage_from_json(&payload);
+    assert_eq!(usage.output_text.as_deref(), Some(r#"{"answer":true}"#));
+    assert_eq!(usage.total_tokens, Some(5));
 }
 
 /// 函数 `parse_usage_from_sse_frame_reads_response_completed_usage`
@@ -690,6 +726,74 @@ fn chat_completions_reader_converts_responses_sse_to_chat_sse() {
 }
 
 #[test]
+fn chat_completions_reader_uses_output_text_done_text_when_delta_missing() {
+    let json_text = r#"{"ok":true}"#;
+    let sse = concat!(
+        "data: {\"type\":\"response.output_text.done\",\"text\":\"{\\\"ok\\\":true}\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_chat_done_only\",\"model\":\"gpt-5.4\",\"created\":1775900000,\"usage\":{\"input_tokens\":2,\"output_tokens\":2,\"total_tokens\":4}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let response = open_mock_http_response("text/event-stream", sse);
+    let collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = ChatCompletionsFromResponsesSseReader::new(
+        response,
+        Arc::clone(&collector),
+        std::time::Instant::now(),
+    );
+    let mut out = String::new();
+    reader.read_to_string(&mut out).expect("read chat sse");
+
+    assert_eq!(chat_sse_content_fragments(&out), vec![json_text]);
+    assert!(out.contains("\"finish_reason\":\"stop\""));
+    assert!(out.contains("data: [DONE]"));
+}
+
+#[test]
+fn chat_completions_reader_uses_output_item_done_text_when_delta_missing() {
+    let json_text = r#"{"ok":true}"#;
+    let sse = concat!(
+        "data: {\"type\":\"response.output_item.done\",\"response_id\":\"resp_chat_item_only\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"ok\\\":true}\"}]}}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_chat_item_only\",\"model\":\"gpt-5.4\",\"created\":1775900000,\"usage\":{\"input_tokens\":2,\"output_tokens\":2,\"total_tokens\":4}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let response = open_mock_http_response("text/event-stream", sse);
+    let collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = ChatCompletionsFromResponsesSseReader::new(
+        response,
+        Arc::clone(&collector),
+        std::time::Instant::now(),
+    );
+    let mut out = String::new();
+    reader.read_to_string(&mut out).expect("read chat sse");
+
+    assert_eq!(chat_sse_content_fragments(&out), vec![json_text]);
+    assert!(out.contains("data: [DONE]"));
+}
+
+#[test]
+fn chat_completions_reader_does_not_duplicate_output_text_done_snapshot_after_delta() {
+    let json_text = r#"{"ok":true}"#;
+    let sse = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"{\\\"ok\\\":true}\"}\n\n",
+        "data: {\"type\":\"response.output_text.done\",\"text\":\"{\\\"ok\\\":true}\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_chat_no_dup\",\"model\":\"gpt-5.4\",\"created\":1775900000,\"usage\":{\"input_tokens\":2,\"output_tokens\":2,\"total_tokens\":4}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let response = open_mock_http_response("text/event-stream", sse);
+    let collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = ChatCompletionsFromResponsesSseReader::new(
+        response,
+        Arc::clone(&collector),
+        std::time::Instant::now(),
+    );
+    let mut out = String::new();
+    reader.read_to_string(&mut out).expect("read chat sse");
+
+    assert_eq!(chat_sse_content_fragments(&out), vec![json_text]);
+    assert!(out.contains("data: [DONE]"));
+}
+
+#[test]
 fn chat_completions_reader_converts_image_generation_call_to_delta_images() {
     let sse = concat!(
         "data: {\"type\":\"response.output_item.done\",\"response_id\":\"resp_img_1\",\"output_index\":0,\"item\":{\"type\":\"image_generation_call\",\"id\":\"ig_1\",\"status\":\"completed\",\"output_format\":\"png\",\"result\":\"aGVsbG8=\"}}\n\n",
@@ -1055,6 +1159,58 @@ fn collect_non_stream_json_from_sse_bytes_supports_event_only_type_frames() {
     assert_eq!(usage.input_tokens, Some(3));
     assert_eq!(usage.output_tokens, Some(2));
     assert_eq!(usage.total_tokens, Some(5));
+}
+
+#[test]
+fn sse_responses_json_text_not_duplicated_across_delta_item_completed() {
+    let json_text = r#"{"answer":true}"#;
+    let sse = concat!(
+        "event: response.output_text.delta\n",
+        "data: {\"response_id\":\"resp_json_single\",\"delta\":\"{\\\"answer\\\":true}\"}\n\n",
+        "event: response.output_item.done\n",
+        "data: {\"response_id\":\"resp_json_single\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}}\n\n",
+        "event: response.completed\n",
+        "data: {\"response\":{\"id\":\"resp_json_single\",\"created\":3,\"model\":\"gpt-5.3-codex\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":2,\"total_tokens\":5}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let (body, usage) = collect_non_stream_json_from_sse_bytes(sse.as_bytes());
+    let body = body.expect("synthesized response json");
+    let value: serde_json::Value = serde_json::from_slice(&body).expect("parse synthesized body");
+    let content = value["output"][0]["content"][0]["text"]
+        .as_str()
+        .expect("assistant text");
+
+    assert_eq!(content, json_text);
+    serde_json::from_str::<serde_json::Value>(content).expect("parse json mode content");
+    assert!(value.get("output_text").is_none());
+    assert_eq!(usage.output_text.as_deref(), Some(json_text));
+    assert_eq!(usage.input_tokens, Some(3));
+    assert_eq!(usage.output_tokens, Some(2));
+    assert_eq!(usage.total_tokens, Some(5));
+}
+
+#[test]
+fn sse_completed_response_without_usable_output_falls_back_to_delta_text() {
+    let sse = concat!(
+        "event: response.output_text.delta\n",
+        "data: {\"response_id\":\"resp_json_fallback\",\"delta\":\"{\\\"ok\\\":true}\"}\n\n",
+        "event: response.completed\n",
+        "data: {\"response\":{\"id\":\"resp_json_fallback\",\"created\":4,\"model\":\"gpt-5.3-codex\",\"output\":[],\"usage\":{\"input_tokens\":4,\"output_tokens\":2,\"total_tokens\":6}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let (body, usage) = collect_non_stream_json_from_sse_bytes(sse.as_bytes());
+    let body = body.expect("synthesized response json");
+    let value: serde_json::Value = serde_json::from_slice(&body).expect("parse synthesized body");
+    let content = value["output"][0]["content"][0]["text"]
+        .as_str()
+        .expect("assistant text");
+
+    assert_eq!(content, r#"{"ok":true}"#);
+    assert_eq!(value["output_text"], r#"{"ok":true}"#);
+    assert_eq!(usage.output_text.as_deref(), Some(r#"{"ok":true}"#));
+    assert_eq!(usage.input_tokens, Some(4));
+    assert_eq!(usage.output_tokens, Some(2));
+    assert_eq!(usage.total_tokens, Some(6));
 }
 
 /// 函数 `parse_sse_frame_json_supports_json_lines_without_data_prefix`
@@ -2079,6 +2235,48 @@ fn openai_responses_passthrough_reader_collects_output_item_field_text() {
         Some("hello from output_item")
     );
     assert_eq!(collector.usage.total_tokens, Some(2));
+    assert!(collector.saw_terminal);
+}
+
+#[test]
+fn openai_responses_passthrough_reader_usage_text_not_duplicated_across_delta_item_completed() {
+    let json_text = r#"{"answer":true}"#;
+    let (upstream, server) = open_streaming_mock_http_response(
+        "text/event-stream",
+        &[(
+            "event: response.output_text.delta\n\
+             data: {\"response_id\":\"resp_json_single\",\"delta\":\"{\\\"answer\\\":true}\"}\n\n\
+             event: response.output_item.done\n\
+             data: {\"response_id\":\"resp_json_single\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}}\n\n\
+             event: response.completed\n\
+             data: {\"response\":{\"id\":\"resp_json_single\",\"created\":3,\"model\":\"gpt-5.3-codex\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":2,\"total_tokens\":5}}}\n\n",
+            0,
+        )],
+    );
+    let usage_collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = OpenAIResponsesPassthroughSseReader::new(
+        upstream,
+        Arc::clone(&usage_collector),
+        SseKeepAliveFrame::OpenAIResponses,
+        std::time::Instant::now(),
+    );
+    let mut mapped = String::new();
+    reader
+        .read_to_string(&mut mapped)
+        .expect("read json mode openai responses stream");
+    server
+        .join()
+        .expect("join json mode openai responses upstream");
+
+    let collector = usage_collector
+        .lock()
+        .expect("lock usage collector")
+        .clone();
+    assert!(mapped.contains("event: response.output_item.done"));
+    assert_eq!(collector.usage.output_text.as_deref(), Some(json_text));
+    assert_eq!(collector.usage.input_tokens, Some(3));
+    assert_eq!(collector.usage.output_tokens, Some(2));
+    assert_eq!(collector.usage.total_tokens, Some(5));
     assert!(collector.saw_terminal);
 }
 

--- a/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
+++ b/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
@@ -2281,6 +2281,50 @@ fn openai_responses_passthrough_reader_usage_text_not_duplicated_across_delta_it
 }
 
 #[test]
+fn openai_responses_passthrough_reader_usage_text_dedupes_snapshot_only_events() {
+    let json_text = r#"{"answer":true}"#;
+    let (upstream, server) = open_streaming_mock_http_response(
+        "text/event-stream",
+        &[(
+            "event: response.output_text.done\n\
+             data: {\"response_id\":\"resp_snapshot_single\",\"output_index\":0,\"content_index\":0,\"text\":\"{\\\"answer\\\":true}\"}\n\n\
+             event: response.content_part.done\n\
+             data: {\"response_id\":\"resp_snapshot_single\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}}\n\n\
+             event: response.output_item.done\n\
+             data: {\"response_id\":\"resp_snapshot_single\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}}\n\n\
+             event: response.completed\n\
+             data: {\"response\":{\"id\":\"resp_snapshot_single\",\"created\":3,\"model\":\"gpt-5.3-codex\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"{\\\"answer\\\":true}\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":2,\"total_tokens\":5}}}\n\n",
+            0,
+        )],
+    );
+    let usage_collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = OpenAIResponsesPassthroughSseReader::new(
+        upstream,
+        Arc::clone(&usage_collector),
+        SseKeepAliveFrame::OpenAIResponses,
+        std::time::Instant::now(),
+    );
+    let mut mapped = String::new();
+    reader
+        .read_to_string(&mut mapped)
+        .expect("read snapshot-only openai responses stream");
+    server
+        .join()
+        .expect("join snapshot-only openai responses upstream");
+
+    let collector = usage_collector
+        .lock()
+        .expect("lock usage collector")
+        .clone();
+    assert!(mapped.contains("event: response.output_item.done"));
+    assert_eq!(collector.usage.output_text.as_deref(), Some(json_text));
+    assert_eq!(collector.usage.input_tokens, Some(3));
+    assert_eq!(collector.usage.output_tokens, Some(2));
+    assert_eq!(collector.usage.total_tokens, Some(5));
+    assert!(collector.saw_terminal);
+}
+
+#[test]
 fn openai_responses_passthrough_reader_marks_incomplete_terminal_error_from_status_details() {
     let (upstream, server) = open_streaming_mock_http_response(
         "text/event-stream",

--- a/docs/zh-CN/ARCHITECTURE.md
+++ b/docs/zh-CN/ARCHITECTURE.md
@@ -20,10 +20,10 @@ CodexManager 由两类运行模式组成：
 ```text
 .
 ├─ apps/                  # 前端与 Tauri 桌面端
-│  ├─ src/                # Vite + 原生 JavaScript 前端
+│  ├─ src/                # Next.js App Router + TypeScript 前端
 │  ├─ src-tauri/          # Tauri 桌面壳与原生命令桥接
 │  ├─ tests/              # 前端 UI/结构测试
-│  └─ dist/               # 前端构建产物
+│  └─ out/                # Next.js 静态导出产物
 ├─ crates/
 │  ├─ core/               # 数据库迁移、存储基础、认证/用量底层能力
 │  ├─ service/            # 本地 HTTP/RPC 服务、网关、协议适配、设置持久化
@@ -39,17 +39,19 @@ CodexManager 由两类运行模式组成：
 
 ### 3.1 前端总控入口
 
-- `apps/src/main.js`：前端启动装配入口
-- `apps/src/runtime/app-bootstrap.js`：界面初始化编排
-- `apps/src/runtime/app-runtime.js`：刷新流程与运行期协同
-- `apps/src/settings/controller.js`：设置域门面，继续向子模块分发
+- `apps/src/app/layout.tsx`：App Router 根布局与全局 Provider 装配
+- `apps/src/components/providers.tsx`：React Query、next-themes、i18n、Tooltip 与 Toaster 装配
+- `apps/src/components/layout/app-bootstrap.tsx`：桌面/Web 运行时初始化与 service 连接编排
+- `apps/src/components/layout/page-keep-alive-viewport.tsx`：顶层页面懒加载与 keep-alive 缓存
+- `apps/src/lib/api/transport.ts`：Tauri invoke 与 Web RPC fallback 的统一传输层
+- `apps/src/lib/app-shell/top-level-routes.ts`：顶层路由、角色可见性与导航分组配置
 
 ### 3.2 桌面端壳层入口
 
 - `apps/src-tauri/src/lib.rs`：Tauri 应用装配入口
-- `apps/src-tauri/src/settings_commands.rs`：桌面端设置桥接命令
+- `apps/src-tauri/src/commands/registry.rs`：Tauri command 注册入口
 - `apps/src-tauri/src/service_runtime.rs`：桌面内嵌 service 生命周期
-- `apps/src-tauri/src/rpc_client.rs`：桌面端 RPC 调用基础设施
+- `apps/src-tauri/src/rpc_client/`：桌面端 RPC 调用基础设施
 
 ### 3.3 service 网关与协议入口
 
@@ -155,7 +157,7 @@ Service 模式由以下二进制组成：
 
 - 提供 Web UI 静态资源
 - 挂载或代理到 service
-- 可选把 `apps/dist` 内嵌到二进制，形成单文件发布物
+- 可选把 `apps/out` 内嵌到二进制，形成单文件发布物
 
 ### 5.6 `crates/start/`
 
@@ -218,7 +220,8 @@ Service 模式由以下二进制组成：
 
 - `pnpm -C apps run dev`
 - `pnpm -C apps run build`
-- `pnpm -C apps run check`
+- `pnpm -C apps run build:desktop`
+- `pnpm -C apps run test:runtime`
 
 Rust：
 
@@ -265,16 +268,17 @@ Rust：
 
 当前仓库需要重点关注以下问题：
 
-1. `apps/src-tauri/src/lib.rs` 仍偏厚，桌面壳层装配与命令实现尚需继续拆开。
-2. `crates/service/src/lib.rs` 配置、运行时同步、副作用边界不够清晰。
-3. `crates/service/src/gateway/protocol_adapter/response_conversion.rs` 兼容分支较多，回归风险高。
-4. `.github/workflows/release-all.yml` 仍然较长，多平台逻辑需要持续约束。
+1. `apps/src/app/settings/page.tsx`、`apps/src/app/logs/page.tsx`、`apps/src/app/aggregate-api/page.tsx` 等页面仍偏厚，新增逻辑应优先下沉到 hooks、feature components 或 `src/lib/` helper。
+2. `apps/src-tauri/src/lib.rs` 仍是桌面壳层装配入口，新增桌面能力应优先落在 `app_shell/`、`commands/`、`rpc_client/` 等子模块。
+3. `crates/service/src/lib.rs` 是 service 总出口，新增业务实现应优先落在领域模块，避免继续扩大导出和副作用边界。
+4. `crates/service/src/gateway/` 协议兼容分支较多，回归风险高。
+5. `.github/workflows/release-all.yml` 仍然较长，多平台逻辑需要持续约束。
 
 ## 10. 建议的改动落点
 
 为了减少结构污染，新增需求尽量按以下原则落点：
 
-- 新页面或前端交互：优先落在 `apps/src/views/`、`apps/src/services/`、`apps/src/ui/`
+- 新页面或前端交互：优先落在 `apps/src/app/`、`apps/src/components/`、`apps/src/hooks/`、`apps/src/lib/`
 - 新桌面能力：优先落在 `apps/src-tauri/src/` 的独立模块，而不是全部继续塞进 `lib.rs`
 - 新设置项：先判断属于环境变量、持久化配置还是运行时状态
 - 新协议兼容：优先落在 gateway / protocol adapter 子模块，不要把条件分支继续无序堆叠


### PR DESCRIPTION
## Summary

Fixes #249.

This fixes OpenAI Chat Completions compatibility when requests are routed to the Responses backend. JSON mode request shape is now preserved as Responses `text.format`, and non-stream Responses SSE aggregation no longer duplicates the same JSON text across delta, output item, and completed events.

## Root cause

Chat Completions `response_format` was not carried through the `/v1/chat/completions` -> `/v1/responses` adapter, so JSON mode constraints were silently lost. On the response side, aggregation treated incremental deltas, output item snapshots, and completed response snapshots as independent text sources, which could append the same JSON multiple times before converting back to Chat Completions.

## Changes

- Map Chat `response_format` to Responses `text.format` for `json_object` and `json_schema`.
- Preserve existing object-shaped `text` fields while adding or replacing only `text.format`.
- Reject invalid or unsupported `response_format` values instead of silently dropping them.
- Aggregate Responses SSE output according to event semantics so final Chat content is a single JSON string.
- Avoid adding duplicate top-level `output_text` when completed Responses events already contain structured output.
- Align streaming Chat compatibility and usage text aggregation with the same delta-vs-snapshot behavior.
- Add targeted regression tests for request adaptation, SSE aggregation, and non-stream Chat compatibility.
- Include current local repository guidance and architecture doc updates.

## Validation

- `cargo fmt`
- `git diff --check` over changed service files
- `cargo test -p codexmanager-service openai_chat_completions`
- `cargo test -p codexmanager-service sse`
- `cargo test -p codexmanager-service chat_completions_reader`
- `cargo test -p codexmanager-service openai_responses_passthrough_reader`
- `cargo test -p codexmanager-service non_stream_chat`
- `cargo test -p codexmanager-service`

No skipped or ignored tests were reported in the targeted and full service runs.
