### PR TITLE
[codex] fix chat completions reasoning compatibility

### DIFF
--- a/crates/service/src/gateway/local_validation/request.rs
+++ b/crates/service/src/gateway/local_validation/request.rs
@@ -415,6 +415,33 @@ fn chat_text_config_with_response_format(
     }
 }
 
+const DEFAULT_CHAT_RESPONSES_REASONING_EFFORT: &str = "medium";
+const DEFAULT_CHAT_RESPONSES_REASONING_SUMMARY: &str = "auto";
+
+fn chat_reasoning_config_for_responses(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Value {
+    if let Some(reasoning) = obj.get("reasoning") {
+        let mut reasoning = reasoning.clone();
+        if let Some(reasoning_obj) = reasoning.as_object_mut() {
+            reasoning_obj
+                .entry("summary".to_string())
+                .or_insert_with(|| {
+                    serde_json::Value::String(DEFAULT_CHAT_RESPONSES_REASONING_SUMMARY.to_string())
+                });
+        }
+        return reasoning;
+    }
+
+    let effort = obj.get("reasoning_effort").cloned().unwrap_or_else(|| {
+        serde_json::Value::String(DEFAULT_CHAT_RESPONSES_REASONING_EFFORT.to_string())
+    });
+    serde_json::json!({
+        "effort": effort,
+        "summary": DEFAULT_CHAT_RESPONSES_REASONING_SUMMARY
+    })
+}
+
 fn adapt_openai_chat_completions_body_to_responses(body: Vec<u8>) -> Result<Vec<u8>, String> {
     let payload = serde_json::from_slice::<serde_json::Value>(&body)
         .map_err(|err| format!("invalid chat completions request json: {err}"))?;
@@ -503,14 +530,10 @@ fn adapt_openai_chat_completions_body_to_responses(body: Vec<u8>) -> Result<Vec<
     if let Some(stream) = obj.get("stream") {
         rewritten.insert("stream".to_string(), stream.clone());
     }
-    if let Some(reasoning) = obj.get("reasoning") {
-        rewritten.insert("reasoning".to_string(), reasoning.clone());
-    } else if let Some(reasoning_effort) = obj.get("reasoning_effort") {
-        rewritten.insert(
-            "reasoning".to_string(),
-            serde_json::json!({ "effort": reasoning_effort }),
-        );
-    }
+    rewritten.insert(
+        "reasoning".to_string(),
+        chat_reasoning_config_for_responses(obj),
+    );
     if let Some(tools) = obj.get("tools").and_then(serde_json::Value::as_array) {
         rewritten.insert(
             "tools".to_string(),

--- a/crates/service/src/gateway/local_validation/tests/request_tests.rs
+++ b/crates/service/src/gateway/local_validation/tests/request_tests.rs
@@ -611,6 +611,112 @@ fn openai_chat_completions_api_body_is_adapted_to_responses_for_codex_backend() 
             .and_then(Value::as_str),
         Some("ping")
     );
+    assert_eq!(
+        payload
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("effort"))
+            .and_then(Value::as_str),
+        Some("medium")
+    );
+    assert_eq!(
+        payload
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("summary"))
+            .and_then(Value::as_str),
+        Some("auto")
+    );
+}
+
+#[test]
+fn openai_chat_completions_reasoning_effort_adds_summary_for_responses() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "你好" }],
+        "reasoning_effort": "high"
+    });
+    let adapted = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect("adapt chat body");
+    let payload: Value = serde_json::from_slice(&adapted).expect("json body");
+
+    assert_eq!(
+        payload
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("effort"))
+            .and_then(Value::as_str),
+        Some("high")
+    );
+    assert_eq!(
+        payload
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("summary"))
+            .and_then(Value::as_str),
+        Some("auto")
+    );
+}
+
+#[test]
+fn openai_chat_completions_reasoning_object_preserves_fields_and_adds_missing_summary() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "你好" }],
+        "reasoning": {
+            "effort": "low"
+        }
+    });
+    let adapted = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect("adapt chat body");
+    let payload: Value = serde_json::from_slice(&adapted).expect("json body");
+
+    assert_eq!(
+        payload
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("effort"))
+            .and_then(Value::as_str),
+        Some("low")
+    );
+    assert_eq!(
+        payload
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("summary"))
+            .and_then(Value::as_str),
+        Some("auto")
+    );
+}
+
+#[test]
+fn openai_chat_completions_reasoning_object_keeps_existing_summary() {
+    let body = serde_json::json!({
+        "model": "gpt-5.5",
+        "messages": [{ "role": "user", "content": "你好" }],
+        "reasoning": {
+            "effort": "low",
+            "summary": "detailed"
+        }
+    });
+    let adapted = adapt_openai_chat_completions_body_to_responses(
+        serde_json::to_vec(&body).expect("serialize chat body"),
+    )
+    .expect("adapt chat body");
+    let payload: Value = serde_json::from_slice(&adapted).expect("json body");
+
+    assert_eq!(
+        payload
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("effort"))
+            .and_then(Value::as_str),
+        Some("low")
+    );
+    assert_eq!(
+        payload
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("summary"))
+            .and_then(Value::as_str),
+        Some("detailed")
+    );
 }
 
 #[test]

