### PR TITLE
修复 Responses WebSocket 上游握手头

### DIFF
--- a/crates/service/src/http/responses_websocket.rs
+++ b/crates/service/src/http/responses_websocket.rs
@@ -27,6 +27,7 @@ use crate::http::proxy_response::{text_error_response, text_response};
 use crate::storage_helpers::{hash_platform_key, open_storage};
 
 const RESPONSES_WS_ERROR_CODE: &str = "responses_websocket_error";
+const RESPONSES_WEBSOCKETS_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
 
 #[derive(Clone)]
 struct WsRequestContext {
@@ -1138,6 +1139,11 @@ fn build_upstream_websocket_request(
         "originator",
         &crate::gateway::current_wire_originator(),
     )?;
+    insert_header(
+        headers,
+        "OpenAI-Beta",
+        RESPONSES_WEBSOCKETS_BETA_HEADER_VALUE,
+    )?;
     if let Some(residency_requirement) = crate::gateway::current_residency_requirement() {
         insert_header(
             headers,
@@ -1876,6 +1882,13 @@ mod tests {
                 .get("x-oai-attestation")
                 .and_then(|value| value.to_str().ok()),
             Some("attest-ws")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("openai-beta")
+                .and_then(|value| value.to_str().ok()),
+            Some(super::RESPONSES_WEBSOCKETS_BETA_HEADER_VALUE)
         );
     }
 

--- a/crates/service/src/http/tests/proxy_runtime_tests.rs
+++ b/crates/service/src/http/tests/proxy_runtime_tests.rs
@@ -839,7 +839,10 @@ async fn official_responses_websocket_proxies_frames_and_headers() {
             .map(String::as_str),
         Some("chatgpt_proxy_runtime_ws")
     );
-    assert_eq!(capture.headers.get("openai-beta").map(String::as_str), None);
+    assert_eq!(
+        capture.headers.get("openai-beta").map(String::as_str),
+        Some("responses_websockets=2026-02-06")
+    );
     assert_eq!(capture.headers.get("version").map(String::as_str), None);
     assert_eq!(
         capture


### PR DESCRIPTION
## 变更摘要

- 为官方 Codex Responses WebSocket 上游握手补充 `OpenAI-Beta: responses_websockets=2026-02-06`
- 更新 WebSocket 代理测试，断言上游握手会携带该 beta header
- 解决本地 Responses WebSocket 代理连 ChatGPT 上游时容易握手失败、随后退化到 HTTP/SSE 路径的问题

## 背景与调研

- 在启用 WebSocket upstream 后，实际部署中经常看到请求退回 HTTP 路径，日志类似：

```text
[2026-05-25T14:17:31Z WARN  codexmanager_service::gateway::upstream::attempt_flow::transport] event=gateway_websocket_upstream_fallback_to_http path=/v1/responses account_id=<redacted-account-id> target_url=https://chatgpt.com/backend-api/codex/responses err=WebSocket connect timed out
[2026-05-25T14:18:03Z WARN  codexmanager_service::gateway::upstream::attempt_flow::transport] event=gateway_websocket_upstream_fallback_to_http path=/v1/responses account_id=<redacted-account-id> target_url=https://chatgpt.com/backend-api/codex/responses err=WebSocket connect timed out
```

- 对照官方 Codex 的 Responses WebSocket 实现，握手请求需要携带：

```http
OpenAI-Beta: responses_websockets=2026-02-06
```

- 当前仓库里 HTTP/SSE 请求优先尝试 upstream WebSocket 的实验路径已经会补这个 header；但客户端直接连本地 `/v1/responses` WebSocket，再由本地代理连接 ChatGPT upstream WebSocket 的路径没有补。
- 在 GCE Docker 部署上做过额外排查：
  - 容器内 HTTPS 到 `chatgpt.com/backend-api/codex/responses` 可达；
  - 原始 WebSocket Upgrade 探测能从 ChatGPT 收到 `401 Unauthorized`，说明网络和 WebSocket upgrade 链路本身可达；
  - 因此该问题更像是上游握手请求形状不完整，而不是单纯公网连通性问题。

和 #264 的关系：

- #264 里主要现象是上游不稳定时请求容易等待很久，最后以 502 / timeout 形式失败，再切换账号。
- 讨论里提到使用 socket / WebSocket 交互可以降低此类问题发生概率。
- 本 PR 不处理账号失效、风控、真实上游 502，也不修改 retry/circuit breaker 逻辑。
- 本 PR 只修复一个明确的 WebSocket 握手兼容性缺口：本地 `/v1/responses` WebSocket 代理转发到 ChatGPT upstream WebSocket 时，缺少官方 Codex 使用的 beta header。
- 该 header 缺失会让请求更容易在上游握手阶段失败或迟迟无法完成，随后退化到 HTTP/SSE 路径，间接放大 #264 这类长等待/多账号重试问题。

代码路径差异：

- `gateway/upstream/attempt_flow/transport.rs` 的 HTTP/SSE -> upstream WebSocket 实验路径已经会注入 `OpenAI-Beta: responses_websockets=2026-02-06`。
- `http/responses_websocket.rs` 的客户端 WebSocket -> upstream WebSocket 代理路径此前没有注入该 header。
- 本 PR 将两条 WebSocket upstream 握手路径对齐。

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [x] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/http/responses_websocket.rs`
- `crates/service/src/http/tests/proxy_runtime_tests.rs`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
cargo test -p codexmanager-service upstream_websocket_request_forwards_oai_attestation_header
cargo test -p codexmanager-service official_responses_websocket_proxies_frames_and_headers
cargo test -p codexmanager-service websocket

GCE Docker smoke test:
- built linux/amd64 codexmanager-service:ws-beta-fix
- deployed to a GCE Docker VM with CODEXMANAGER_USE_WEBSOCKET_UPSTREAM=1
- sent real /v1/responses traffic
- confirmed service stayed healthy and no gateway_websocket_upstream_fallback_to_http warnings appeared after the test requests
- before the fix, the same deployment had repeated gateway_websocket_upstream_fallback_to_http warnings
```

未执行的验证与原因：

```text
pnpm frontend checks: not applicable; no frontend files changed.
cargo test --workspace: not run; change is narrowly scoped to service WebSocket handshake headers, and service websocket regression tests passed.
```

## 风险与影响面

- 影响官方 Codex Responses WebSocket 上游握手请求。
- HTTP/SSE fallback 路径不改变。
- 如果上游后续更换 Responses WebSocket beta header 版本，需要同步更新该常量。

## 备注

- Refs #264
- 提交前已确认未包含敏感 token、cookie、API key。
