### PR TITLE
[codex] fix anthropic sse duplicate messages

### DIFF
--- a/crates/service/src/gateway/observability/http_bridge/stream_readers/anthropic.rs
+++ b/crates/service/src/gateway/observability/http_bridge/stream_readers/anthropic.rs
@@ -31,6 +31,7 @@ struct AnthropicSseState {
     total_tokens: Option<i64>,
     reasoning_output_tokens: i64,
     output_text: String,
+    emitted_text_to_client: bool,
     stop_reason: Option<&'static str>,
 }
 
@@ -249,6 +250,7 @@ impl AnthropicSseReader {
                         }
                     }),
                 );
+                self.state.emitted_text_to_client = true;
                 self.state.stop_reason.get_or_insert("end_turn");
             }
             "response.output_item.done" => {
@@ -331,8 +333,9 @@ impl AnthropicSseReader {
                     let mut extracted_output_text = String::new();
                     collect_response_output_text(response, &mut extracted_output_text);
                     if !extracted_output_text.trim().is_empty() {
-                        // 若已在流式过程中发过文本增量，不再重复把 completed 全文再发一遍。
-                        if self.state.text_block_index.is_none() {
+                        // Completed carries a full text snapshot. If any text delta was already
+                        // delivered, do not replay that snapshot after tool blocks close text.
+                        if !self.state.emitted_text_to_client {
                             append_output_text(
                                 &mut self.state.output_text,
                                 extracted_output_text.as_str(),
@@ -352,6 +355,7 @@ impl AnthropicSseReader {
                                     }
                                 }),
                             );
+                            self.state.emitted_text_to_client = true;
                         }
                         self.state.stop_reason.get_or_insert("end_turn");
                     }

--- a/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
+++ b/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
@@ -3,10 +3,10 @@ use super::openai::{
 };
 use super::{
     collect_non_stream_json_from_sse_bytes, inspect_sse_frame, parse_sse_frame_json,
-    parse_usage_from_json, parse_usage_from_sse_frame, ChatCompletionsFromResponsesSseReader,
-    GeminiSseReader, ImagesFromResponsesSseReader, ImagesResponseFormat,
-    OpenAIResponsesPassthroughSseReader, PassthroughSseCollector, PassthroughSseProtocol,
-    PassthroughSseUsageReader, SseKeepAliveFrame,
+    parse_usage_from_json, parse_usage_from_sse_frame, AnthropicSseReader,
+    ChatCompletionsFromResponsesSseReader, GeminiSseReader, ImagesFromResponsesSseReader,
+    ImagesResponseFormat, OpenAIResponsesPassthroughSseReader, PassthroughSseCollector,
+    PassthroughSseProtocol, PassthroughSseUsageReader, SseKeepAliveFrame,
 };
 use crate::gateway::GeminiStreamOutputMode;
 use serde_json::json;
@@ -469,6 +469,48 @@ fn anthropic_sse_reader_final_usage_contains_input_cache_and_output_tokens() {
     assert!(out.contains("\"output_tokens\":9"));
     assert!(out.contains("\"total_tokens\":40"));
     assert!(out.contains("\"reasoning_output_tokens\":2"));
+}
+
+#[test]
+fn anthropic_sse_reader_does_not_replay_completed_snapshot_after_tool_call() {
+    let (response, server) = open_streaming_mock_http_response(
+        "text/event-stream",
+        &[(
+            "event: response.output_text.delta\n\
+             data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello before tool\"}\n\n\
+             event: response.output_item.done\n\
+             data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"call_id\":\"call_search_1\",\"name\":\"search\",\"arguments\":\"{\\\"query\\\":\\\"hello\\\"}\"}}\n\n\
+             event: response.completed\n\
+             data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_anthropic_dup\",\"model\":\"gpt-5.3-codex\",\"usage\":{\"input_tokens\":3,\"output_tokens\":2,\"total_tokens\":5},\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello before tool\"}]},{\"type\":\"function_call\",\"call_id\":\"call_search_1\",\"name\":\"search\",\"arguments\":\"{\\\"query\\\":\\\"hello\\\"}\"}]}}\n\n\
+             data: [DONE]\n\n",
+            0,
+        )],
+    );
+    let usage_collector = Arc::new(Mutex::new(super::UpstreamResponseUsage::default()));
+    let mut reader = AnthropicSseReader::new(
+        response,
+        Arc::clone(&usage_collector),
+        None,
+        None,
+        std::time::Instant::now(),
+    );
+    let mut out = String::new();
+    reader
+        .read_to_string(&mut out)
+        .expect("read anthropic sse reader");
+    server.join().expect("join streaming mock upstream");
+
+    assert_eq!(out.matches("\"text\":\"hello before tool\"").count(), 1);
+    assert!(out.contains("\"type\":\"tool_use\""));
+    assert!(out.contains("\"stop_reason\":\"tool_use\""));
+    let usage = usage_collector
+        .lock()
+        .expect("lock usage collector")
+        .clone();
+    assert_eq!(usage.output_text.as_deref(), Some("hello before tool"));
+    assert_eq!(usage.input_tokens, Some(3));
+    assert_eq!(usage.output_tokens, Some(2));
+    assert_eq!(usage.total_tokens, Some(5));
 }
 
 #[test]

--- a/docs/report/anthropic-sse-duplicate-message-fix-20260521.md
+++ b/docs/report/anthropic-sse-duplicate-message-fix-20260521.md
@@ -1,0 +1,32 @@
+# Anthropic SSE 重复消息修复（2026-05-21）
+
+## 背景
+
+用户反馈 Claude Code 通过 `http://ip:port/` 接入 Anthropic Messages 协议时，终端里同一条助手文本会出现两次。
+
+## 根因
+
+`/v1/messages` 会被改写为 `/v1/responses`，再由 `AnthropicSseReader` 转回 Anthropic SSE。上游在工具调用链路里可能按以下顺序返回：
+
+1. `response.output_text.delta`：文本增量
+2. `response.output_item.done`：工具调用快照，本地会关闭当前文本 block
+3. `response.completed`：包含完整输出文本的终态快照
+
+旧逻辑用 `text_block_index.is_none()` 判断是否需要从 completed 快照补发文本。工具调用会关闭文本 block 并清空 `text_block_index`，因此 completed 全量文本会被再次作为 `content_block_delta` 发给 Claude Code，造成重复显示。
+
+## 修复
+
+- 在 `AnthropicSseState` 增加 `emitted_text_to_client`，单独记录是否已向客户端发送过文本。
+- `response.completed` 只在从未发送过文本时补发快照，避免工具调用关闭文本 block 后重复回放。
+- 新增回归测试覆盖“文本 delta → 工具调用 → completed 全量快照”链路，并确认日志用 `output_text` 不重复。
+
+## 涉及文件
+
+- `crates/service/src/gateway/observability/http_bridge/stream_readers/anthropic.rs`
+- `crates/service/src/gateway/observability/tests/http_bridge_tests.rs`
+
+## 验证
+
+- `cargo test -p codexmanager-service anthropic_sse_reader_does_not_replay_completed_snapshot_after_tool_call`
+- `cargo test -p codexmanager-service anthropic`
+- `cargo test -p codexmanager-service gateway::http_bridge::tests`


### PR DESCRIPTION
## Summary
- Fix Anthropic Messages SSE conversion so completed response snapshots are not replayed after tool calls.
- Add a regression test for text delta -> tool call -> completed snapshot ordering.
- Record the fix in docs/report.

## Root cause
Claude Code enters through /v1/messages, which is adapted to /v1/responses and then converted back to Anthropic SSE. When a tool call closed the text block, the bridge used the open text-block state to decide whether completed snapshots should be emitted. That made a later response.completed full-text snapshot look unsent and replayed the same assistant text.

## Validation
- cargo fmt --all
- cargo test -p codexmanager-service anthropic_sse_reader_does_not_replay_completed_snapshot_after_tool_call
- cargo test -p codexmanager-service anthropic
- cargo test -p codexmanager-service gateway::http_bridge::tests
- git diff --check