--- a/crates/service/src/gateway/observability/http_bridge/aggregate/mod.rs
+++ b/crates/service/src/gateway/observability/http_bridge/aggregate/mod.rs
@@ -6,9 +6,10 @@ mod sse_frame;
 pub(super) use output_text::append_output_text;
 pub(super) use output_text::{
     append_output_text_raw, collect_output_text_from_event_fields, collect_response_output_text,
-    extract_error_hint_from_body, extract_error_message_from_json, merge_usage,
-    parse_usage_from_json, reload_from_env as reload_output_text_from_env, usage_has_signal,
-    UpstreamResponseBridgeResult, UpstreamResponseUsage,
+    collect_response_reasoning_summary_text, extract_error_hint_from_body,
+    extract_error_message_from_json, merge_usage, parse_usage_from_json,
+    reload_from_env as reload_output_text_from_env, usage_has_signal, UpstreamResponseBridgeResult,
+    UpstreamResponseUsage,
 };
 #[cfg(test)]
 pub(super) use output_text::{output_text_limit_bytes, OUTPUT_TEXT_TRUNCATED_MARKER};

--- a/crates/service/src/gateway/observability/http_bridge/aggregate/output_text.rs
+++ b/crates/service/src/gateway/observability/http_bridge/aggregate/output_text.rs
@@ -340,6 +340,99 @@ pub(in super::super) fn collect_response_output_text(value: &Value, output: &mut
     }
 }
 
