### PR TITLE
[codex] Suspend refresh on region-blocked token errors

### DIFF
--- a/apps/src/app/accounts/accounts-page-helpers.tsx
+++ b/apps/src/app/accounts/accounts-page-helpers.tsx
@@ -341,6 +341,9 @@ export function formatAccountStatusReasonLabel(
         return t("Refresh Token 失效，需要重新登录");
     }
   }
+  if (reason === "refresh_token_region_blocked") {
+    return t("代理地区不受支持，已暂停账号刷新");
+  }
 
   const usageHttpStatus = reason.match(/^usage_http_(\d{3})$/);
   if (usageHttpStatus) {

--- a/crates/core/src/storage/tokens.rs
+++ b/crates/core/src/storage/tokens.rs
@@ -80,6 +80,7 @@ impl Storage {
                     OR (
                         latest_status.message NOT LIKE '% reason=account_deactivated'
                         AND latest_status.message NOT LIKE '% reason=workspace_deactivated'
+                        AND latest_status.message NOT LIKE '% reason=refresh_token_region_blocked'
                     )
                )
                AND (

--- a/crates/core/tests/storage.rs
+++ b/crates/core/tests/storage.rs
@@ -383,6 +383,7 @@ fn tokens_due_for_refresh_include_other_unavailable_accounts_but_skip_deactivate
 
     for (id, status) in [
         ("acc-active-refresh", "active"),
+        ("acc-region-blocked-refresh", "unavailable"),
         ("acc-unavailable-refresh", "unavailable"),
         ("acc-deactivated-refresh", "banned"),
     ] {
@@ -422,6 +423,14 @@ fn tokens_due_for_refresh_include_other_unavailable_accounts_but_skip_deactivate
             created_at: now + 1,
         })
         .expect("insert deactivated event");
+    storage
+        .insert_event(&Event {
+            account_id: Some("acc-region-blocked-refresh".to_string()),
+            event_type: "account_status_update".to_string(),
+            message: "status=unavailable reason=refresh_token_region_blocked".to_string(),
+            created_at: now + 1,
+        })
+        .expect("insert region blocked event");
 
     let due = storage
         .list_tokens_due_for_refresh(4_102_444_300, 4_102_444_900, 10)
@@ -437,6 +446,22 @@ fn tokens_due_for_refresh_include_other_unavailable_accounts_but_skip_deactivate
             "acc-unavailable-refresh".to_string()
         ]
     );
+
+    storage
+        .insert_event(&Event {
+            account_id: Some("acc-region-blocked-refresh".to_string()),
+            event_type: "account_status_update".to_string(),
+            message: "status=active reason=manual_enable".to_string(),
+            created_at: now + 2,
+        })
+        .expect("insert manual enable event");
+    let recovered_due = storage
+        .list_tokens_due_for_refresh(4_102_444_300, 4_102_444_900, 10)
+        .expect("list due after manual enable")
+        .into_iter()
+        .map(|token| token.account_id)
+        .collect::<Vec<_>>();
+    assert!(recovered_due.contains(&"acc-region-blocked-refresh".to_string()));
 }
 
 /// 函数 `storage_login_session_roundtrip`

--- a/crates/service/src/account/account_status.rs
+++ b/crates/service/src/account/account_status.rs
@@ -1,8 +1,11 @@
 use codexmanager_core::storage::{now_ts, Event, Storage};
 
