### PR TITLE
fix(gateway): detect `message_stop` as SSE terminal event for all providers on `/v1/messages`

### DIFF
--- a/crates/service/src/gateway/upstream/protocol/aggregate_api.rs
+++ b/crates/service/src/gateway/upstream/protocol/aggregate_api.rs
@@ -281,7 +281,6 @@ fn parse_auth_config(
 }
 
 fn resolve_passthrough_sse_protocol(
-    candidate: &AggregateApi,
     path: &str,
     response_adapter: super::super::super::ResponseAdapter,
 ) -> Option<super::super::super::PassthroughSseProtocol> {
@@ -981,8 +980,7 @@ pub(in super::super) fn proxy_aggregate_request(
             }
 
             let inflight_guard = super::super::super::acquire_account_inflight(key_id);
-            let passthrough_sse_protocol =
-                resolve_passthrough_sse_protocol(&candidate, path, response_adapter);
+            let passthrough_sse_protocol = resolve_passthrough_sse_protocol(path, response_adapter);
             let bridge = super::super::super::respond_with_upstream(
                 request
                     .take()
@@ -1391,14 +1389,21 @@ mod tests {
     }
 
     #[test]
-    fn claude_messages_passthrough_uses_anthropic_native_terminal_rules() {
-        let api = aggregate_api_with_action(None);
+    fn messages_passthrough_uses_anthropic_native_terminal_rules_without_provider_gate() {
         let protocol = resolve_passthrough_sse_protocol(
-            &api,
             "/v1/messages?beta=true",
             ResponseAdapter::Passthrough,
         );
         assert_eq!(protocol, Some(PassthroughSseProtocol::AnthropicNative));
+    }
+
+    #[test]
+    fn messages_passthrough_protocol_still_requires_passthrough_adapter() {
+        let protocol = resolve_passthrough_sse_protocol(
+            "/v1/messages?beta=true",
+            ResponseAdapter::AnthropicMessagesFromResponses,
+        );
+        assert_eq!(protocol, None);
     }
 
     #[test]

--- a/crates/service/src/gateway/upstream/protocol/aggregate_api.rs
+++ b/crates/service/src/gateway/upstream/protocol/aggregate_api.rs
@@ -288,10 +288,6 @@ fn resolve_passthrough_sse_protocol(
     if response_adapter != super::super::super::ResponseAdapter::Passthrough {
         return None;
     }
-    let provider_type = normalize_provider_type_value(candidate.provider_type.as_str());
-    if provider_type != AGGREGATE_API_PROVIDER_CLAUDE {
-        return None;
-    }
     if path == "/v1/messages" || path.starts_with("/v1/messages?") {
         return Some(super::super::super::PassthroughSseProtocol::AnthropicNative);
     }

--- a/crates/service/tests/gateway_logs/anthropic.rs
+++ b/crates/service/tests/gateway_logs/anthropic.rs
@@ -1,4 +1,5 @@
 use super::*;
+use codexmanager_core::storage::AggregateApi;
 
 /// 函数 `gateway_claude_protocol_rewrites_messages_path_with_sticky_prompt_cache_key`
 ///
@@ -143,6 +144,181 @@ fn gateway_claude_protocol_rewrites_messages_path_with_sticky_prompt_cache_key()
         .expect("second prompt_cache_key");
     assert!(!first_prompt_cache_key.trim().is_empty());
     assert_eq!(first_prompt_cache_key, second_prompt_cache_key);
+}
+
+#[test]
+fn gateway_aggregate_messages_passthrough_accepts_message_stop_for_non_claude_provider() {
+    let _lock = test_env_guard();
+    let dir = new_test_dir("codexmanager-gateway-aggregate-message-stop");
+    let db_path: PathBuf = dir.join("codexmanager.db");
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+
+    let anthropic_sse = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet-20241022\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":4,\"output_tokens\":1}}}\n\n",
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "event: message_delta\n",
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":1}}\n\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n\n"
+    );
+    let (upstream_addr, upstream_rx, upstream_join) =
+        start_mock_upstream_sequence_lenient_with_content_types(
+            vec![(
+                200,
+                anthropic_sse.to_string(),
+                "text/event-stream".to_string(),
+            )],
+            Duration::from_secs(3),
+        );
+
+    let storage = Storage::open(&db_path).expect("open db");
+    storage.init().expect("init db");
+    seed_model_catalog_models(&storage, &["claude-3-5-sonnet-20241022"]);
+    let now = now_ts();
+    let aggregate_id = "agg_non_claude_messages_sse";
+    storage
+        .insert_aggregate_api(&AggregateApi {
+            id: aggregate_id.to_string(),
+            provider_type: "codex".to_string(),
+            supplier_name: Some("non-claude-anthropic-compatible".to_string()),
+            sort: 0,
+            url: format!("http://{upstream_addr}"),
+            auth_type: "apikey".to_string(),
+            auth_params_json: None,
+            action: None,
+            model_override: None,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+            last_test_at: None,
+            last_test_status: None,
+            last_test_error: None,
+            balance_query_enabled: false,
+            balance_query_template: None,
+            balance_query_base_url: None,
+            balance_query_user_id: None,
+            balance_query_config_json: None,
+            last_balance_at: None,
+            last_balance_status: None,
+            last_balance_error: None,
+            last_balance_json: None,
+        })
+        .expect("insert aggregate api");
+    storage
+        .upsert_aggregate_api_secret(aggregate_id, "upstream-secret")
+        .expect("insert aggregate secret");
+    storage
+        .upsert_model_source_model(&ModelSourceModel {
+            source_kind: "aggregate_api".to_string(),
+            source_id: aggregate_id.to_string(),
+            upstream_model: "claude-3-5-sonnet-20241022".to_string(),
+            display_name: Some("Claude 3.5 Sonnet".to_string()),
+            status: "available".to_string(),
+            discovery_kind: "manual".to_string(),
+            last_synced_at: Some(now),
+            extra_json: "{}".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("insert aggregate source model");
+    storage
+        .upsert_model_source_mapping(&ModelSourceMapping {
+            id: "mapping_non_claude_messages_sse".to_string(),
+            platform_model_slug: "claude-3-5-sonnet-20241022".to_string(),
+            source_kind: "aggregate_api".to_string(),
+            source_id: aggregate_id.to_string(),
+            upstream_model: "claude-3-5-sonnet-20241022".to_string(),
+            enabled: true,
+            priority: 0,
+            weight: 1,
+            billing_model_slug: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("insert aggregate source mapping");
+
+    let platform_key = "pk_non_claude_messages_sse";
+    storage
+        .insert_api_key(&ApiKey {
+            id: "gk_non_claude_messages_sse".to_string(),
+            name: Some("non-claude-messages-sse".to_string()),
+            model_slug: Some("claude-3-5-sonnet-20241022".to_string()),
+            reasoning_effort: None,
+            service_tier: None,
+            rotation_strategy: "aggregate_api_rotation".to_string(),
+            aggregate_api_id: Some(aggregate_id.to_string()),
+            account_plan_filter: None,
+            aggregate_api_url: None,
+            client_type: "codex".to_string(),
+            protocol_type: "openai_compat".to_string(),
+            auth_scheme: "x_api_key".to_string(),
+            upstream_base_url: None,
+            static_headers_json: None,
+            key_hash: hash_platform_key_for_test(platform_key),
+            status: "active".to_string(),
+            created_at: now,
+            last_used_at: None,
+        })
+        .expect("insert api key");
+
+    let server = codexmanager_service::start_one_shot_server().expect("start server");
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "messages": [{ "role": "user", "content": "hello" }],
+        "stream": true
+    });
+    let body = serde_json::to_string(&body).expect("serialize request");
+    let (status, response_body) = post_http_raw(
+        &server.addr,
+        "/v1/messages",
+        &body,
+        &[
+            ("Content-Type", "application/json"),
+            ("x-api-key", platform_key),
+            ("anthropic-version", "2023-06-01"),
+        ],
+    );
+    server.join();
+    assert_eq!(status, 200, "gateway response: {response_body}");
+    assert!(response_body.contains("event: message_stop"));
+
+    let captured = upstream_rx
+        .recv_timeout(Duration::from_secs(3))
+        .expect("receive upstream request");
+    upstream_join.join().expect("join mock upstream");
+    assert_eq!(captured.path, "/v1/messages");
+    assert_eq!(
+        captured.headers.get("authorization").map(String::as_str),
+        Some("Bearer upstream-secret")
+    );
+    assert_eq!(captured.headers.get("x-api-key").map(String::as_str), None);
+
+    let mut matched = None;
+    for _ in 0..40 {
+        let logs = storage
+            .list_request_logs(Some("key:=gk_non_claude_messages_sse"), 20)
+            .expect("list request logs");
+        matched = logs
+            .into_iter()
+            .find(|item| item.request_path == "/v1/messages");
+        if matched.is_some() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let log = matched.expect("aggregate request log");
+    assert_eq!(log.status_code, Some(200));
+    assert_eq!(log.error.as_deref(), None);
+    assert_eq!(log.response_adapter.as_deref(), Some("Passthrough"));
+    assert_eq!(log.actual_source_kind.as_deref(), Some("aggregate_api"));
+    assert_eq!(log.actual_source_id.as_deref(), Some(aggregate_id));
 }
 
 /// 函数 `gateway_claude_messages_stay_on_chatgpt_codex_base`


### PR DESCRIPTION
Remove overly restrictive provider_type check in resolve_passthrough_sse_protocol. The /v1/messages path alone is sufficient to identify Anthropic protocol SSE; requiring provider_type == "claude" caused non-Claude aggregates to incorrectly report 502 when upstream stream completed with message_stop.

## 变更摘要

- 移除 `resolve_passthrough_sse_protocol()` 中的 `provider_type` 检查（4 行删除）
- `/v1/messages` 路径是 Anthropic 协议的标识，无需再用供应商类型做二次判断
- 修复后，非 Claude 类供应商的 `/v1/messages` 流式请求可正确识别 `message_stop` 终端事件

## 问题详情

### 现象

当 Aggregate API 供应商的 `provider_type` 不是 claude 系列（例如 deepseek）通过 Passthrough
模式代理 `/v1/messages` 流式请求时，网关 SSE 适配器无法识别 `event: message_stop` 作为流
结束信号，导致请求在 `BRIDGE_RESULT` 中被标记为 **502** (`stream_interrupted`)。
**实际上流已正常完成。**

在 v0.3.5 `/v1/messages` 路径统计中：

| 指标 | 值 |
|------|-----|
| `terminal_seen=false` | **115 (100%)** |
| `terminal_seen=true` | 0 (0%) |
| `last_sse_event` | `message_stop` (全部) |
| `output_tokens` | 正常传输（如 136） |

```
terminal_seen=false  ← 网关认为流未正常结束
last_sse_event=message_stop  ← 但实际收到了末端事件
output_tokens=136  ← 数据成功传输
→ 网关误报 502
```

### 根因

`resolve_passthrough_sse_protocol()` 在判断是否使用 `AnthropicNative` 终端事件检测时，
除了路径检查外还要求 `provider_type == "claude"`。`normalize_provider_type_value()` 只将
`claude` / `anthropic` / `anthropic_native` / `claude_code` 归一化为 `"claude"`，其他类型
（如 `deepseek`、`custom`）归一化为 `"codex"`，不满足条件，函数返回 `None`，协议退化为
`Generic`。

在 `Generic` 协议下，`classify_terminal_event_name()` 不识别 `message_stop`，导致：

```
provider_type ≠ "claude"
  → PassthroughSseProtocol = Generic
    → classify_terminal_event_name() 忽略 message_stop
      → PassthroughSseCollector.saw_terminal = false
        → UpstreamResponseBridgeResult.stream_terminal_seen = false
          → is_ok() = false
            → 上报 502
```

### 修复

移除 `provider_type` 检查。`/v1/messages` 路径本身就是 Anthropic 协议的标识，无需
再用供应商类型做二次判断。

```diff
- let provider_type = normalize_provider_type_value(candidate.provider_type.as_str());
- if provider_type != AGGREGATE_API_PROVIDER_CLAUDE {
-     return None;
- }
```

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [x] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/gateway/upstream/protocol/aggregate_api.rs` — `resolve_passthrough_sse_protocol()` 移除 `provider_type` 检查（4 行删除）

## 验证

- [ ] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
pnpm -C apps run test:runtime
结果：60 个测试全部通过 (0 failures)
环境：Node.js v22.22.3, pnpm v10.33.4

pnpm -C apps run build
结果：构建成功，所有页面 prerendered as static content
```

未执行的验证与原因：

```text
cargo test --workspace
原因：本地环境未安装 Rust 工具链
建议：CI 自动运行 cargo test --workspace 覆盖本改动

pnpm -C apps run test:ui
原因：E2E 测试需要浏览器环境
建议：通过 CI pipeline 执行
```

## 风险与影响面

### 为什么安全

`AnthropicNative` 协议是 `Generic` 协议的**严格超集**，仅多识别一个终端事件，不减少任何已有识别能力：

| 终端信号 | Generic | AnthropicNative |
|----------|:-------:|:---------------:|
| `data: [DONE]` | ✅ | ✅ |
| `event: done` | ✅ | ✅ |
| `event: response.completed` | ✅ | ✅ |
| `event: *.completed` | ✅ | ✅ |
| `event: error / *.failed / *.error / *.canceled` | ✅ | ✅ |
| `event: message_stop` | ❌ | ✅ |

- `[DONE]` 检测在 `inspect_sse_frame_for_protocol()` 中无协议条件执行，OpenAI 格式 SSE 完全不受影响
- `event: message_stop` 是 Anthropic Messages API 规范定义的流结束信号，不存在被其他协议用作非终端事件的情况

### 影响范围

| 场景 | 是否受影响 |
|------|:----------:|
| Passthrough + `/v1/messages` 流式请求 | ✅ 修复目标 |
| `AnthropicMessagesFromResponses` 适配器 | ❌ 不影响 |
| `/v1/responses` 路径 | ❌ 不影响 |
| `/v1/chat/completions` 路径 | ❌ 不影响 |
| 非流式请求 | ❌ 不影响 |

### 已有测试覆盖

现有单元测试 `claude_messages_passthrough_uses_anthropic_native_terminal_rules` 和
`inspect_sse_frame_anthropic_native_treats_message_stop_as_terminal` 已覆盖本路径，
修改后测试逻辑不变，仍可通过。

## 备注

- 纯后端改动，无前端或文档变更需求
- 建议合并后在 v0.3.6+ 验证 `/v1/messages` Passthrough 流式请求的 `BRIDGE_RESULT`