+fn collect_reasoning_text_fragment(value: &Value, output: &mut String) {
+    match value {
+        Value::String(text) => output.push_str(text),
+        Value::Array(items) => {
+            for item in items {
+                collect_reasoning_text_fragment(item, output);
+            }
+        }
+        Value::Object(map) => {
+            if let Some(text) = map.get("text").and_then(Value::as_str) {
+                output.push_str(text);
+            }
+            if let Some(summary) = map.get("summary") {
+                collect_reasoning_text_fragment(summary, output);
+            }
+            if let Some(content) = map.get("content") {
+                collect_reasoning_text_fragment(content, output);
+            }
+            if let Some(delta) = map.get("delta") {
+                collect_reasoning_text_fragment(delta, output);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// 函数 `collect_response_reasoning_summary_text`
+///
+/// 作者: gaohongshun
+///
+/// 时间: 2026-05-21
+///
+/// # 参数
+/// - in super: 参数 in super
+///
+/// # 返回
+/// 无
+pub(in super::super) fn collect_response_reasoning_summary_text(
+    value: &Value,
+    output: &mut String,
+) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_response_reasoning_summary_text(item, output);
+            }
+        }
+        Value::Object(map) => {
+            let event_type = map.get("type").and_then(Value::as_str);
+            match event_type {
+                Some("reasoning") => {
+                    if let Some(summary) = map.get("summary") {
+                        collect_reasoning_text_fragment(summary, output);
+                    }
+                    if let Some(content) = map.get("content") {
+                        collect_reasoning_text_fragment(content, output);
+                    }
+                    if let Some(text) = map.get("text") {
+                        collect_reasoning_text_fragment(text, output);
+                    }
+                }
+                Some("response.reasoning_summary_text.delta")
+                | Some("response.reasoning_text.delta") => {
+                    if let Some(delta) = map.get("delta") {
+                        collect_reasoning_text_fragment(delta, output);
+                    }
+                }
+                Some("response.reasoning_summary_text.done")
+                | Some("response.reasoning_text.done") => {
+                    if let Some(text) = map.get("text").or_else(|| map.get("delta")) {
+                        collect_reasoning_text_fragment(text, output);
+                    }
+                }
+                _ => {}
+            }
+
+            if let Some(response) = map.get("response") {
+                collect_response_reasoning_summary_text(response, output);
+            }
+            if let Some(output_field) = map.get("output") {
+                collect_response_reasoning_summary_text(output_field, output);
+            }
+            if let Some(item) = map.get("item") {
+                collect_response_reasoning_summary_text(item, output);
+            }
+            if let Some(output_item) = map.get("output_item") {
+                collect_response_reasoning_summary_text(output_item, output);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// 函数 `output_text_limit_bytes`
 ///
 /// 作者: gaohongshun

--- a/crates/service/src/gateway/observability/http_bridge/delivery.rs
+++ b/crates/service/src/gateway/observability/http_bridge/delivery.rs
@@ -9,9 +9,9 @@ use crate::gateway::upstream::GatewayStreamResponse;
 use super::super::{GeminiStreamOutputMode, ResponseAdapter, ToolNameRestoreMap};
 use super::{
     build_images_api_response, collect_image_generation_chat_images,
-    collect_non_stream_json_from_sse_bytes, extract_error_hint_from_body,
-    extract_error_message_from_json, looks_like_sse_payload, merge_usage, parse_usage_from_json,
-    push_trace_id_header, usage_has_signal, AnthropicSseReader,
+    collect_non_stream_json_from_sse_bytes, collect_response_reasoning_summary_text,
+    extract_error_hint_from_body, extract_error_message_from_json, looks_like_sse_payload,
+    merge_usage, parse_usage_from_json, push_trace_id_header, usage_has_signal, AnthropicSseReader,
     ChatCompletionsFromResponsesSseReader, GeminiSseReader, ImagesFromResponsesSseReader,
     ImagesResponseFormat, OpenAIResponsesPassthroughSseReader, PassthroughSseCollector,
     PassthroughSseProtocol, PassthroughSseUsageReader, SseKeepAliveFrame,
@@ -753,6 +753,8 @@ fn convert_responses_body_to_chat_completions(body: &[u8]) -> Option<Vec<u8>> {
             collect_chat_output_text(output, &mut text);
         }
     }
+    let mut reasoning_text = String::new();
+    collect_response_reasoning_summary_text(response, &mut reasoning_text);
     let id = response
         .get("id")
         .or_else(|| value.get("id"))
@@ -790,6 +792,10 @@ fn convert_responses_body_to_chat_completions(body: &[u8]) -> Option<Vec<u8>> {
     });
     if let Some(usage) = usage {
         completion["usage"] = usage;
+    }
+    if !reasoning_text.trim().is_empty() {
+        completion["choices"][0]["message"]["reasoning"] = Value::String(reasoning_text.clone());
+        completion["choices"][0]["message"]["reasoning_content"] = Value::String(reasoning_text);
     }
     let images = collect_image_generation_chat_images(response);
     if !images.is_empty() {
@@ -4065,6 +4071,69 @@ mod tests {
         assert_eq!(
             value["usage"]["prompt_tokens"],
             serde_json::Value::Number(2.into())
+        );
+    }
+
+    #[test]
+    fn non_stream_chat_completion_response_preserves_reasoning_content() {
+        let body = json!({
+            "id": "resp_non_stream_reasoning",
+            "model": "gpt-5.4",
+            "output": [{
+                "type": "reasoning",
+                "id": "rs_non_stream_1",
+                "summary": [{
+                    "type": "summary_text",
+                    "text": "先读配置"
+                }]
+            }],
+            "usage": { "input_tokens": 4, "output_tokens": 2, "total_tokens": 6 }
+        });
+
+        let mapped = convert_responses_body_to_chat_completions(
+            serde_json::to_vec(&body).expect("body").as_slice(),
+        )
+        .expect("convert chat completion body");
+        let value: serde_json::Value = serde_json::from_slice(&mapped).expect("parse mapped body");
+
+        assert_eq!(value["choices"][0]["message"]["content"], "");
+        assert_eq!(
+            value["choices"][0]["message"]["reasoning_content"],
+            "先读配置"
+        );
+        assert_eq!(value["choices"][0]["message"]["reasoning"], "先读配置");
+        assert_eq!(
+            value["usage"]["prompt_tokens"],
+            serde_json::Value::Number(4.into())
+        );
+    }
+
+    #[test]
+    fn non_stream_chat_completion_response_preserves_answer_and_reasoning_content() {
+        let body = json!({
+            "id": "resp_non_stream_text_and_reasoning",
+            "model": "gpt-5.4",
+            "output_text": "OK",
+            "output": [{
+                "type": "reasoning",
+                "id": "rs_non_stream_1",
+                "summary": [{
+                    "type": "summary_text",
+                    "text": "先想一下"
+                }]
+            }]
+        });
+
+        let mapped = convert_responses_body_to_chat_completions(
+            serde_json::to_vec(&body).expect("body").as_slice(),
+        )
+        .expect("convert chat completion body");
+        let value: serde_json::Value = serde_json::from_slice(&mapped).expect("parse mapped body");
+
+        assert_eq!(value["choices"][0]["message"]["content"], "OK");
+        assert_eq!(
+            value["choices"][0]["message"]["reasoning_content"],
+            "先想一下"
         );
     }
 

--- a/crates/service/src/gateway/observability/http_bridge/mod.rs
+++ b/crates/service/src/gateway/observability/http_bridge/mod.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 mod aggregate;
 #[cfg(test)]
 mod openai;
+use aggregate::collect_response_reasoning_summary_text;
 use aggregate::openai_responses_event::{OpenAIResponsesEvent, OpenAIResponsesOutputTextState};
 pub(crate) use aggregate::PassthroughSseProtocol;
 #[allow(unused_imports)]

--- a/crates/service/src/gateway/observability/http_bridge/stream_readers.rs
+++ b/crates/service/src/gateway/observability/http_bridge/stream_readers.rs
@@ -4,7 +4,8 @@ use std::sync::{Arc, Mutex};
 
 use super::{
     append_output_text, collect_output_text_from_event_fields, collect_response_output_text,
-    extract_error_hint_from_body, extract_error_message_from_json, merge_usage,
+    collect_response_reasoning_summary_text, extract_error_hint_from_body,
+    extract_error_message_from_json, merge_usage,
 };
 use super::{
     build_images_api_response, chat_image_payload, collect_image_generation_data_urls,

--- a/crates/service/src/gateway/observability/http_bridge/stream_readers/chat_completions.rs
+++ b/crates/service/src/gateway/observability/http_bridge/stream_readers/chat_completions.rs
@@ -1,7 +1,8 @@
 use super::{
     chat_image_payload, classify_upstream_stream_read_error, collect_image_generation_data_urls,
-    collect_output_text_from_event_fields, collect_response_output_text, mark_first_response_ms,
-    merge_usage, should_emit_keepalive, stream_idle_timed_out, stream_idle_timeout_message,
+    collect_output_text_from_event_fields, collect_response_output_text,
+    collect_response_reasoning_summary_text, mark_first_response_ms, merge_usage,
+    should_emit_keepalive, stream_idle_timed_out, stream_idle_timeout_message,
     stream_reader_disconnected_message, stream_wait_timeout,
     upstream_hint_or_stream_incomplete_message, Arc, Cursor, Mutex, PassthroughSseCollector, Read,
     SseKeepAliveFrame, UpstreamSseFramePump, UpstreamSseFramePumpItem,
@@ -20,6 +21,7 @@ pub(crate) struct ChatCompletionsFromResponsesSseReader {
     finished: bool,
     emitted_assistant_role: bool,
     emitted_text: bool,
+    emitted_reasoning: bool,
     emitted_tool_calls: bool,
     emitted_tool_call_indices: HashSet<usize>,
     tool_call_arguments: HashMap<usize, String>,
@@ -45,6 +47,7 @@ impl ChatCompletionsFromResponsesSseReader {
             finished: false,
             emitted_assistant_role: false,
             emitted_text: false,
+            emitted_reasoning: false,
             emitted_tool_calls: false,
             emitted_tool_call_indices: HashSet::new(),
             tool_call_arguments: HashMap::new(),
@@ -332,6 +335,48 @@ impl ChatCompletionsFromResponsesSseReader {
         }
     }
 
+    fn reasoning_delta_chunk(&mut self, text: String) -> Option<Vec<u8>> {
+        if text.trim().is_empty() {
+            return None;
+        }
+        self.emitted_reasoning = true;
+        let reasoning_content = text.clone();
+        Some(self.assistant_delta_chunk(serde_json::json!({
+            "reasoning": text,
+            "reasoning_content": reasoning_content
+        })))
+    }
+
+    fn reasoning_text_from_event(event_type: Option<&str>, value: &Value) -> Option<String> {
+        let mut reasoning = String::new();
+        match event_type {
+            Some("response.reasoning_summary_text.delta")
+            | Some("response.reasoning_text.delta") => {
+                if let Some(delta) = value.get("delta") {
+                    collect_response_output_text(delta, &mut reasoning);
+                }
+            }
+            Some("response.reasoning_summary_text.done") | Some("response.reasoning_text.done") => {
+                if let Some(text) = value.get("text").or_else(|| value.get("delta")) {
+                    collect_response_output_text(text, &mut reasoning);
+                }
+            }
+            _ => collect_response_reasoning_summary_text(value, &mut reasoning),
+        }
+        if reasoning.trim().is_empty() {
+            None
+        } else {
+            Some(reasoning)
+        }
+    }
+
+    fn is_reasoning_delta_event(event_type: Option<&str>) -> bool {
+        matches!(
+            event_type,
+            Some("response.reasoning_summary_text.delta") | Some("response.reasoning_text.delta")
+        )
+    }
+
     fn update_terminal_success(&self, event_type: Option<&str>) {
         if let Ok(mut collector) = self.usage_collector.lock() {
             if let Some(event_type) = event_type {
@@ -345,6 +390,20 @@ impl ChatCompletionsFromResponsesSseReader {
         let value = Self::data_json(lines)?;
         self.remember_meta(&value);
         let event_type = Self::event_type(lines, &value);
+        let is_terminal_event = matches!(
+            event_type.as_deref(),
+            Some("response.completed") | Some("response.done")
+        );
+        if !is_terminal_event
+            && (Self::is_reasoning_delta_event(event_type.as_deref()) || !self.emitted_reasoning)
+        {
+            if let Some(reasoning) = Self::reasoning_text_from_event(event_type.as_deref(), &value)
+            {
+                if let Some(chunk) = self.reasoning_delta_chunk(reasoning) {
+                    return Some(chunk);
+                }
+            }
+        }
         let mut text = String::new();
         match event_type.as_deref() {
             Some("response.output_text.delta") | Some("response.content_part.delta") => {
@@ -388,6 +447,15 @@ impl ChatCompletionsFromResponsesSseReader {
                 }
             }
             if let Some(response) = value.get("response") {
+                if !self.emitted_reasoning {
+                    if let Some(reasoning) =
+                        Self::reasoning_text_from_event(event_type.as_deref(), response)
+                    {
+                        if let Some(chunk) = self.reasoning_delta_chunk(reasoning) {
+                            out.extend(chunk);
+                        }
+                    }
+                }
                 if let Some(tool_calls) = self.completed_tool_calls_chunk(response) {
                     out.extend(tool_calls);
                 }

--- a/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
+++ b/crates/service/src/gateway/observability/tests/http_bridge_tests.rs
@@ -161,6 +161,19 @@ fn chat_sse_content_fragments(out: &str) -> Vec<String> {
         .collect()
 }
 
+fn chat_sse_reasoning_fragments(out: &str) -> Vec<String> {
+    out.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter(|data| data.trim() != "[DONE]")
+        .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+        .filter_map(|value| {
+            value["choices"][0]["delta"]["reasoning_content"]
+                .as_str()
+                .map(str::to_string)
+        })
+        .collect()
+}
+
 /// 函数 `parse_usage_from_json_reads_cached_and_reasoning_details`
 ///
 /// 作者: gaohongshun
@@ -723,6 +736,53 @@ fn chat_completions_reader_converts_responses_sse_to_chat_sse() {
     assert_eq!(collector.usage.input_tokens, Some(2));
     assert_eq!(collector.usage.output_tokens, Some(2));
     assert_eq!(collector.usage.total_tokens, Some(4));
+}
+
+#[test]
+fn chat_completions_reader_converts_reasoning_output_item_to_reasoning_delta() {
+    let sse = concat!(
+        "data: {\"type\":\"response.output_item.done\",\"response_id\":\"resp_reason_1\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"先读配置\"}],\"encrypted_content\":\"sig_reason_1\"}}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_reason_1\",\"model\":\"gpt-5.4\",\"created\":1775900000,\"usage\":{\"input_tokens\":4,\"output_tokens\":2,\"total_tokens\":6}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let response = open_mock_http_response("text/event-stream", sse);
+    let collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = ChatCompletionsFromResponsesSseReader::new(
+        response,
+        Arc::clone(&collector),
+        std::time::Instant::now(),
+    );
+    let mut out = String::new();
+    reader.read_to_string(&mut out).expect("read chat sse");
+
+    assert_eq!(chat_sse_reasoning_fragments(&out), vec!["先读配置"]);
+    assert!(out.contains("\"reasoning\":\"先读配置\""));
+    assert!(!out.contains("\"content\":\"先读配置\""));
+    assert!(out.contains("\"finish_reason\":\"stop\""));
+    assert!(out.contains("data: [DONE]"));
+}
+
+#[test]
+fn chat_completions_reader_converts_reasoning_summary_delta_to_reasoning_delta() {
+    let sse = concat!(
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"response_id\":\"resp_reason_delta_1\",\"delta\":\"先读配置\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_reason_delta_1\",\"model\":\"gpt-5.4\",\"created\":1775900000,\"usage\":{\"input_tokens\":4,\"output_tokens\":2,\"total_tokens\":6}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let response = open_mock_http_response("text/event-stream", sse);
+    let collector = Arc::new(Mutex::new(PassthroughSseCollector::default()));
+    let mut reader = ChatCompletionsFromResponsesSseReader::new(
+        response,
+        Arc::clone(&collector),
+        std::time::Instant::now(),
+    );
+    let mut out = String::new();
+    reader.read_to_string(&mut out).expect("read chat sse");
+
+    assert_eq!(chat_sse_reasoning_fragments(&out), vec!["先读配置"]);
+    assert!(out.contains("\"reasoning\":\"先读配置\""));
+    assert!(out.contains("\"finish_reason\":\"stop\""));
+    assert!(out.contains("data: [DONE]"));
 }
 
 #[test]

--- a/docs/report/chat-completions-reasoning-compat-fix-20260521.md
+++ b/docs/report/chat-completions-reasoning-compat-fix-20260521.md
@@ -1,0 +1,45 @@
+# Chat Completions Reasoning 兼容修复（2026-05-21）
+
+## 背景
+
+Hermes 通过 OpenAI-compatible `/v1/chat/completions` 接入 CodeXManager 时，CodeXManager 会把请求改写到 `/v1/responses`。当上游只返回 reasoning summary 而没有普通 `output_text` 时，旧转换逻辑不会把 reasoning 暴露回 Chat Completions 响应，客户端会把这类成功响应识别成 empty。
+
+## 修复
+
+- Chat Completions 兼容请求改写到 Responses 时，默认补：
+  - `reasoning.effort = "medium"`
+  - `reasoning.summary = "auto"`
+- 客户端传 `reasoning_effort` 时保留 effort，并补 `summary = "auto"`。
+- 客户端传 `reasoning` 对象时保留已有字段，仅在缺失 `summary` 时补默认值。
+- Responses 转 Chat Completions 时，将 reasoning summary 映射到兼容扩展字段：
+  - 流式：`choices[].delta.reasoning` 和 `choices[].delta.reasoning_content`
+  - 非流式：`choices[].message.reasoning` 和 `choices[].message.reasoning_content`
+- 普通答案仍只进入 `content`，reasoning 不写入普通可见答案文本。
+
+## 涉及文件
+
+- `crates/service/src/gateway/local_validation/request.rs`
+- `crates/service/src/gateway/observability/http_bridge/aggregate/output_text.rs`
+- `crates/service/src/gateway/observability/http_bridge/delivery.rs`
+- `crates/service/src/gateway/observability/http_bridge/stream_readers/chat_completions.rs`
+- `crates/service/src/gateway/local_validation/tests/request_tests.rs`
+- `crates/service/src/gateway/observability/tests/http_bridge_tests.rs`
+
+## 验证
+
+- `cargo test -p codexmanager-service gateway::observability::tests::http_bridge_tests`
+  - 当前仓库真实测试路径不匹配该过滤条件，Cargo 显示 0 个测试执行。
+- `cargo test -p codexmanager-service gateway::local_validation::tests::request_tests`
+  - 当前仓库真实测试路径不匹配该过滤条件，Cargo 显示 0 个测试执行。
+- `cargo test -p codexmanager-service gateway::http_bridge::tests`
+  - 70 passed。
+- `cargo test -p codexmanager-service gateway::local_validation::request::tests`
+  - 36 passed。
+- `cargo test -p codexmanager-service`
+  - 951 passed。
+- `cargo build -p codexmanager-service`
+  - 通过。
+
+## 本机运行状态
+
+检查本机没有正在监听 `48761` 的 CodeXManager service 进程，因此本次没有执行服务重启。当前 Hermes 配置的远端端点需要部署包含本修复的 CodeXManager 版本后，才能用 Hermes 端到端验收该问题。


### PR DESCRIPTION
## Summary

This PR fixes an OpenAI-compatible Chat Completions bridge issue where CodeXManager can successfully proxy a `/v1/chat/completions` request through `/v1/responses` but return an apparently empty assistant message to compatible clients such as Hermes.

The visible symptom is a successful response with empty `content` when the upstream Responses result is reasoning-only. Hermes already understands `reasoning` and `reasoning_content`, but CodeXManager was not mapping Responses reasoning summaries back into those Chat Completions extension fields.

## Root Cause

The Chat Completions compatibility path rewrites non-native OpenAI-compatible `/v1/chat/completions` requests to `/v1/responses`. The request rewrite only preserved caller-provided reasoning fields and did not request reasoning summaries by default. On the way back, the Responses-to-Chat-Completions conversion only extracted normal answer text, tools, and images, so `type: "reasoning"` output items and reasoning summary stream events were dropped from the Chat Completions payload.

That made reasoning-only upstream results look like empty assistant responses to clients that rely on Chat Completions semantics.

## Changes

- Default adapted Chat Completions requests to `reasoning: { effort: "medium", summary: "auto" }` when the caller did not provide reasoning settings.
- Preserve explicit `reasoning_effort` while adding `summary: "auto"`.
- Preserve explicit `reasoning` objects while adding a missing `summary: "auto"`.
- Add shared extraction for Responses reasoning summary text from:
  - `type: "reasoning"` output items
  - `summary[].text`
  - reasoning summary delta/done stream events
- Map reasoning summaries to Chat Completions extension fields:
  - streaming: `choices[].delta.reasoning` and `choices[].delta.reasoning_content`
  - non-streaming: `choices[].message.reasoning` and `choices[].message.reasoning_content`
- Keep reasoning out of normal `content`, so user-visible answer text is not polluted.
- Preserve normal output text, images, and tool call behavior.

## Validation

- `cargo test -p codexmanager-service gateway::http_bridge::tests`
  - 69 passed
- `cargo test -p codexmanager-service gateway::local_validation::request::tests`
  - 36 passed
- `cargo test -p codexmanager-service`
  - 950 passed
- `cargo build -p codexmanager-service`
  - passed

The branch is based directly on `upstream/main` and contains only this reasoning compatibility fix.