+pub(crate) const REFRESH_TOKEN_REGION_BLOCKED_REASON: &str = "refresh_token_region_blocked";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AccountAvailabilitySignal {
     RefreshToken(crate::usage_http::RefreshTokenAuthErrorReason),
+    RefreshTokenRegionBlocked,
     Deactivation(&'static str),
     UsageHttp(u16),
 }
@@ -113,6 +116,9 @@ fn should_preserve_manual_account_status(storage: &Storage, account_id: &str) ->
 /// # 返回
 /// 返回函数执行结果
 pub(crate) fn classify_account_availability_signal(err: &str) -> Option<AccountAvailabilitySignal> {
+    if crate::usage_http::is_refresh_token_region_blocked_error_message(err) {
+        return Some(AccountAvailabilitySignal::RefreshTokenRegionBlocked);
+    }
     if let Some(reason) = crate::usage_http::refresh_token_auth_error_reason_from_message(err) {
         return Some(AccountAvailabilitySignal::RefreshToken(reason));
     }
@@ -236,6 +242,16 @@ pub(crate) fn is_banned_status_reason(reason: &str) -> bool {
         reason.trim().to_ascii_lowercase().as_str(),
         "account_deactivated" | "workspace_deactivated" | "deactivated_workspace"
     )
+}
+
+pub(crate) fn is_refresh_blocked_status_reason(reason: &str) -> bool {
+    reason
+        .trim()
+        .eq_ignore_ascii_case(REFRESH_TOKEN_REGION_BLOCKED_REASON)
+}
+
+pub(crate) fn is_account_refresh_blocked_status_reason(reason: &str) -> bool {
+    is_banned_status_reason(reason) || is_refresh_blocked_status_reason(reason)
 }
 
 /// 函数 `should_failover_for_deactivation_error`
@@ -394,6 +410,13 @@ pub(crate) fn mark_account_unavailable_for_auth_error(
         return false;
     };
     match signal {
+        AccountAvailabilitySignal::RefreshTokenRegionBlocked => {
+            set_account_unavailable_with_reason(
+                storage,
+                account_id,
+                REFRESH_TOKEN_REGION_BLOCKED_REASON,
+            )
+        }
         AccountAvailabilitySignal::RefreshToken(reason) => {
             let status_reason = format!("refresh_token_invalid:{}", reason.as_code());
             set_account_unavailable_with_reason(storage, account_id, &status_reason)
@@ -421,13 +444,20 @@ pub(crate) fn mark_account_unavailable_for_refresh_token_error(
     account_id: &str,
     err: &str,
 ) -> bool {
-    let Some(AccountAvailabilitySignal::RefreshToken(reason)) =
-        classify_account_availability_signal(err)
-    else {
-        return false;
-    };
-    let status_reason = format!("refresh_token_invalid:{}", reason.as_code());
-    set_account_unavailable_with_reason(storage, account_id, &status_reason)
+    match classify_account_availability_signal(err) {
+        Some(AccountAvailabilitySignal::RefreshTokenRegionBlocked) => {
+            set_account_unavailable_with_reason(
+                storage,
+                account_id,
+                REFRESH_TOKEN_REGION_BLOCKED_REASON,
+            )
+        }
+        Some(AccountAvailabilitySignal::RefreshToken(reason)) => {
+            let status_reason = format!("refresh_token_invalid:{}", reason.as_code());
+            set_account_unavailable_with_reason(storage, account_id, &status_reason)
+        }
+        _ => false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/service/src/usage/refresh/batch.rs
+++ b/crates/service/src/usage/refresh/batch.rs
@@ -1,4 +1,4 @@
-use crate::account_status::is_banned_status_reason;
+use crate::account_status::is_account_refresh_blocked_status_reason;
 use codexmanager_core::storage::{Account, AggregateApi, Storage, Token};
 use crossbeam_channel::unbounded;
 use std::collections::HashSet;
@@ -338,7 +338,7 @@ fn load_banned_account_ids(
         .map_err(|err| err.to_string())?;
     Ok(reasons
         .into_iter()
-        .filter(|(_, reason)| is_banned_status_reason(reason))
+        .filter(|(_, reason)| is_account_refresh_blocked_status_reason(reason))
         .map(|(account_id, _)| account_id)
         .collect())
 }

--- a/crates/service/src/usage/refresh/errors.rs
+++ b/crates/service/src/usage/refresh/errors.rs
@@ -81,6 +81,9 @@ pub(super) fn mark_usage_unreachable_if_needed(storage: &Storage, account_id: &s
 /// # 返回
 /// 返回函数执行结果
 pub(super) fn should_retry_with_refresh(err: &str) -> bool {
+    if crate::usage_http::is_region_blocked_error_message(err) {
+        return false;
+    }
     err.contains("401") || err.contains("403")
 }
 

--- a/crates/service/src/usage/tests/usage_http_tests.rs
+++ b/crates/service/src/usage/tests/usage_http_tests.rs
@@ -337,6 +337,41 @@ fn refresh_token_status_error_uses_header_only_debug_suffix_for_empty_body() {
     assert!(message.contains("cf_ray=cf_refresh_empty"));
 }
 
+#[test]
+fn refresh_token_status_error_detects_region_blocked_header_marker() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-openai-authorization-error",
+        HeaderValue::from_static("unsupported_country_region_territory"),
+    );
+    headers.insert("cf-ray", HeaderValue::from_static("cf_refresh_region"));
+
+    let message = super::format_refresh_token_status_error_with_headers(
+        StatusCode::FORBIDDEN,
+        Some(&headers),
+        "",
+    );
+
+    assert!(message.contains("refresh token failed with status 403 Forbidden"));
+    assert!(message.contains("kind=cloudflare_blocked"));
+    assert!(message.contains("auth_error=unsupported_country_region_territory"));
+    assert!(super::is_region_blocked_error_message(&message));
+    assert!(super::is_refresh_token_region_blocked_error_message(
+        &message
+    ));
+}
+
+#[test]
+fn refresh_token_status_error_plain_forbidden_is_not_region_blocked() {
+    let message = super::format_refresh_token_status_error(StatusCode::FORBIDDEN, "");
+
+    assert_eq!(message, "refresh token failed with status 403 Forbidden");
+    assert!(!super::is_region_blocked_error_message(&message));
+    assert!(!super::is_refresh_token_region_blocked_error_message(
+        &message
+    ));
+}
+
 /// 函数 `refresh_token_auth_error_reason_from_message_tracks_canonical_messages`
 ///
 /// 作者: gaohongshun
@@ -615,6 +650,60 @@ fn refresh_token_url_preserves_custom_issuer_and_override() {
         Some(value) => std::env::set_var("CODEX_REFRESH_TOKEN_URL_OVERRIDE", value),
         None => std::env::remove_var("CODEX_REFRESH_TOKEN_URL_OVERRIDE"),
     }
+}
+
+#[test]
+fn refresh_access_token_mock_region_blocked_response_surfaces_marker() {
+    let _lock = crate::test_env_guard();
+    let previous = std::env::var("CODEX_REFRESH_TOKEN_URL_OVERRIDE").ok();
+    let _ = super::usage_http_client();
+    let server = Server::http("127.0.0.1:0").expect("start mock refresh server");
+    let url = format!("http://{}/oauth/token", server.server_addr());
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = thread::spawn(move || {
+        let mut request = server
+            .recv_timeout(Duration::from_secs(5))
+            .expect("refresh server timeout")
+            .expect("receive refresh request");
+        let mut body = String::new();
+        request
+            .as_reader()
+            .read_to_string(&mut body)
+            .expect("read refresh request body");
+        tx.send(body).expect("send refresh request body");
+        let response = Response::from_string("")
+            .with_status_code(TinyStatusCode(403))
+            .with_header(
+                Header::from_bytes(
+                    "x-openai-authorization-error",
+                    "unsupported_country_region_territory",
+                )
+                .expect("auth error header"),
+            )
+            .with_header(Header::from_bytes("cf-ray", "ray-hkg").expect("cf-ray header"));
+        request.respond(response).expect("respond refresh request");
+    });
+    std::env::set_var("CODEX_REFRESH_TOKEN_URL_OVERRIDE", &url);
+
+    let err =
+        match super::refresh_access_token("https://auth.openai.com", "client-id", "refresh-old") {
+            Ok(_) => panic!("region blocked refresh should fail"),
+            Err(err) => err,
+        };
+    let body = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("receive refresh request body");
+    handle.join().expect("join refresh server");
+    match previous {
+        Some(value) => std::env::set_var("CODEX_REFRESH_TOKEN_URL_OVERRIDE", value),
+        None => std::env::remove_var("CODEX_REFRESH_TOKEN_URL_OVERRIDE"),
+    }
+
+    assert!(body.contains("grant_type=refresh_token"));
+    assert!(body.contains("refresh_token=refresh-old"));
+    assert!(err.contains("refresh token failed with status 403 Forbidden"));
+    assert!(err.contains("auth_error=unsupported_country_region_territory"));
+    assert!(super::is_refresh_token_region_blocked_error_message(&err));
 }
 
 /// 函数 `summarize_usage_error_response_stabilizes_html_and_debug_headers`

--- a/crates/service/src/usage/tests/usage_refresh_tests.rs
+++ b/crates/service/src/usage/tests/usage_refresh_tests.rs
@@ -260,6 +260,27 @@ fn usage_refresh_retry_skips_when_refresh_token_is_empty() {
     ));
 }
 
+#[test]
+fn usage_refresh_retry_skips_region_blocked_errors() {
+    let token = Token {
+        account_id: "acc-region-blocked-retry".to_string(),
+        id_token: "id".to_string(),
+        access_token: "access".to_string(),
+        refresh_token: "refresh".to_string(),
+        api_key_access_token: None,
+        last_refresh: now_ts(),
+    };
+
+    assert!(!should_retry_usage_refresh_with_token(
+        &token,
+        "usage endpoint failed: status=403 Forbidden body=code=unsupported_country_region_territory cf_ray=ray-HKG",
+    ));
+    assert!(should_retry_usage_refresh_with_token(
+        &token,
+        "usage endpoint status 403 Forbidden"
+    ));
+}
+
 /// 函数 `due_cutoff_includes_next_poll_window_and_buffer`
 ///
 /// 作者: gaohongshun

--- a/crates/service/src/usage/usage_http.rs
+++ b/crates/service/src/usage/usage_http.rs
@@ -250,6 +250,21 @@ fn looks_like_refresh_token_blocked_marker(value: &str) -> bool {
         || normalized.contains("region_restricted")
 }
 
+pub(crate) fn is_region_blocked_error_message(message: &str) -> bool {
+    let normalized = message.trim().to_ascii_lowercase();
+    normalized.contains("unsupported_country_region_territory")
+        || normalized.contains("unsupported_country")
+        || normalized.contains("region_restricted")
+        || normalized.contains("kind=cloudflare_blocked")
+        || normalized.contains("access blocked by cloudflare")
+        || normalized.contains("country, region, or territory not supported")
+}
+
+pub(crate) fn is_refresh_token_region_blocked_error_message(message: &str) -> bool {
+    let normalized = message.trim().to_ascii_lowercase();
+    normalized.contains("refresh token failed") && is_region_blocked_error_message(message)
+}
+
 /// 函数 `classify_refresh_token_status_error_kind_with_headers`
 ///
 /// 作者: gaohongshun

--- a/crates/service/src/usage/usage_snapshot_store.rs
+++ b/crates/service/src/usage/usage_snapshot_store.rs
@@ -1,5 +1,5 @@
 use crate::account_availability::{evaluate_snapshot, Availability};
-use crate::account_status::set_account_status;
+use crate::account_status::{is_refresh_blocked_status_reason, set_account_status};
 use codexmanager_core::storage::{now_ts, Storage, UsageSnapshotRecord};
 use codexmanager_core::usage::parse_usage_snapshot;
 
@@ -7,8 +7,16 @@ const DEFAULT_USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT: usize = 1;
 const USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT_ENV: &str =
     "CODEXMANAGER_USAGE_SNAPSHOTS_RETAIN_PER_ACCOUNT";
 
-fn usage_status_updates_blocked(current_status: &str) -> bool {
-    current_status.trim().eq_ignore_ascii_case("disabled")
+fn usage_status_updates_blocked(storage: &Storage, account_id: &str, current_status: &str) -> bool {
+    if current_status.trim().eq_ignore_ascii_case("disabled") {
+        return true;
+    }
+    storage
+        .latest_account_status_reasons(&[account_id.to_string()])
+        .ok()
+        .and_then(|mut reasons| reasons.remove(account_id))
+        .as_deref()
+        .is_some_and(is_refresh_blocked_status_reason)
 }
 
 /// 函数 `usage_snapshots_retain_per_account`
@@ -52,7 +60,7 @@ pub(crate) fn apply_status_from_snapshot(
         .map(|account| account.status)
         .unwrap_or_default();
 
-    if usage_status_updates_blocked(&current_status) {
+    if usage_status_updates_blocked(storage, &record.account_id, &current_status) {
         return availability;
     }
 

--- a/crates/service/src/usage/usage_token_refresh.rs
+++ b/crates/service/src/usage/usage_token_refresh.rs
@@ -169,6 +169,9 @@ mod tests {
     use base64::Engine;
     use codexmanager_core::storage::Account;
     use std::ffi::OsString;
+    use std::thread;
+    use std::time::Duration;
+    use tiny_http::{Header, Response, Server, StatusCode as TinyStatusCode};
 
     fn jwt_with_json(payload_json: &str) -> String {
         let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload_json);
@@ -232,6 +235,40 @@ mod tests {
             .expect("insert account");
     }
 
+    fn start_region_blocked_refresh_server() -> (
+        String,
+        std::sync::mpsc::Receiver<String>,
+        thread::JoinHandle<()>,
+    ) {
+        let server = Server::http("127.0.0.1:0").expect("start refresh mock server");
+        let url = format!("http://{}/oauth/token", server.server_addr());
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = thread::spawn(move || {
+            let mut request = server
+                .recv_timeout(Duration::from_secs(5))
+                .expect("refresh mock timeout")
+                .expect("receive refresh request");
+            let mut body = String::new();
+            request
+                .as_reader()
+                .read_to_string(&mut body)
+                .expect("read refresh request body");
+            tx.send(body).expect("send refresh request body");
+            let response = Response::from_string("")
+                .with_status_code(TinyStatusCode(403))
+                .with_header(
+                    Header::from_bytes(
+                        "x-openai-authorization-error",
+                        "unsupported_country_region_territory",
+                    )
+                    .expect("auth error header"),
+                )
+                .with_header(Header::from_bytes("cf-ray", "ray-hkg").expect("cf-ray header"));
+            request.respond(response).expect("respond refresh request");
+        });
+        (url, rx, handle)
+    }
+
     #[test]
     fn recover_refresh_race_uses_latest_token_when_refresh_token_changed() {
         let storage = Storage::open_in_memory().expect("open");
@@ -273,6 +310,59 @@ mod tests {
 
         assert!(!recovered);
         assert_eq!(token.refresh_token, "refresh-old");
+    }
+
+    #[test]
+    fn refresh_and_persist_region_blocked_mock_suspends_account() {
+        let _guard = crate::test_env_guard();
+        let _ = crate::usage_http::usage_http_client();
+        let storage = Storage::open_in_memory().expect("open");
+        storage.init().expect("init");
+        insert_account(&storage, "acc-region-blocked");
+        let mut token = token_with_refresh("acc-region-blocked", "refresh-old");
+        storage.insert_token(&token).expect("insert token");
+        let (url, rx, handle) = start_region_blocked_refresh_server();
+        let _restore = EnvVarRestore::set("CODEX_REFRESH_TOKEN_URL_OVERRIDE", &url);
+
+        let err = refresh_and_persist_access_token(
+            &storage,
+            &mut token,
+            "https://auth.openai.com",
+            "client-id",
+            token_refresh_ahead_secs(),
+        )
+        .expect_err("region blocked refresh should fail");
+        let body = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("receive refresh request body");
+        handle.join().expect("join refresh mock server");
+
+        assert!(body.contains("refresh_token=refresh-old"));
+        assert!(err.contains("auth_error=unsupported_country_region_territory"));
+        assert!(
+            crate::account_status::mark_account_unavailable_for_auth_error(
+                &storage,
+                "acc-region-blocked",
+                &err,
+            )
+        );
+        let account = storage
+            .find_account_by_id("acc-region-blocked")
+            .expect("find account")
+            .expect("account exists");
+        assert_eq!(account.status, "unavailable");
+        let reasons = storage
+            .latest_account_status_reasons(&["acc-region-blocked".to_string()])
+            .expect("load reasons");
+        assert_eq!(
+            reasons.get("acc-region-blocked").map(String::as_str),
+            Some(crate::account_status::REFRESH_TOKEN_REGION_BLOCKED_REASON)
+        );
+        let stored = storage
+            .find_token_by_account_id("acc-region-blocked")
+            .expect("load token")
+            .expect("token exists");
+        assert_eq!(stored.refresh_token, "refresh-old");
     }
 
     #[test]

--- a/crates/service/tests/usage/usage_refresh_status_tests.rs
+++ b/crates/service/tests/usage/usage_refresh_status_tests.rs
@@ -5,7 +5,8 @@ use crate::account_availability::Availability;
 use crate::account_status::{
     deactivation_reason_from_message, mark_account_unavailable_for_auth_error,
     mark_account_unavailable_for_deactivation_error,
-    mark_account_unavailable_for_refresh_token_error,
+    mark_account_unavailable_for_refresh_token_error, set_account_status,
+    REFRESH_TOKEN_REGION_BLOCKED_REASON,
 };
 use crate::usage_snapshot_store::apply_status_from_snapshot;
 use codexmanager_core::storage::{now_ts, Account, Storage, UsageSnapshotRecord};
@@ -538,6 +539,61 @@ fn apply_status_available_preserves_manual_disabled_status() {
     assert_eq!(storage.event_count().expect("count events"), 0);
 }
 
+#[test]
+fn apply_status_available_preserves_region_blocked_status() {
+    let storage = Storage::open_in_memory().expect("open");
+    storage.init().expect("init");
+    let base_updated_at = now_ts() - 10;
+    storage
+        .insert_account(&Account {
+            id: "acc-region-blocked-status".to_string(),
+            label: "main".to_string(),
+            issuer: "issuer".to_string(),
+            chatgpt_account_id: None,
+            workspace_id: None,
+            group_name: None,
+            sort: 0,
+            status: "active".to_string(),
+            created_at: base_updated_at,
+            updated_at: base_updated_at,
+        })
+        .expect("insert");
+    set_account_status(
+        &storage,
+        "acc-region-blocked-status",
+        "unavailable",
+        REFRESH_TOKEN_REGION_BLOCKED_REASON,
+    );
+
+    let available = UsageSnapshotRecord {
+        account_id: "acc-region-blocked-status".to_string(),
+        used_percent: Some(10.0),
+        window_minutes: Some(300),
+        resets_at: None,
+        secondary_used_percent: Some(20.0),
+        secondary_window_minutes: Some(10080),
+        secondary_resets_at: None,
+        credits_json: None,
+        captured_at: now_ts(),
+    };
+
+    let availability = apply_status_from_snapshot(&storage, &available);
+    assert!(matches!(availability, Availability::Available));
+
+    let account = storage
+        .find_account_by_id("acc-region-blocked-status")
+        .expect("find")
+        .expect("exists");
+    assert_eq!(account.status, "unavailable");
+    let reasons = storage
+        .latest_account_status_reasons(&["acc-region-blocked-status".to_string()])
+        .expect("load reasons");
+    assert_eq!(
+        reasons.get("acc-region-blocked-status").map(String::as_str),
+        Some(REFRESH_TOKEN_REGION_BLOCKED_REASON)
+    );
+}
+
 /// 函数 `refresh_token_auth_error_marks_account_unavailable`
 ///
 /// 作者: gaohongshun
@@ -618,6 +674,45 @@ fn refresh_token_forbidden_without_invalid_grant_keeps_account_active() {
         .expect("find")
         .expect("exists");
     assert_eq!(active.status, "active");
+}
+
+#[test]
+fn refresh_token_region_blocked_forbidden_marks_account_unavailable() {
+    let storage = Storage::open_in_memory().expect("open");
+    storage.init().expect("init");
+    let account = Account {
+        id: "acc-refresh-region-blocked".to_string(),
+        label: "main".to_string(),
+        issuer: "issuer".to_string(),
+        chatgpt_account_id: None,
+        workspace_id: None,
+        group_name: None,
+        sort: 0,
+        status: "active".to_string(),
+        created_at: now_ts(),
+        updated_at: now_ts(),
+    };
+    storage.insert_account(&account).expect("insert");
+
+    assert!(mark_account_unavailable_for_refresh_token_error(
+        &storage,
+        "acc-refresh-region-blocked",
+        "refresh token failed with status 403 Forbidden: code=unsupported_country_region_territory type=request_forbidden Country, region, or territory not supported [cf_ray=ray-HKG, kind=cloudflare_blocked]"
+    ));
+    let unavailable = storage
+        .find_account_by_id("acc-refresh-region-blocked")
+        .expect("find")
+        .expect("exists");
+    assert_eq!(unavailable.status, "unavailable");
+    let reasons = storage
+        .latest_account_status_reasons(&["acc-refresh-region-blocked".to_string()])
+        .expect("load reasons");
+    assert_eq!(
+        reasons
+            .get("acc-refresh-region-blocked")
+            .map(String::as_str),
+        Some(REFRESH_TOKEN_REGION_BLOCKED_REASON)
+    );
 }
 
 /// 函数 `refresh_token_invalid_grant_on_forbidden_keeps_account_active`

--- a/docs/en/report/background-task-account-skip-notes.md
+++ b/docs/en/report/background-task-account-skip-notes.md
@@ -4,9 +4,9 @@ Below we only look at "where to filter what status" to facilitate local troubles
 
 | Tasks | Filter Locations | Filter Conditions | Skipped Status/Results | Description |
 | --- | --- | --- | --- | --- |
-| Usage polling thread | [crates/service/src/usage/refresh/batch.rs](../../../crates/service/src/usage/refresh/batch.rs#L91) | `status = disabled`, and the latest event hit ban reason | `disabled`, `account_deactivated`, `workspace_deactivated` | Put these accounts into `skipped_ids` first, and then filter them out from the token list |
+| Usage polling thread | [crates/service/src/usage/refresh/batch.rs](../../../crates/service/src/usage/refresh/batch.rs#L91) | `status = disabled`, and the latest event hit a ban or refresh-blocked reason | `disabled`, `account_deactivated`, `workspace_deactivated`, `refresh_token_region_blocked` | Put these accounts into `skipped_ids` first, and then filter them out from the token list |
 | Gateway keep-alive thread | [crates/core/src/storage/accounts.rs](../../../crates/core/src/storage/accounts.rs#L117) | `status = active`, and meet the gateway availability conditions | Accounts other than `active` will not enter the candidate set directly | Instead of traversing all accounts, candidate accounts will be screened first and then kept alive |
-| Token refresh polling | [crates/core/src/storage/tokens.rs](../../../crates/core/src/storage/tokens.rs#L28) | `refresh_token` cannot be empty; the latest status cannot be a deactivated class reason | None `refresh_token`, `account_deactivated`, `workspace_deactivated` | Only process tokens that can be refreshed and are not deactivated |
+| Token refresh polling | [crates/core/src/storage/tokens.rs](../../../crates/core/src/storage/tokens.rs#L28) | `refresh_token` cannot be empty; the latest status cannot be a deactivated class reason or `refresh_token_region_blocked` | None `refresh_token`, `account_deactivated`, `workspace_deactivated`, `refresh_token_region_blocked` | Only process tokens that can be refreshed and are not paused; after fixing the proxy route, manually restoring the account makes it eligible again |
 
 ## Supplement
 

--- a/docs/en/report/environment-and-runtime-config.md
+++ b/docs/en/report/environment-and-runtime-config.md
@@ -251,6 +251,11 @@ codexmanager-service-bundle/
 - 用量查询请求
 - `refresh_token` 刷新 access token 的请求
 
+Safety note:
+
+- Login-state refresh paths such as `auth.openai.com` / `oauth/token` must exit from an OpenAI-supported region; do not include restricted locations such as Hong Kong in automatic rotation for this path.
+- If the refresh request returns `unsupported_country_region_territory`, Service marks the account as `refresh_token_region_blocked` and pauses subsequent automatic refresh attempts. Fix the proxy route, then manually restore the account.
+
 默认不接管的是：
 
 - 你本机浏览器 / 桌面端访问 `localhost` / `127.0.0.1` 的本地回环请求

--- a/docs/zh-CN/report/后台任务账号跳过说明.md
+++ b/docs/zh-CN/report/后台任务账号跳过说明.md
@@ -4,9 +4,9 @@
 
 | 任务 | 过滤位置 | 过滤条件 | 被跳过的状态/结果 | 说明 |
 | --- | --- | --- | --- | --- |
-| 用量轮询线程 | [crates/service/src/usage/refresh/batch.rs](../../../crates/service/src/usage/refresh/batch.rs#L91) | `status = disabled`，以及最新事件命中封禁原因 | `disabled`，`account_deactivated`，`workspace_deactivated` | 先把这些账号放进 `skipped_ids`，再从 token 列表里过滤掉 |
+| 用量轮询线程 | [crates/service/src/usage/refresh/batch.rs](../../../crates/service/src/usage/refresh/batch.rs#L91) | `status = disabled`，以及最新事件命中封禁或刷新受阻原因 | `disabled`，`account_deactivated`，`workspace_deactivated`，`refresh_token_region_blocked` | 先把这些账号放进 `skipped_ids`，再从 token 列表里过滤掉 |
 | 网关保活线程 | [crates/core/src/storage/accounts.rs](../../../crates/core/src/storage/accounts.rs#L117) | `status = active`，且满足网关可用条件 | 非 `active` 的账号直接不进入候选集 | 不是遍历所有账号，而是先筛候选账号，再做保活 |
-| 令牌刷新轮询 | [crates/core/src/storage/tokens.rs](../../../crates/core/src/storage/tokens.rs#L28) | `refresh_token` 不能为空；最新状态不能是停用类原因 | 没有 `refresh_token`，`account_deactivated`，`workspace_deactivated` | 只处理能刷新且未停用的 token |
+| 令牌刷新轮询 | [crates/core/src/storage/tokens.rs](../../../crates/core/src/storage/tokens.rs#L28) | `refresh_token` 不能为空；最新状态不能是停用类原因或 `refresh_token_region_blocked` | 没有 `refresh_token`，`account_deactivated`，`workspace_deactivated`，`refresh_token_region_blocked` | 只处理能刷新且未被暂停的 token；修正代理后手动恢复账号会重新进入轮询 |
 
 ## 补充
 

--- a/docs/zh-CN/report/环境变量与运行配置说明.md
+++ b/docs/zh-CN/report/环境变量与运行配置说明.md
@@ -258,6 +258,11 @@ codexmanager-service-bundle/
 - 用量查询请求
 - `refresh_token` 刷新 access token 的请求
 
+安全提示：
+
+- `auth.openai.com` / `oauth/token` 等登录态刷新链路必须走 OpenAI 支持的地区出口；不要把香港等受限节点纳入这条链路的自动轮换。
+- 如果刷新请求返回 `unsupported_country_region_territory`，Service 会将账号标记为 `refresh_token_region_blocked` 并暂停后续自动刷新；修正代理后需要手动恢复账号。
+
 默认不接管的是：
 
 - 你本机浏览器 / 桌面端访问 `localhost` / `127.0.0.1` 的本地回环请求


### PR DESCRIPTION
## Summary

Fixes #257.

This PR pauses automatic account refresh when the refresh-token endpoint returns a restricted-region signal such as `unsupported_country_region_territory`. The account is marked `unavailable` with reason `refresh_token_region_blocked`, and background refresh paths skip it until the operator fixes the proxy route and manually restores the account.

## Root cause

The refresh-token path already surfaced useful Cloudflare/OpenAI diagnostics, but account status classification only treated refresh-token `401` and `400 invalid_grant` as auth failures. A restricted-region `403` could therefore keep retrying and risk turning a proxy routing issue into a reused refresh-token failure.

## Changes

- Detect restricted-region refresh-token failures and persist `refresh_token_region_blocked`.
- Stop usage retry logic from invoking token refresh on region-blocked `403` errors.
- Skip region-blocked accounts in usage polling and token refresh polling while preserving manual recovery.
- Add mock-backed tests for the actual refresh-token HTTP path and update proxy/runtime docs.

## Validation

- `cargo test -p codexmanager-service region_blocked -- --nocapture`
- `cargo test -p codexmanager-core tokens_due_for_refresh_include_other_unavailable_accounts_but_skip_deactivated -- --nocapture`
- `cargo fmt --check`
- `pnpm install --frozen-lockfile` in `apps/`
- `pnpm run build:desktop` in `apps/`