### PR TITLE
Fix stale model cleanup and prevent deleted discovered models from reappearing

### DIFF
--- a/crates/core/src/storage/model_sources.rs
+++ b/crates/core/src/storage/model_sources.rs
@@ -169,6 +169,40 @@ impl Storage {
             self.upsert_model_source_model(&record)?;
             out.push(record);
         }
+
+        let mut stmt = self.conn.prepare(
+            "SELECT upstream_model
+             FROM model_source_models
+             WHERE source_kind = ?1
+               AND source_id = ?2
+               AND discovery_kind = ?3",
+        )?;
+        let existing_rows = stmt.query_map(params![&source_kind, &source_id, &discovery_kind], |row| {
+            row.get::<_, String>(0)
+        })?;
+        let existing_upstream_models: std::collections::BTreeSet<String> =
+            existing_rows.collect::<Result<Vec<_>>>()?.into_iter().collect();
+        let stale_upstream_models = existing_upstream_models
+            .difference(&seen)
+            .cloned()
+            .collect::<Vec<_>>();
+        for upstream_model in stale_upstream_models {
+            self.conn.execute(
+                "DELETE FROM model_source_mappings
+                 WHERE source_kind = ?1
+                   AND source_id = ?2
+                   AND upstream_model = ?3",
+                params![&source_kind, &source_id, &upstream_model],
+            )?;
+            self.conn.execute(
+                "DELETE FROM model_source_models
+                 WHERE source_kind = ?1
+                   AND source_id = ?2
+                   AND upstream_model = ?3
+                   AND discovery_kind = ?4",
+                params![&source_kind, &source_id, &upstream_model, &discovery_kind],
+            )?;
+        }
         Ok(out)
     }
 

--- a/crates/core/src/storage/model_sources.rs
+++ b/crates/core/src/storage/model_sources.rs
@@ -177,11 +177,14 @@ impl Storage {
                AND source_id = ?2
                AND discovery_kind = ?3",
         )?;
-        let existing_rows = stmt.query_map(params![&source_kind, &source_id, &discovery_kind], |row| {
-            row.get::<_, String>(0)
-        })?;
-        let existing_upstream_models: std::collections::BTreeSet<String> =
-            existing_rows.collect::<Result<Vec<_>>>()?.into_iter().collect();
+        let existing_rows = stmt
+            .query_map(params![&source_kind, &source_id, &discovery_kind], |row| {
+                row.get::<_, String>(0)
+            })?;
+        let existing_upstream_models: std::collections::BTreeSet<String> = existing_rows
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .collect();
         let stale_upstream_models = existing_upstream_models
             .difference(&seen)
             .cloned()

--- a/crates/core/tests/storage.rs
+++ b/crates/core/tests/storage.rs
@@ -184,6 +184,104 @@ fn storage_can_upsert_and_resolve_model_source_mappings() {
 }
 
 #[test]
