### PR TITLE
修复 ChatGPT 后端传输错误不切换候选账号

### DIFF
--- a/crates/service/src/gateway/upstream/attempt_flow/primary_attempt.rs
+++ b/crates/service/src/gateway/upstream/attempt_flow/primary_attempt.rs
@@ -70,7 +70,7 @@ where
                 super::super::super::CooldownReason::Network,
             );
             log_gateway_result(Some(url), 502, Some(err_msg.as_str()));
-            if has_more_candidates && !super::super::config::is_official_openai_target(url) {
+            if should_failover_transport_error(url, has_more_candidates) {
                 PrimaryAttemptResult::Failover
             } else {
                 PrimaryAttemptResult::Terminal {
@@ -79,5 +79,51 @@ where
                 }
             }
         }
+    }
+}
+
+fn should_failover_transport_error(url: &str, has_more_candidates: bool) -> bool {
+    if !has_more_candidates {
+        return false;
+    }
+
+    super::super::config::is_chatgpt_backend_base(url)
+        || !super::super::config::is_official_openai_target(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_failover_transport_error;
+
+    #[test]
+    fn chatgpt_transport_error_fails_over_when_more_candidates_exist() {
+        assert!(should_failover_transport_error(
+            "https://chatgpt.com/backend-api/codex/responses",
+            true
+        ));
+    }
+
+    #[test]
+    fn chatgpt_transport_error_stops_without_more_candidates() {
+        assert!(!should_failover_transport_error(
+            "https://chatgpt.com/backend-api/codex/responses",
+            false
+        ));
+    }
+
+    #[test]
+    fn openai_api_transport_error_keeps_terminal_behavior() {
+        assert!(!should_failover_transport_error(
+            "https://api.openai.com/v1/responses",
+            true
+        ));
+    }
+
+    #[test]
+    fn custom_upstream_transport_error_keeps_existing_failover_behavior() {
+        assert!(should_failover_transport_error(
+            "https://example.test/v1/responses",
+            true
+        ));
     }
 }


### PR DESCRIPTION
## 背景

在排查 v0.3.6 Docker 部署的流式响应卡顿时发现：ChatGPT backend 目标发生传输层错误时，即使还有其他候选账号，当前 primary attempt 会直接返回 502，而不是继续 failover。这样会把偶发网络/边缘节点问题放大成用户可见的长时间等待或失败。

## 改动

- 对 `chatgpt.com/backend-api` / `chat.openai.com/backend-api` 这类 ChatGPT backend 目标，传输错误且仍有候选账号时继续 failover。
- 保持 `api.openai.com/v1` 的原有 terminal 行为不变，避免扩大通用官方 API 行为变更范围。
- 增加单元测试覆盖 ChatGPT backend、无候选账号、OpenAI API、第三方上游四种分支。

## 验证

- `cargo test -p codexmanager-service transport_error`
- 在测试 Docker 镜像中对部署环境进行流式请求验证，传输错误不再直接导致该请求终止。
