### PR TITLE
feat: add local Codex account switching in account pool

### DIFF
--- a/apps/src-tauri/Cargo.lock
+++ b/apps/src-tauri/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-log",

--- a/apps/src-tauri/Cargo.toml
+++ b/apps/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ semver = "1.0"
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
 rfd = "0.15"
 rusqlite = { version = "0.31", features = ["bundled", "backup"] }
+sha2 = "0.10"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }

--- a/apps/src-tauri/src/commands/account/local.rs
+++ b/apps/src-tauri/src/commands/account/local.rs
@@ -1,19 +1,441 @@
-use codexmanager_core::storage::Storage;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use codexmanager_core::storage::{Account, Storage, Token};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
 
 use crate::app_storage::resolve_db_path_with_legacy_migration;
 
-/// 函数 `local_account_delete`
-///
-/// 作者: gaohongshun
-///
-/// 时间: 2026-04-02
-///
-/// # 参数
-/// - app: 参数 app
-/// - account_id: 参数 account_id
-///
-/// # 返回
-/// 返回函数执行结果
+const SWITCH_WARNING: &str = "已有 Codex / IDE 会话可能需要重开后才会使用新账号";
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn now_millis() -> i128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as i128)
+        .unwrap_or(0)
+}
+
+fn civil_from_unix_days(days_since_epoch: u64) -> (i128, u32, u32) {
+    let z = days_since_epoch as i128 + 719_468;
+    let era = z.div_euclid(146_097);
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    let year = year + if month <= 2 { 1 } else { 0 };
+    (year, month as u32, day as u32)
+}
+
+fn utc_now_rfc3339_millis() -> String {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let total_seconds = duration.as_secs();
+    let millis = duration.subsec_millis();
+    let days = total_seconds / 86_400;
+    let seconds_of_day = total_seconds % 86_400;
+    let hour = seconds_of_day / 3_600;
+    let minute = (seconds_of_day % 3_600) / 60;
+    let second = seconds_of_day % 60;
+    let (year, month, day) = civil_from_unix_days(days);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
+}
+
+fn sha256_hex(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn user_home_dir() -> Result<PathBuf, String> {
+    std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| "无法定位用户主目录".to_string())
+}
+
+fn live_auth_path() -> Result<PathBuf, String> {
+    Ok(user_home_dir()?.join(".codex").join("auth.json"))
+}
+
+fn codex_dir() -> Result<PathBuf, String> {
+    Ok(user_home_dir()?.join(".codex"))
+}
+
+fn atomic_write_text(path: &Path, content: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("create dir failed ({}): {err}", parent.display()))?;
+    }
+    let tmp = path.with_file_name(format!(
+        ".auth.json.tmp.{}.{}",
+        std::process::id(),
+        now_millis()
+    ));
+    fs::write(&tmp, content)
+        .map_err(|err| format!("write temp auth failed ({}): {err}", tmp.display()))?;
+    match fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(rename_err) => {
+            fs::copy(&tmp, path).map_err(|copy_err| {
+                format!(
+                    "replace auth failed (rename: {rename_err}; copy {} -> {}: {copy_err})",
+                    tmp.display(),
+                    path.display()
+                )
+            })?;
+            let _ = fs::remove_file(&tmp);
+            Ok(())
+        }
+    }
+}
+
+fn backup_live_auth_if_exists(path: &Path) -> Result<Option<PathBuf>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("create auth dir failed ({}): {err}", parent.display()))?;
+    }
+    let backup = path.with_file_name(format!("auth.json.bak.{}", now_millis()));
+    fs::copy(path, &backup).map_err(|err| {
+        format!(
+            "backup live auth failed ({} -> {}): {err}",
+            path.display(),
+            backup.display()
+        )
+    })?;
+    Ok(Some(backup))
+}
+
+fn sorted_json_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(items.iter().map(sorted_json_value).collect()),
+        Value::Object(map) => {
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(right.0));
+            let mut out = Map::new();
+            for (key, item) in entries {
+                out.insert(key.clone(), sorted_json_value(item));
+            }
+            Value::Object(out)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn canonical_json_string(value: &Value) -> String {
+    serde_json::to_string(&sorted_json_value(value)).unwrap_or_else(|_| value.to_string())
+}
+
+fn fingerprint_from_auth_content(content: &str) -> String {
+    match serde_json::from_str::<Value>(content) {
+        Ok(value) => sha256_hex(&canonical_json_string(&value)),
+        Err(_) => sha256_hex(content),
+    }
+}
+
+fn normalized_key_for_volatile_check(key: &str) -> String {
+    key.replace('_', "").to_ascii_lowercase()
+}
+
+fn is_volatile_auth_key(key: &str) -> bool {
+    matches!(
+        normalized_key_for_volatile_check(key).as_str(),
+        "accesstoken"
+            | "refreshtoken"
+            | "idtoken"
+            | "expiresat"
+            | "expiresin"
+            | "lastrefresh"
+            | "tokentype"
+            | "devicetoken"
+            | "sessiontoken"
+            | "authorization"
+    )
+}
+
+fn strip_volatile_auth_fields(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(items.iter().map(strip_volatile_auth_fields).collect()),
+        Value::Object(map) => {
+            let mut out = Map::new();
+            for (key, item) in map {
+                if is_volatile_auth_key(key) {
+                    continue;
+                }
+                out.insert(key.clone(), strip_volatile_auth_fields(item));
+            }
+            Value::Object(out)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn stable_fingerprint_from_auth_content(content: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(content).ok()?;
+    let root = value.as_object()?;
+    if let Some(account_id) = root
+        .get("tokens")
+        .and_then(Value::as_object)
+        .and_then(|tokens| tokens.get("account_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let stable = json!({
+            "auth_mode": root.get("auth_mode").cloned().unwrap_or(Value::Null),
+            "account_id": account_id
+        });
+        return Some(sha256_hex(&canonical_json_string(&stable)));
+    }
+    if let Some(api_key) = root
+        .get("OPENAI_API_KEY")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let stable = json!({
+            "auth_mode": root.get("auth_mode").cloned().unwrap_or(Value::Null),
+            "OPENAI_API_KEY": api_key
+        });
+        return Some(sha256_hex(&canonical_json_string(&stable)));
+    }
+    Some(sha256_hex(&canonical_json_string(
+        &strip_volatile_auth_fields(&value),
+    )))
+}
+
+fn normalize_auth_content_for_runtime(content: &str, live_content: Option<&str>) -> String {
+    let target = match serde_json::from_str::<Value>(content) {
+        Ok(Value::Object(map)) => map,
+        _ => return content.to_string(),
+    };
+    let live = live_content
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .and_then(|value| match value {
+            Value::Object(map) => Some(map),
+            _ => None,
+        });
+    let live_meta = live.as_ref().and_then(|map| map.get("meta").cloned());
+
+    let mut merged = Map::new();
+    if let Some(live_map) = live {
+        for (key, value) in live_map {
+            if key == "tokens" || key == "meta" {
+                continue;
+            }
+            merged.insert(key, value);
+        }
+    }
+    for (key, value) in &target {
+        if key == "tokens" || key == "meta" {
+            continue;
+        }
+        merged.insert(key.clone(), value.clone());
+    }
+    if let Some(tokens) = target.get("tokens") {
+        merged.insert("tokens".to_string(), tokens.clone());
+    }
+    if let Some(meta) = target.get("meta") {
+        merged.insert("meta".to_string(), meta.clone());
+    } else if let Some(meta) = live_meta {
+        merged.insert("meta".to_string(), meta);
+    }
+    if !merged.contains_key("OPENAI_API_KEY") {
+        merged.insert("OPENAI_API_KEY".to_string(), Value::Null);
+    }
+    let refresh_missing = merged
+        .get("last_refresh")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default()
+        .is_empty();
+    if refresh_missing {
+        merged.insert(
+            "last_refresh".to_string(),
+            Value::String(utc_now_rfc3339_millis()),
+        );
+    }
+
+    serde_json::to_string_pretty(&Value::Object(merged)).unwrap_or_else(|_| content.to_string())
+}
+
+fn build_account_pool_auth_content(account: &Account, token: &Token) -> Result<String, String> {
+    let payload = json!({
+        "tokens": {
+            "access_token": token.access_token.clone(),
+            "id_token": token.id_token.clone(),
+            "refresh_token": token.refresh_token.clone(),
+            "account_id": account.id.clone()
+        },
+        "meta": {
+            "label": account.label.clone(),
+            "issuer": account.issuer.clone(),
+            "workspace_id": account.workspace_id.clone(),
+            "chatgpt_account_id": account.chatgpt_account_id.clone(),
+            "exported_at": now_secs()
+        }
+    });
+    serde_json::to_string_pretty(&payload)
+        .map_err(|err| format!("serialize account auth failed: {err}"))
+}
+
+fn token_string<'a>(tokens: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| tokens.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn auth_value_matches_account_token(value: &Value, account_id: &str, token: &Token) -> bool {
+    let Some(tokens) = value.get("tokens").and_then(Value::as_object) else {
+        return false;
+    };
+    if token_string(tokens, &["account_id", "accountId"]).is_some_and(|value| value == account_id)
+    {
+        return true;
+    }
+    let token_matches = |keys: &[&str], expected: &str| {
+        let expected = expected.trim();
+        !expected.is_empty() && token_string(tokens, keys).is_some_and(|value| value == expected)
+    };
+    token_matches(&["refresh_token", "refreshToken"], &token.refresh_token)
+        || token_matches(&["access_token", "accessToken"], &token.access_token)
+        || token_matches(&["id_token", "idToken"], &token.id_token)
+}
+
+fn open_account_pool_storage(app: &tauri::AppHandle) -> Result<Storage, String> {
+    let db_path = resolve_db_path_with_legacy_migration(app)?;
+    Storage::open(db_path).map_err(|err| format!("open account storage failed: {err}"))
+}
+
+fn active_account_pool_id(
+    storage: &Storage,
+    live_raw: Option<&str>,
+) -> Result<Option<String>, String> {
+    let Some(live_raw) = live_raw else {
+        return Ok(None);
+    };
+    let live_value = serde_json::from_str::<Value>(live_raw).ok();
+    let live_fingerprint = Some(fingerprint_from_auth_content(live_raw));
+    let live_stable_fingerprint = stable_fingerprint_from_auth_content(live_raw);
+    let accounts = storage
+        .list_accounts()
+        .map_err(|err| format!("list accounts failed: {err}"))?;
+    for account in accounts {
+        let Some(token) = storage
+            .find_token_by_account_id(&account.id)
+            .map_err(|err| format!("load account token failed: {err}"))?
+        else {
+            continue;
+        };
+        if live_value
+            .as_ref()
+            .is_some_and(|value| auth_value_matches_account_token(value, &account.id, &token))
+        {
+            return Ok(Some(account.id));
+        }
+        let auth_content = build_account_pool_auth_content(&account, &token)?;
+        let full_matches = live_fingerprint
+            .as_ref()
+            .is_some_and(|fingerprint| *fingerprint == fingerprint_from_auth_content(&auth_content));
+        let stable_matches = live_stable_fingerprint.as_ref().is_some_and(|fingerprint| {
+            stable_fingerprint_from_auth_content(&auth_content).as_ref() == Some(fingerprint)
+        });
+        if full_matches || stable_matches {
+            return Ok(Some(account.id));
+        }
+    }
+    Ok(None)
+}
+
+fn account_pool_local_status_value(app: &tauri::AppHandle) -> Result<Value, String> {
+    let live_path = live_auth_path()?;
+    let live_auth_present = live_path.exists();
+    let live_raw = if live_auth_present {
+        fs::read_to_string(&live_path).ok()
+    } else {
+        None
+    };
+    let storage = open_account_pool_storage(app)?;
+    let active_account_id = active_account_pool_id(&storage, live_raw.as_deref())?;
+    Ok(json!({
+        "activeAccountId": active_account_id,
+        "liveAuthPresent": live_auth_present,
+        "liveAuthPath": live_path.to_string_lossy().to_string()
+    }))
+}
+
+#[tauri::command]
+pub async fn codex_local_account_pool_status(app: tauri::AppHandle) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || account_pool_local_status_value(&app))
+        .await
+        .map_err(|err| format!("codex_local_account_pool_status task failed: {err}"))?
+}
+
+#[tauri::command]
+pub async fn codex_local_account_pool_switch(
+    app: tauri::AppHandle,
+    account_id: String,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let account_id = account_id.trim().to_string();
+        if account_id.is_empty() {
+            return Err("缺少账号 ID".to_string());
+        }
+        let storage = open_account_pool_storage(&app)?;
+        let account = storage
+            .find_account_by_id(&account_id)
+            .map_err(|err| format!("load account failed: {err}"))?
+            .ok_or_else(|| "未找到账号池账号".to_string())?;
+        let token = storage
+            .find_token_by_account_id(&account_id)
+            .map_err(|err| format!("load account token failed: {err}"))?
+            .ok_or_else(|| "该账号缺少 AT/RT，无法切换为本地账号".to_string())?;
+        let raw = build_account_pool_auth_content(&account, &token)?;
+        let live_path = live_auth_path()?;
+        let live_raw = fs::read_to_string(&live_path).ok();
+        let backup_path = backup_live_auth_if_exists(&live_path)?;
+        let normalized = normalize_auth_content_for_runtime(&raw, live_raw.as_deref());
+        let dir = codex_dir()?;
+        fs::create_dir_all(&dir)
+            .map_err(|err| format!("create codex dir failed ({}): {err}", dir.display()))?;
+        atomic_write_text(&live_path, &normalized)?;
+        let status = account_pool_local_status_value(&app)?;
+        let active_account_id = status
+            .get("activeAccountId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        Ok(json!({
+            "success": true,
+            "activeAccountId": active_account_id,
+            "backupPath": backup_path.map(|path| path.to_string_lossy().to_string()),
+            "warning": SWITCH_WARNING,
+            "status": status
+        }))
+    })
+    .await
+    .map_err(|err| format!("codex_local_account_pool_switch task failed: {err}"))?
+}
+
 #[tauri::command]
 pub async fn local_account_delete(
     app: tauri::AppHandle,

--- a/apps/src-tauri/src/commands/registry.rs
+++ b/apps/src-tauri/src/commands/registry.rs
@@ -23,6 +23,8 @@ macro_rules! invoke_handler {
             crate::commands::account::transfer::service_account_import_by_directory,
             crate::commands::account::transfer::service_account_export_by_account_files,
             crate::commands::account::local::local_account_delete,
+            crate::commands::account::local::codex_local_account_pool_status,
+            crate::commands::account::local::codex_local_account_pool_switch,
             // account manager
             crate::commands::account_manager::service_account_manager_status,
             crate::commands::account_manager::service_account_manager_session_current,

--- a/apps/src-tauri/tauri.conf.json
+++ b/apps/src-tauri/tauri.conf.json
@@ -15,7 +15,8 @@
     "windows": [
       {
         "title": "CodexManager",
-        "width": 1100,
+        "width": 1320,
+        "minWidth": 1180,
         "height": 720,
         "resizable": true
       }

--- a/apps/src/app/accounts/accounts-page-view.tsx
+++ b/apps/src/app/accounts/accounts-page-view.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUp,
   ArrowUpDown,
   BarChart3,
+  CheckCircle2,
   Download,
   FileUp,
   FolderOpen,
@@ -154,6 +155,10 @@ export interface AccountsPageViewProps {
   isDeletingMany: boolean;
   isCleaningAccountsByStatus: boolean;
   isUpdatingPreferred: boolean;
+  localActiveAccountId: string | null;
+  localAuthPath: string;
+  isLoadingLocalCodexStatus: boolean;
+  isSwitchingLocalCodexAccountId: string | null;
   isReorderingAccounts: boolean;
   isUpdatingProfileAccountId: string | null;
   isUpdatingStatusAccountId: string | null;
@@ -209,6 +214,7 @@ export interface AccountsPageViewProps {
   refreshAccount: (accountId: string) => void;
   clearPreferredAccount: (accountId: string) => void;
   setPreferredAccount: (accountId: string) => void;
+  switchLocalCodexAccount: (accountId: string) => void;
   toggleAccountStatus: (
     accountId: string,
     enabled: boolean,
@@ -263,6 +269,10 @@ export function AccountsPageView(props: AccountsPageViewProps) {
     isDeletingMany,
     isCleaningAccountsByStatus,
     isUpdatingPreferred,
+    localActiveAccountId,
+    localAuthPath,
+    isLoadingLocalCodexStatus,
+    isSwitchingLocalCodexAccountId,
     isReorderingAccounts,
     isUpdatingProfileAccountId,
     isUpdatingStatusAccountId,
@@ -315,6 +325,7 @@ export function AccountsPageView(props: AccountsPageViewProps) {
     refreshAccount,
     clearPreferredAccount,
     setPreferredAccount,
+    switchLocalCodexAccount,
     toggleAccountStatus,
   } = props;
   const cleanupSelectedCount = cleanupStatusOptions.reduce(
@@ -783,6 +794,9 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                 </TableHead>
                 <TableHead className="w-[156px]">{t("顺序")}</TableHead>
                 <TableHead>{t("状态")}</TableHead>
+                <TableHead className="w-[132px] text-center">
+                  {t("本地账号")}
+                </TableHead>
                 <TableHead className="table-sticky-action-head w-[112px] text-center">
                   {t("操作")}
                 </TableHead>
@@ -811,6 +825,9 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                     <TableCell>
                       <Skeleton className="h-6 w-16 rounded-full" />
                     </TableCell>
+                    <TableCell>
+                      <Skeleton className="mx-auto h-7 w-20 rounded-md" />
+                    </TableCell>
                     <TableCell className="table-sticky-action-cell">
                       <Skeleton className="mx-auto h-8 w-24" />
                     </TableCell>
@@ -818,7 +835,7 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                 ))
               ) : visibleAccounts.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="h-48 text-center">
+                  <TableCell colSpan={7} className="h-48 text-center">
                     <div className="flex flex-col items-center justify-center gap-2 text-muted-foreground">
                       <Search className="h-8 w-8 opacity-20" />
                       <p>{t("未找到符合条件的账号")}</p>
@@ -834,6 +851,9 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                     isRefreshingAccountId === account.id;
                   const isRefreshingCurrentRt =
                     isRefreshingRtAccountId === account.id;
+                  const isLocalActive = localActiveAccountId === account.id;
+                  const isSwitchingLocalAccount =
+                    isSwitchingLocalCodexAccountId === account.id;
                   const filteredIndex =
                     filteredAccountIndexMap.get(account.id) ?? -1;
                   const canMoveUp = filteredIndex > 0;
@@ -950,6 +970,55 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                       </TableCell>
                       <TableCell>
                         <AccountStatusCell account={account} />
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <div className="flex justify-center">
+                          {isLocalActive ? (
+                            <Tooltip>
+                              <TooltipTrigger render={<span />} className="inline-flex">
+                                <span className="inline-flex h-7 items-center gap-1.5 rounded-md border border-green-500/30 bg-green-500/10 px-2 text-xs font-medium text-green-700 dark:text-green-300">
+                                  <CheckCircle2 className="h-3.5 w-3.5" />
+                                  {t("运行中")}
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent className="max-w-xs">
+                                <div className="space-y-1">
+                                  <div>{t("当前本机 Codex 正在使用此账号")}</div>
+                                  {localAuthPath ? (
+                                    <div className="break-all font-mono text-[10px] opacity-80">
+                                      {localAuthPath}
+                                    </div>
+                                  ) : null}
+                                </div>
+                              </TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-7 px-2 text-xs"
+                              disabled={
+                                !isServiceReady ||
+                                !account.hasToken ||
+                                isLoadingLocalCodexStatus ||
+                                Boolean(isSwitchingLocalCodexAccountId)
+                              }
+                              onClick={() => switchLocalCodexAccount(account.id)}
+                              title={
+                                account.hasToken
+                                  ? t("切换本机 Codex 到此账号")
+                                  : t("该账号缺少 AT/RT，无法切换")
+                              }
+                            >
+                              {isSwitchingLocalAccount ? (
+                                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                              )}
+                              {t("切换")}
+                            </Button>
+                          )}
+                        </div>
                       </TableCell>
                       <TableCell className="table-sticky-action-cell">
                         <div className="table-action-cell gap-1">

--- a/apps/src/app/accounts/page.tsx
+++ b/apps/src/app/accounts/page.tsx
@@ -69,6 +69,11 @@ export default function AccountsPage() {
     setPreferredAccount,
     clearPreferredAccount,
     isUpdatingPreferred,
+    localActiveAccountId,
+    localAuthPath,
+    isLoadingLocalCodexStatus,
+    isSwitchingLocalCodexAccountId,
+    switchLocalCodexAccount,
     reorderAccounts,
     isReorderingAccounts,
     updateAccountProfile,
@@ -648,6 +653,10 @@ const toggleCleanupStatus = (rawStatus: string) => {
       isDeletingMany={isDeletingMany}
       isCleaningAccountsByStatus={isCleaningAccountsByStatus}
       isUpdatingPreferred={isUpdatingPreferred}
+      localActiveAccountId={localActiveAccountId}
+      localAuthPath={localAuthPath}
+      isLoadingLocalCodexStatus={isLoadingLocalCodexStatus}
+      isSwitchingLocalCodexAccountId={isSwitchingLocalCodexAccountId}
       isReorderingAccounts={isReorderingAccounts}
       isUpdatingProfileAccountId={isUpdatingProfileAccountId}
       isUpdatingStatusAccountId={isUpdatingStatusAccountId}
@@ -700,6 +709,7 @@ const toggleCleanupStatus = (rawStatus: string) => {
       refreshAccount={refreshAccount}
       clearPreferredAccount={clearPreferredAccount}
       setPreferredAccount={setPreferredAccount}
+      switchLocalCodexAccount={switchLocalCodexAccount}
       toggleAccountStatus={toggleAccountStatus}
     />
   );

--- a/apps/src/hooks/useAccounts.ts
+++ b/apps/src/hooks/useAccounts.ts
@@ -165,7 +165,7 @@ export function useAccounts() {
   const localDayRange = useLocalDayRange();
   const serviceStatus = useAppStore((state) => state.serviceStatus);
   const backgroundTasks = useAppStore((state) => state.appSettings.backgroundTasks);
-  const { canAccessManagementRpc } = useRuntimeCapabilities();
+  const { canAccessManagementRpc, isDesktopRuntime } = useRuntimeCapabilities();
   const isServiceReady = canAccessManagementRpc && serviceStatus.connected;
   const isPageActive = useDesktopPageActive("/accounts/");
   const areAccountQueriesEnabled = useDeferredDesktopActivation(
@@ -240,6 +240,15 @@ export function useAccounts() {
     refetchIntervalInBackground: false,
     placeholderData: (previousData) =>
       previousData || (startupUsages.length > 0 ? startupUsages : undefined),
+  });
+
+  const localCodexAccountStatusQuery = useQuery({
+    queryKey: ["local-codex-account-status"],
+    queryFn: () => accountClient.getLocalCodexAccountStatus(),
+    enabled: isDesktopRuntime && isPageActive,
+    retry: 1,
+    refetchInterval: isDesktopRuntime && isPageActive ? 5_000 : false,
+    refetchIntervalInBackground: false,
   });
 
   const usageListFingerprint = useMemo(
@@ -384,6 +393,7 @@ export function useAccounts() {
       queryClient.invalidateQueries({ queryKey: ["today-summary"] }),
       queryClient.invalidateQueries({ queryKey: ["startup-snapshot"] }),
       queryClient.invalidateQueries({ queryKey: ["logs"] }),
+      queryClient.invalidateQueries({ queryKey: ["local-codex-account-status"] }),
     ]);
   };
 
@@ -730,6 +740,20 @@ export function useAccounts() {
     },
   });
 
+  const switchLocalCodexAccountMutation = useMutation({
+    mutationFn: (accountId: string) => accountClient.switchLocalCodexAccount(accountId),
+    onSuccess: async (result) => {
+      await queryClient.invalidateQueries({ queryKey: ["local-codex-account-status"] });
+      toast.success(t("本地账号已切换"));
+      if (result.warning) {
+        toast.info(t(result.warning));
+      }
+    },
+    onError: (error: unknown) => {
+      toast.error(`${t("切换本地账号失败")}: ${getAppErrorMessage(error)}`);
+    },
+  });
+
   return {
     accounts,
     planTypes,
@@ -814,6 +838,15 @@ export function useAccounts() {
       if (!ensureServiceReady("取消优先账号")) return;
       clearPreferredMutation.mutate(accountId);
     },
+    switchLocalCodexAccount: (accountId: string) => {
+      if (!ensureServiceReady("切换本地账号")) return;
+      const targetAccountId = accountId.trim();
+      if (!targetAccountId) {
+        toast.error(t("未找到当前账号，请刷新后重试"));
+        return;
+      }
+      switchLocalCodexAccountMutation.mutate(targetAccountId);
+    },
     updateAccountSort: async (accountId: string, sort: number) => {
       if (!ensureServiceReady("更新账号顺序")) return;
       await updateAccountSortMutation.mutateAsync({ accountId, sort });
@@ -863,6 +896,14 @@ export function useAccounts() {
     isCleaningAccountsByStatus: deleteByStatusesMutation.isPending,
     isUpdatingPreferred:
       setPreferredMutation.isPending || clearPreferredMutation.isPending,
+    localActiveAccountId: localCodexAccountStatusQuery.data?.activeAccountId || null,
+    localAuthPath: localCodexAccountStatusQuery.data?.liveAuthPath || "",
+    isLoadingLocalCodexStatus: localCodexAccountStatusQuery.isLoading,
+    isSwitchingLocalCodexAccountId:
+      switchLocalCodexAccountMutation.isPending &&
+      typeof switchLocalCodexAccountMutation.variables === "string"
+        ? switchLocalCodexAccountMutation.variables
+        : "",
     isUpdatingSortAccountId:
       updateAccountSortMutation.isPending &&
       updateAccountSortMutation.variables &&

--- a/apps/src/lib/api/account-client.ts
+++ b/apps/src/lib/api/account-client.ts
@@ -60,6 +60,8 @@ import {
   CurrentAccessTokenAccountReadResult,
   LoginStatusResult,
   LoginStartResult,
+  LocalCodexAccountPoolSwitchResult,
+  LocalCodexAccountStatus,
   ManagedModelCatalog,
   ManagedModelInfo,
   ManagedModelRouting,
@@ -194,6 +196,42 @@ interface AggregateApiPayload {
 
 const MAX_IMPORT_RPC_BODY_BYTES = 4 * 1024 * 1024;
 const MAX_IMPORT_ERROR_ITEMS = 50;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asBoolean(value: unknown): boolean {
+  return typeof value === "boolean" ? value : false;
+}
+
+function readLocalCodexAccountStatus(value: unknown): LocalCodexAccountStatus {
+  const source = asRecord(value);
+  return {
+    activeAccountId: asString(source.activeAccountId) || null,
+    liveAuthPresent: asBoolean(source.liveAuthPresent),
+    liveAuthPath: asString(source.liveAuthPath),
+  };
+}
+
+function readLocalCodexAccountPoolSwitchResult(
+  value: unknown,
+): LocalCodexAccountPoolSwitchResult {
+  const source = asRecord(value);
+  return {
+    success: asBoolean(source.success),
+    activeAccountId: asString(source.activeAccountId) || null,
+    backupPath: asString(source.backupPath) || null,
+    warning: asString(source.warning) || null,
+    status: readLocalCodexAccountStatus(source.status),
+  };
+}
 
 /**
  * 函数 `createEmptyImportResult`
@@ -349,6 +387,18 @@ export const accountClient = {
   async list(params?: Record<string, unknown>): Promise<AccountListResult> {
     const result = await invoke<unknown>("service_account_list", withAddr(params));
     return normalizeAccountList(result);
+  },
+  async getLocalCodexAccountStatus(): Promise<LocalCodexAccountStatus> {
+    const result = await invoke<unknown>("codex_local_account_pool_status");
+    return readLocalCodexAccountStatus(result);
+  },
+  async switchLocalCodexAccount(
+    accountId: string,
+  ): Promise<LocalCodexAccountPoolSwitchResult> {
+    const result = await invoke<unknown>("codex_local_account_pool_switch", {
+      accountId,
+    });
+    return readLocalCodexAccountPoolSwitchResult(result);
   },
   delete: (accountId: string) =>
     invoke("service_account_delete", withAddr({ accountId })),

--- a/apps/src/types/account.ts
+++ b/apps/src/types/account.ts
@@ -53,6 +53,20 @@ export interface AccountListResult {
   pageSize: number;
 }
 
+export interface LocalCodexAccountStatus {
+  activeAccountId: string | null;
+  liveAuthPresent: boolean;
+  liveAuthPath: string;
+}
+
+export interface LocalCodexAccountPoolSwitchResult {
+  success: boolean;
+  activeAccountId: string | null;
+  backupPath: string | null;
+  warning: string | null;
+  status: LocalCodexAccountStatus;
+}
+
 export interface UsageAggregateSummary {
   primaryBucketCount: number;
   primaryKnownCount: number;


### PR DESCRIPTION
## 变更内容

- 在 OpenAI 账号池表格中新增“本地账号”列，可以直接把账号池中的账号切换为本机 Codex 当前使用账号。
- 自动识别本机 `~/.codex/auth.json` 当前正在使用的账号，并在账号池中显示“运行中”状态。
- 切换时从账号池账号生成 Codex auth 内容，写入本机 `auth.json`，并在覆盖前自动备份现有 auth 文件。
- 支持通过账号池中保存的 `access_token`、`id_token`、`refresh_token` 和账号 ID 判断当前本地账号。
- 扩大桌面窗口默认宽度，并设置最小宽度，给新增账号池列留出空间。

## 验证

- `pnpm install --frozen-lockfile`
- `pnpm run build:desktop`

## 说明

该改动将本地 Codex 账号切换能力整合到现有 OpenAI 账号池中，避免单独维护一套本地账号入口。账号池导入逻辑保持不变，切换动作直接复用账号池里已保存的登录令牌。