+fn upsert_discovered_source_models_prunes_stale_discovered_routes() {
+    let storage = Storage::open_in_memory().expect("open in memory");
+    storage.init().expect("init schema");
+    let now = now_ts();
+
+    storage
+        .upsert_model_source_model(&ModelSourceModel {
+            source_kind: "openai_account".to_string(),
+            source_id: "acc-sync-prune".to_string(),
+            upstream_model: "deepseek-v4-pro".to_string(),
+            display_name: Some("deepseek-v4-pro".to_string()),
+            status: "available".to_string(),
+            discovery_kind: "synced".to_string(),
+            last_synced_at: Some(now),
+            extra_json: "{}".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed stale discovered model");
+    storage
+        .upsert_model_source_model(&ModelSourceModel {
+            source_kind: "openai_account".to_string(),
+            source_id: "acc-sync-prune".to_string(),
+            upstream_model: "manual-keep".to_string(),
+            display_name: Some("manual-keep".to_string()),
+            status: "available".to_string(),
+            discovery_kind: "manual".to_string(),
+            last_synced_at: Some(now),
+            extra_json: "{}".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed manual model");
+
+    storage
+        .upsert_model_source_mapping(&ModelSourceMapping {
+            id: "map-stale-discovered".to_string(),
+            platform_model_slug: "deepseek-v4-pro".to_string(),
+            source_kind: "openai_account".to_string(),
+            source_id: "acc-sync-prune".to_string(),
+            upstream_model: "deepseek-v4-pro".to_string(),
+            enabled: true,
+            priority: 0,
+            weight: 1,
+            billing_model_slug: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed stale discovered mapping");
+    storage
+        .upsert_model_source_mapping(&ModelSourceMapping {
+            id: "map-manual-keep".to_string(),
+            platform_model_slug: "manual-keep".to_string(),
+            source_kind: "openai_account".to_string(),
+            source_id: "acc-sync-prune".to_string(),
+            upstream_model: "manual-keep".to_string(),
+            enabled: true,
+            priority: 0,
+            weight: 1,
+            billing_model_slug: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed manual mapping");
+
+    storage
+        .upsert_discovered_model_source_models(
+            "openai_account",
+            "acc-sync-prune",
+            &["gpt-4.1".to_string()],
+            "synced",
+        )
+        .expect("sync discovered models");
+
+    let source_models = storage
+        .list_model_source_models(Some("openai_account"), Some("acc-sync-prune"))
+        .expect("list source models");
+    assert!(source_models
+        .iter()
+        .any(|item| item.upstream_model == "gpt-4.1" && item.discovery_kind == "synced"));
+    assert!(source_models
+        .iter()
+        .any(|item| item.upstream_model == "manual-keep" && item.discovery_kind == "manual"));
+    assert!(!source_models
+        .iter()
+        .any(|item| item.upstream_model == "deepseek-v4-pro"));
+
+    let stale_mappings = storage
+        .list_model_source_mappings(Some("deepseek-v4-pro"))
+        .expect("list stale mappings");
+    assert!(stale_mappings.is_empty());
+    let manual_mappings = storage
+        .list_model_source_mappings(Some("manual-keep"))
+        .expect("list manual mappings");
+    assert_eq!(manual_mappings.len(), 1);
+}
+
+#[test]
 fn delete_account_removes_openai_model_source_routes() {
     let mut storage = Storage::open_in_memory().expect("open in memory");
     storage.init().expect("init schema");

--- a/crates/service/src/apikey/apikey_models.rs
+++ b/crates/service/src/apikey/apikey_models.rs
@@ -603,9 +603,15 @@ where
         .collect::<HashSet<_>>();
     match requested_source_id.as_deref() {
         Some(source_id) if !active_source_ids.contains(source_id) => {
+            let stale_upstream_models = stale_source_upstream_models(
+                storage,
+                ROUTING_SOURCE_KIND_AGGREGATE_API,
+                source_id,
+            )?;
             storage
                 .delete_model_source_routes_for_source(ROUTING_SOURCE_KIND_AGGREGATE_API, source_id)
                 .map_err(|err| format!("delete stale aggregate api source routes failed: {err}"))?;
+            cleanup_orphan_auto_catalog_models(storage, &stale_upstream_models)?;
             if apis.iter().any(|api| api.id == source_id) {
                 return Err(format!("aggregate api `{source_id}` is disabled"));
             }
@@ -689,12 +695,79 @@ fn prune_stale_aggregate_api_source_routes(
         if active_source_ids.contains(source_id.as_str()) {
             continue;
         }
+        let stale_upstream_models =
+            stale_source_upstream_models(storage, ROUTING_SOURCE_KIND_AGGREGATE_API, source_id.as_str())?;
         storage
             .delete_model_source_routes_for_source(
                 ROUTING_SOURCE_KIND_AGGREGATE_API,
                 source_id.as_str(),
             )
             .map_err(|err| format!("delete stale aggregate api source routes failed: {err}"))?;
+        cleanup_orphan_auto_catalog_models(storage, &stale_upstream_models)?;
+    }
+    Ok(())
+}
+
+fn stale_source_upstream_models(
+    storage: &Storage,
+    source_kind: &str,
+    source_id: &str,
+) -> Result<HashSet<String>, String> {
+    storage
+        .list_model_source_models(Some(source_kind), Some(source_id))
+        .map_err(|err| format!("list source models failed: {err}"))
+        .map(|models| {
+            models
+                .into_iter()
+                .map(|model| model.upstream_model)
+                .collect::<HashSet<_>>()
+        })
+}
+
+fn cleanup_orphan_auto_catalog_models(
+    storage: &Storage,
+    candidate_slugs: &HashSet<String>,
+) -> Result<(), String> {
+    if candidate_slugs.is_empty() {
+        return Ok(());
+    }
+
+    let catalog_models = storage
+        .list_model_catalog_models(MODEL_CACHE_SCOPE_DEFAULT)
+        .map_err(|err| format!("list model catalog failed: {err}"))?;
+    if catalog_models.is_empty() {
+        return Ok(());
+    }
+
+    let enabled_mappings = storage
+        .list_model_source_mappings(None)
+        .map_err(|err| format!("list model mappings failed: {err}"))?
+        .into_iter()
+        .filter(|mapping| mapping.enabled)
+        .map(|mapping| mapping.platform_model_slug)
+        .collect::<HashSet<_>>();
+
+    let remaining_source_model_slugs = storage
+        .list_model_source_models(None, None)
+        .map_err(|err| format!("list source models failed: {err}"))?
+        .into_iter()
+        .map(|model| model.upstream_model)
+        .collect::<HashSet<_>>();
+
+    for model in catalog_models {
+        if !candidate_slugs.contains(model.slug.as_str()) {
+            continue;
+        }
+        if model.source_kind != MODEL_SOURCE_KIND_REMOTE || model.user_edited {
+            continue;
+        }
+        if remaining_source_model_slugs.contains(model.slug.as_str()) {
+            continue;
+        }
+        if enabled_mappings.contains(model.slug.as_str()) {
+            continue;
+        }
+        delete_model_catalog_entry(storage, model.slug.as_str())?;
     }
     Ok(())
 }
@@ -1938,7 +2011,9 @@ fn needs_structured_backfill(rows: &[ModelCatalogModelRecord], missing_scope_row
 mod tests {
     use std::collections::BTreeMap;
 
-    use codexmanager_core::storage::{now_ts, Account, AggregateApi, ModelSourceMapping, Storage};
+    use codexmanager_core::storage::{
+        now_ts, Account, AggregateApi, ModelSourceMapping, ModelSourceModel, Storage,
+    };
     use serde_json::{json, Value};
 
     use super::{
@@ -2765,6 +2840,139 @@ mod tests {
             .list_model_source_mappings(Some("vendor-stale"))
             .expect("list mappings")
             .is_empty());
+    }
+
+    #[test]
+    fn bootstrap_aggregate_routes_cleans_orphan_auto_catalog_model() {
+        let storage = Storage::open_in_memory().expect("open storage");
+        storage.init().expect("init storage");
+        insert_test_aggregate_api(&storage, "agg-orphan", "disabled");
+        let now = now_ts();
+        storage
+            .upsert_model_source_model(&ModelSourceModel {
+                source_kind: ROUTING_SOURCE_KIND_AGGREGATE_API.to_string(),
+                source_id: "agg-orphan".to_string(),
+                upstream_model: "orphan-agg-model".to_string(),
+                display_name: Some("Orphan Aggregate Model".to_string()),
+                status: "available".to_string(),
+                discovery_kind: "synced".to_string(),
+                last_synced_at: Some(now),
+                extra_json: "{}".to_string(),
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("seed source model");
+        save_managed_model_catalog_with_storage(
+            &storage,
+            &ManagedModelCatalogResult {
+                items: vec![ManagedModelCatalogEntry {
+                    model: ModelInfo {
+                        slug: "orphan-agg-model".to_string(),
+                        display_name: "Orphan Aggregate Model".to_string(),
+                        supported_in_api: true,
+                        visibility: Some("list".to_string()),
+                        input_modalities: vec!["text".to_string()],
+                        ..Default::default()
+                    },
+                    source_kind: MODEL_SOURCE_KIND_REMOTE.to_string(),
+                    user_edited: false,
+                    sort_index: 0,
+                    updated_at: now,
+                }],
+                extra: Default::default(),
+            },
+        )
+        .expect("seed catalog model");
+
+        bootstrap_aggregate_api_model_routes(&storage).expect("bootstrap aggregate routes");
+
+        let source_models = storage
+            .list_model_source_models(Some(ROUTING_SOURCE_KIND_AGGREGATE_API), Some("agg-orphan"))
+            .expect("list source models");
+        assert!(source_models.is_empty());
+
+        let catalog_after = read_managed_model_catalog_from_storage(&storage)
+            .expect("read catalog after bootstrap");
+        assert!(
+            !catalog_after
+                .items
+                .iter()
+                .any(|item| item.model.slug == "orphan-agg-model")
+        );
+    }
+
+    #[test]
+    fn bootstrap_aggregate_routes_keeps_unrelated_remote_catalog_model() {
+        let storage = Storage::open_in_memory().expect("open storage");
+        storage.init().expect("init storage");
+        insert_test_aggregate_api(&storage, "agg-orphan", "disabled");
+        let now = now_ts();
+        storage
+            .upsert_model_source_model(&ModelSourceModel {
+                source_kind: ROUTING_SOURCE_KIND_AGGREGATE_API.to_string(),
+                source_id: "agg-orphan".to_string(),
+                upstream_model: "orphan-agg-model".to_string(),
+                display_name: Some("Orphan Aggregate Model".to_string()),
+                status: "available".to_string(),
+                discovery_kind: "synced".to_string(),
+                last_synced_at: Some(now),
+                extra_json: "{}".to_string(),
+                created_at: now,
+                updated_at: now,
+            })
+            .expect("seed source model");
+        save_managed_model_catalog_with_storage(
+            &storage,
+            &ManagedModelCatalogResult {
+                items: vec![
+                    ManagedModelCatalogEntry {
+                        model: ModelInfo {
+                            slug: "orphan-agg-model".to_string(),
+                            display_name: "Orphan Aggregate Model".to_string(),
+                            supported_in_api: true,
+                            visibility: Some("list".to_string()),
+                            input_modalities: vec!["text".to_string()],
+                            ..Default::default()
+                        },
+                        source_kind: MODEL_SOURCE_KIND_REMOTE.to_string(),
+                        user_edited: false,
+                        sort_index: 0,
+                        updated_at: now,
+                    },
+                    ManagedModelCatalogEntry {
+                        model: ModelInfo {
+                            slug: "unrelated-remote-model".to_string(),
+                            display_name: "Unrelated Remote Model".to_string(),
+                            supported_in_api: true,
+                            visibility: Some("list".to_string()),
+                            input_modalities: vec!["text".to_string()],
+                            ..Default::default()
+                        },
+                        source_kind: MODEL_SOURCE_KIND_REMOTE.to_string(),
+                        user_edited: false,
+                        sort_index: 1,
+                        updated_at: now,
+                    },
+                ],
+                extra: Default::default(),
+            },
+        )
+        .expect("seed catalog models");
+
+        bootstrap_aggregate_api_model_routes(&storage).expect("bootstrap aggregate routes");
+
+        let catalog_after = read_managed_model_catalog_from_storage(&storage)
+            .expect("read catalog after bootstrap");
+        assert!(catalog_after
+            .items
+            .iter()
+            .any(|item| item.model.slug == "unrelated-remote-model"));
+        assert!(
+            !catalog_after
+                .items
+                .iter()
+                .any(|item| item.model.slug == "orphan-agg-model")
+        );
     }
 
     #[test]

--- a/crates/service/src/apikey/apikey_models.rs
+++ b/crates/service/src/apikey/apikey_models.rs
@@ -632,7 +632,12 @@ where
     {
         match discover_models(api.id.as_str()) {
             Ok(models) => {
-                storage
+                let previous_upstream_models = stale_source_upstream_models(
+                    storage,
+                    ROUTING_SOURCE_KIND_AGGREGATE_API,
+                    api.id.as_str(),
+                )?;
+                let synced_source_models = storage
                     .upsert_discovered_model_source_models(
                         ROUTING_SOURCE_KIND_AGGREGATE_API,
                         api.id.as_str(),
@@ -640,6 +645,15 @@ where
                         "synced",
                     )
                     .map_err(|err| format!("sync aggregate api source models failed: {err}"))?;
+                let synced_upstream_models = synced_source_models
+                    .into_iter()
+                    .map(|model| model.upstream_model)
+                    .collect::<HashSet<_>>();
+                let disappeared_upstream_models = previous_upstream_models
+                    .difference(&synced_upstream_models)
+                    .cloned()
+                    .collect::<HashSet<_>>();
+                cleanup_orphan_auto_catalog_models(storage, &disappeared_upstream_models)?;
                 auto_associate_source_models(
                     storage,
                     ROUTING_SOURCE_KIND_AGGREGATE_API,
@@ -695,8 +709,11 @@ fn prune_stale_aggregate_api_source_routes(
         if active_source_ids.contains(source_id.as_str()) {
             continue;
         }
-        let stale_upstream_models =
-            stale_source_upstream_models(storage, ROUTING_SOURCE_KIND_AGGREGATE_API, source_id.as_str())?;
+        let stale_upstream_models = stale_source_upstream_models(
+            storage,
+            ROUTING_SOURCE_KIND_AGGREGATE_API,
+            source_id.as_str(),
+        )?;
         storage
             .delete_model_source_routes_for_source(
                 ROUTING_SOURCE_KIND_AGGREGATE_API,
@@ -2893,12 +2910,10 @@ mod tests {
 
         let catalog_after = read_managed_model_catalog_from_storage(&storage)
             .expect("read catalog after bootstrap");
-        assert!(
-            !catalog_after
-                .items
-                .iter()
-                .any(|item| item.model.slug == "orphan-agg-model")
-        );
+        assert!(!catalog_after
+            .items
+            .iter()
+            .any(|item| item.model.slug == "orphan-agg-model"));
     }
 
     #[test]
@@ -2967,12 +2982,84 @@ mod tests {
             .items
             .iter()
             .any(|item| item.model.slug == "unrelated-remote-model"));
-        assert!(
-            !catalog_after
-                .items
-                .iter()
-                .any(|item| item.model.slug == "orphan-agg-model")
+        assert!(!catalog_after
+            .items
+            .iter()
+            .any(|item| item.model.slug == "orphan-agg-model"));
+    }
+
+    #[test]
+    fn aggregate_source_sync_cleans_orphan_auto_catalog_model_when_model_disappears() {
+        let storage = Storage::open_in_memory().expect("open storage");
+        storage.init().expect("init storage");
+        insert_test_aggregate_api(&storage, "agg-changing", "active");
+
+        sync_aggregate_api_source_models_with_discovery(
+            &storage,
+            Some("agg-changing"),
+            |source_id| {
+                assert_eq!(source_id, "agg-changing");
+                Ok(vec!["vendor-old".to_string()])
+            },
+        )
+        .expect("sync initial aggregate models");
+
+        let initial_catalog =
+            read_managed_model_catalog_from_storage(&storage).expect("read initial catalog");
+        assert!(initial_catalog
+            .items
+            .iter()
+            .any(|item| item.model.slug == "vendor-old"));
+        assert_eq!(
+            storage
+                .list_enabled_model_source_mappings_for_platform("vendor-old")
+                .expect("list initial mapping")
+                .len(),
+            1
         );
+
+        sync_aggregate_api_source_models_with_discovery(
+            &storage,
+            Some("agg-changing"),
+            |source_id| {
+                assert_eq!(source_id, "agg-changing");
+                Ok(vec!["vendor-new".to_string()])
+            },
+        )
+        .expect("sync changed aggregate models");
+
+        let source_models = storage
+            .list_model_source_models(
+                Some(ROUTING_SOURCE_KIND_AGGREGATE_API),
+                Some("agg-changing"),
+            )
+            .expect("list source models");
+        assert!(!source_models
+            .iter()
+            .any(|item| item.upstream_model == "vendor-old"));
+        assert!(source_models
+            .iter()
+            .any(|item| item.upstream_model == "vendor-new"));
+        assert!(storage
+            .list_model_source_mappings(Some("vendor-old"))
+            .expect("list old mappings")
+            .is_empty());
+
+        let catalog_after =
+            read_managed_model_catalog_from_storage(&storage).expect("read catalog after sync");
+        assert!(!catalog_after
+            .items
+            .iter()
+            .any(|item| item.model.slug == "vendor-old"));
+        assert!(catalog_after
+            .items
+            .iter()
+            .any(|item| item.model.slug == "vendor-new"));
+        let new_mappings = storage
+            .list_enabled_model_source_mappings_for_platform("vendor-new")
+            .expect("list new mappings");
+        assert_eq!(new_mappings.len(), 1);
+        assert_eq!(new_mappings[0].source_id, "agg-changing");
     }
 
     #[test]


### PR DESCRIPTION
## 变更摘要

- 修复聚合 API 提供商失效（禁用/删除）后，自动并入的孤儿模型未被清理的问题。
- 修复来源模型同步仅“新增/更新”不“清理陈旧项”的问题，避免模型在管理页删除后因残留路由再次出现。

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/apikey/apikey_models.rs`
- `crates/core/src/storage/model_sources.rs`
- `crates/core/tests/storage.rs`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
cargo test -p codexmanager-service bootstrap_aggregate_routes_ -- --nocapture
cargo test -p codexmanager-service aggregate_bootstrap_prunes_stale_source_routes -- --nocapture
cargo test -p codexmanager-core upsert_discovered_source_models_prunes_stale_discovered_routes -- --nocapture
cargo test -p codexmanager-service account_pool_bootstrap_ -- --nocapture
```

未执行的验证与原因：

```text
pnpm -C apps run test / build / test:ui：本次改动不涉及前端与 Tauri。
cargo test --workspace：本次为定向修复，已执行 service/core 相关回归测试；未在本轮执行全量工作区测试。
```

## 风险与影响面

- `upsert_discovered_model_source_models` 由“仅上插”调整为“同步语义（会清理同 source 同 discovery_kind 的陈旧项）”，可能影响依赖旧行为（保留历史 discovered 项）的场景。
- 清理陈旧 discovered source model 时会同步删除对应 `model_source_mappings`，以避免删除后模型被残留路由重建；该行为符合“同步结果应收敛到当前发现集”的预期。

## 备注

- 提交前已确认未包含敏感 token、cookie、API key。
