### PR TITLE
修复 Windows 托盘恢复卡死

### DIFF
--- a/apps/src-tauri/src/app_shell/lifecycle.rs
+++ b/apps/src-tauri/src/app_shell/lifecycle.rs
@@ -18,7 +18,7 @@ use super::state::{
     TRAY_AVAILABLE,
 };
 #[cfg(target_os = "macos")]
-use super::window::show_main_window;
+use super::window::request_show_main_window;
 use super::window::{hide_tray_preview_window, MAIN_WINDOW_LABEL, TRAY_PREVIEW_WINDOW_LABEL};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,7 +49,7 @@ fn resolve_main_window_close_mode(
     if !close_to_tray_on_close || !tray_available {
         return MainWindowCloseMode::AllowWindowClose;
     }
-    if lightweight_tray_close {
+    if cfg!(target_os = "windows") || lightweight_tray_close {
         return MainWindowCloseMode::CloseForLightweightTray;
     }
     MainWindowCloseMode::HideToTray
@@ -225,7 +225,7 @@ pub(crate) fn handle_run_event(app: &tauri::AppHandle, event: &tauri::RunEvent) 
         }
         #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => {
-            show_main_window(app);
+            request_show_main_window(app);
         }
         _ => {}
     }
@@ -259,9 +259,15 @@ mod tests {
             resolve_main_window_close_mode(true, false, false),
             MainWindowCloseMode::AllowWindowClose
         );
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(
             resolve_main_window_close_mode(true, true, false),
             MainWindowCloseMode::HideToTray
+        );
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            resolve_main_window_close_mode(true, true, false),
+            MainWindowCloseMode::CloseForLightweightTray
         );
         assert_eq!(
             resolve_main_window_close_mode(true, true, true),

--- a/apps/src-tauri/src/app_shell/lifecycle.rs
+++ b/apps/src-tauri/src/app_shell/lifecycle.rs
@@ -225,7 +225,9 @@ pub(crate) fn handle_run_event(app: &tauri::AppHandle, event: &tauri::RunEvent) 
         }
         #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => {
-            request_show_main_window(app);
+            if let Err(err) = request_show_main_window(app) {
+                log::warn!("request show main window from reopen failed: {}", err);
+            }
         }
         _ => {}
     }

--- a/apps/src-tauri/src/app_shell/mod.rs
+++ b/apps/src-tauri/src/app_shell/mod.rs
@@ -13,5 +13,5 @@ pub(crate) use state::{
     prepare_for_forced_app_exit, set_unsaved_settings_draft_sections, CLOSE_TO_TRAY_ON_CLOSE,
     KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE, LIGHTWEIGHT_MODE_ON_CLOSE_TO_TRAY, TRAY_AVAILABLE,
 };
-pub(crate) use tray::{notify_existing_instance_focused, setup_tray};
-pub(crate) use window::show_main_window;
+pub(crate) use tray::setup_tray;
+pub(crate) use window::request_show_main_window;

--- a/apps/src-tauri/src/app_shell/tray.rs
+++ b/apps/src-tauri/src/app_shell/tray.rs
@@ -1,4 +1,3 @@
-use rfd::{MessageButtons, MessageDialog, MessageLevel};
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 
@@ -9,30 +8,10 @@ use super::state::{
     has_unsaved_settings_draft_sections, mark_skip_next_unsaved_settings_exit_confirm,
     APP_EXIT_REQUESTED, KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE, TRAY_AVAILABLE,
 };
-use super::window::{show_main_window, toggle_tray_preview_window};
+use super::window::{request_show_main_window, toggle_tray_preview_window};
 
 const TRAY_MENU_SHOW_MAIN: &str = "tray_show_main";
 const TRAY_MENU_QUIT_APP: &str = "tray_quit_app";
-
-/// 函数 `notify_existing_instance_focused`
-///
-/// 作者: gaohongshun
-///
-/// 时间: 2026-04-02
-///
-/// # 参数
-/// - crate: 参数 crate
-///
-/// # 返回
-/// 无
-pub(crate) fn notify_existing_instance_focused() {
-    let _ = MessageDialog::new()
-        .set_title("CodexManager")
-        .set_description("CodexManager 已在运行，已切换到现有窗口。")
-        .set_level(MessageLevel::Info)
-        .set_buttons(MessageButtons::Ok)
-        .show();
-}
 
 /// 函数 `setup_tray`
 ///
@@ -55,7 +34,7 @@ pub(crate) fn setup_tray(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id().as_ref() {
             TRAY_MENU_SHOW_MAIN => {
-                show_main_window(app);
+                request_show_main_window(app);
             }
             TRAY_MENU_QUIT_APP => {
                 if has_unsaved_settings_draft_sections() {

--- a/apps/src-tauri/src/app_shell/tray.rs
+++ b/apps/src-tauri/src/app_shell/tray.rs
@@ -34,7 +34,9 @@ pub(crate) fn setup_tray(app: &tauri::AppHandle) -> Result<(), tauri::Error> {
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id().as_ref() {
             TRAY_MENU_SHOW_MAIN => {
-                request_show_main_window(app);
+                if let Err(err) = request_show_main_window(app) {
+                    log::warn!("request show main window from tray failed: {}", err);
+                }
             }
             TRAY_MENU_QUIT_APP => {
                 if has_unsaved_settings_draft_sections() {

--- a/apps/src-tauri/src/app_shell/window.rs
+++ b/apps/src-tauri/src/app_shell/window.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tauri::webview::Color;
 use tauri::window::{Effect, EffectState, EffectsBuilder};
 use tauri::Manager;
@@ -23,17 +25,39 @@ const TRAY_PREVIEW_MARGIN: f64 = 8.0;
 /// # 返回
 /// 无
 pub(crate) fn show_main_window(app: &tauri::AppHandle) {
+    log::info!("show main window requested");
     hide_tray_preview_window(app);
-    KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(false, std::sync::atomic::Ordering::Relaxed);
     let Some(window) = ensure_main_window(app) else {
         return;
     };
+    if let Err(err) = window.unminimize() {
+        log::debug!("unminimize main window before show skipped: {}", err);
+    }
     if let Err(err) = window.show() {
         log::warn!("show main window failed: {}", err);
         return;
     }
-    let _ = window.unminimize();
-    let _ = window.set_focus();
+    KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(false, std::sync::atomic::Ordering::Relaxed);
+    if let Err(err) = window.unminimize() {
+        log::warn!("unminimize main window after show failed: {}", err);
+    }
+    if let Err(err) = window.set_focus() {
+        log::warn!("focus main window failed: {}", err);
+    }
+    log::info!("show main window completed");
+}
+
+pub(crate) fn request_show_main_window(app: &tauri::AppHandle) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(50));
+        let app_for_show = app.clone();
+        if let Err(err) = app.run_on_main_thread(move || {
+            show_main_window(&app_for_show);
+        }) {
+            log::warn!("schedule show main window on main thread failed: {}", err);
+        }
+    });
 }
 
 pub(crate) fn hide_tray_preview_window(app: &tauri::AppHandle) {

--- a/apps/src-tauri/src/app_shell/window.rs
+++ b/apps/src-tauri/src/app_shell/window.rs
@@ -1,17 +1,18 @@
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tauri::webview::Color;
 use tauri::window::{Effect, EffectState, EffectsBuilder};
 use tauri::Manager;
 use tauri::{PhysicalPosition, PhysicalRect, Rect, WebviewUrl, WebviewWindowBuilder};
 
-use super::state::KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE;
+use super::state::{APP_EXIT_REQUESTED, KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE};
 
 pub(crate) const MAIN_WINDOW_LABEL: &str = "main";
 pub(crate) const TRAY_PREVIEW_WINDOW_LABEL: &str = "tray-preview";
 const TRAY_PREVIEW_WIDTH: f64 = 360.0;
 const TRAY_PREVIEW_HEIGHT: f64 = 390.0;
 const TRAY_PREVIEW_MARGIN: f64 = 8.0;
+static SHOW_MAIN_WINDOW_PENDING: AtomicBool = AtomicBool::new(false);
 
 /// 函数 `show_main_window`
 ///
@@ -24,20 +25,24 @@ const TRAY_PREVIEW_MARGIN: f64 = 8.0;
 ///
 /// # 返回
 /// 无
-pub(crate) fn show_main_window(app: &tauri::AppHandle) {
+fn show_main_window(app: &tauri::AppHandle) -> bool {
+    if APP_EXIT_REQUESTED.load(Ordering::Relaxed) {
+        log::info!("show main window skipped because app exit is already requested");
+        return false;
+    }
     log::info!("show main window requested");
     hide_tray_preview_window(app);
+    KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(false, Ordering::Relaxed);
     let Some(window) = ensure_main_window(app) else {
-        return;
+        return false;
     };
     if let Err(err) = window.unminimize() {
         log::debug!("unminimize main window before show skipped: {}", err);
     }
     if let Err(err) = window.show() {
         log::warn!("show main window failed: {}", err);
-        return;
+        return false;
     }
-    KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(false, std::sync::atomic::Ordering::Relaxed);
     if let Err(err) = window.unminimize() {
         log::warn!("unminimize main window after show failed: {}", err);
     }
@@ -45,19 +50,43 @@ pub(crate) fn show_main_window(app: &tauri::AppHandle) {
         log::warn!("focus main window failed: {}", err);
     }
     log::info!("show main window completed");
+    true
 }
 
-pub(crate) fn request_show_main_window(app: &tauri::AppHandle) {
+pub(crate) fn request_show_main_window(app: &tauri::AppHandle) -> Result<(), String> {
+    if APP_EXIT_REQUESTED.load(Ordering::Relaxed) {
+        return Err("app is exiting; show main window request skipped".to_string());
+    }
+    if SHOW_MAIN_WINDOW_PENDING.swap(true, Ordering::AcqRel) {
+        log::debug!("show main window request coalesced because one is already pending");
+        return Ok(());
+    }
+
     let app = app.clone();
     std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_millis(50));
+        if APP_EXIT_REQUESTED.load(Ordering::Relaxed) {
+            SHOW_MAIN_WINDOW_PENDING.store(false, Ordering::Release);
+            return;
+        }
         let app_for_show = app.clone();
         if let Err(err) = app.run_on_main_thread(move || {
-            show_main_window(&app_for_show);
+            if APP_EXIT_REQUESTED.load(Ordering::Relaxed) {
+                log::info!("show main window skipped on main thread because app is exiting");
+                SHOW_MAIN_WINDOW_PENDING.store(false, Ordering::Release);
+                return;
+            }
+            let shown = show_main_window(&app_for_show);
+            if !shown {
+                log::warn!("show main window request completed without showing a window");
+            }
+            SHOW_MAIN_WINDOW_PENDING.store(false, Ordering::Release);
         }) {
             log::warn!("schedule show main window on main thread failed: {}", err);
+            KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE.store(false, Ordering::Relaxed);
+            SHOW_MAIN_WINDOW_PENDING.store(false, Ordering::Release);
         }
     });
+    Ok(())
 }
 
 pub(crate) fn hide_tray_preview_window(app: &tauri::AppHandle) {

--- a/apps/src-tauri/src/commands/system.rs
+++ b/apps/src-tauri/src/commands/system.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app_shell::{set_unsaved_settings_draft_sections, show_main_window},
+    app_shell::{request_show_main_window, set_unsaved_settings_draft_sections},
     commands::shared::{
         open_external_url_blocking, open_in_browser_blocking, open_in_file_manager_blocking,
     },
@@ -67,6 +67,6 @@ pub fn app_window_unsaved_draft_sections_set(sections: Vec<String>) -> Result<()
 
 #[tauri::command]
 pub fn app_show_main_window(app: tauri::AppHandle) -> Result<(), String> {
-    show_main_window(&app);
+    request_show_main_window(&app);
     Ok(())
 }

--- a/apps/src-tauri/src/commands/system.rs
+++ b/apps/src-tauri/src/commands/system.rs
@@ -67,6 +67,5 @@ pub fn app_window_unsaved_draft_sections_set(sections: Vec<String>) -> Result<()
 
 #[tauri::command]
 pub fn app_show_main_window(app: tauri::AppHandle) -> Result<(), String> {
-    request_show_main_window(&app);
-    Ok(())
+    request_show_main_window(&app)
 }

--- a/apps/src-tauri/src/lib.rs
+++ b/apps/src-tauri/src/lib.rs
@@ -8,9 +8,8 @@ mod rpc_client;
 mod service_runtime;
 
 use app_shell::{
-    handle_main_window_event, handle_run_event, load_env_from_exe_dir,
-    notify_existing_instance_focused, setup_tray, show_main_window, sync_startup_window_state,
-    CLOSE_TO_TRAY_ON_CLOSE, TRAY_AVAILABLE,
+    handle_main_window_event, handle_run_event, load_env_from_exe_dir, request_show_main_window,
+    setup_tray, sync_startup_window_state, CLOSE_TO_TRAY_ON_CLOSE, TRAY_AVAILABLE,
 };
 
 const USAGE_REFRESH_COMPLETED_EVENT: &str = "usage-refresh-completed";
@@ -43,8 +42,8 @@ pub fn run() {
                 args,
                 cwd
             );
-            show_main_window(app);
-            notify_existing_instance_focused();
+            request_show_main_window(app);
+            log::info!("secondary instance focus request handled without blocking dialog");
         }))
         .setup(|app| {
             load_env_from_exe_dir();

--- a/apps/src-tauri/src/lib.rs
+++ b/apps/src-tauri/src/lib.rs
@@ -42,8 +42,14 @@ pub fn run() {
                 args,
                 cwd
             );
-            request_show_main_window(app);
-            log::info!("secondary instance focus request handled without blocking dialog");
+            match request_show_main_window(app) {
+                Ok(()) => {
+                    log::info!("secondary instance focus request queued without blocking dialog");
+                }
+                Err(err) => {
+                    log::warn!("secondary instance focus request skipped: {}", err);
+                }
+            }
         }))
         .setup(|app| {
             load_env_from_exe_dir();


### PR DESCRIPTION
## 变更摘要

- 修复 Windows 桌面版关闭到托盘后，再从托盘菜单或二次启动恢复主窗口时 UI 卡死的问题。
- Windows 关闭到托盘时改为销毁主 WebView，恢复时重新创建主窗口，避免 WebView2 隐藏恢复异常。
- 将托盘菜单、single-instance 二次启动、前端 `app_show_main_window` 命令统一走异步恢复入口，避免在 single-instance 回调中同步创建/显示窗口导致回调卡住。
- 移除二次启动时的阻塞式提示弹窗，改为日志记录。

## 改动范围

- [ ] Frontend
- [x] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `apps/src-tauri/src/app_shell/window.rs`
- `apps/src-tauri/src/app_shell/lifecycle.rs`
- `apps/src-tauri/src/app_shell/tray.rs`
- `apps/src-tauri/src/lib.rs`
- `apps/src-tauri/src/commands/system.rs`
- `apps/src-tauri/src/app_shell/mod.rs`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
cargo test --manifest-path apps\src-tauri\Cargo.toml
结果：47 passed

pnpm -C apps run build:desktop
结果：通过

corepack pnpm dlx @tauri-apps/cli@2.10.1 build
结果：正式 NSIS/MSI 安装包生成成功

独立测试版自测：
- productName=CodexManagerTest
- identifier=com.codexmanager.desktop.test
- CODEXMANAGER_SERVICE_ADDR=localhost:48763
- 与当前已安装旧版同时运行，确认不抢占旧版 single-instance 和数据目录
- 二次启动测试版后，日志出现：
  secondary instance focus request handled without blocking dialog
  show main window requested
  show main window completed
- 未留下第二个测试进程常驻
```

未执行的验证与原因：

```text
pnpm -C apps run test：本次未改前端运行时测试覆盖的 TypeScript 逻辑，已执行更贴近桌面静态导出的 pnpm -C apps run build:desktop。

pnpm -C apps run test:ui：本次改动集中在 Tauri 桌面生命周期、托盘和窗口恢复路径；该问题需要 Windows 托盘/single-instance 原生行为复现，Playwright UI 测试无法完整覆盖托盘恢复链路。

cargo test --workspace：本次改动范围仅在 apps/src-tauri 桌面壳，已执行更窄且相关的 cargo test --manifest-path apps\src-tauri\Cargo.toml。
```

## 风险与影响面

- 影响平台：主要影响 Windows 桌面版托盘关闭与恢复路径。
- macOS `Reopen` 入口改为同一异步恢复入口，行为应保持为显示主窗口。
- 不涉及 service、gateway、协议适配、数据库迁移、环境变量或发布 workflow。
- Windows 关闭到托盘现在强制走轻量关闭模式，会在托盘保活时销毁主 WebView；恢复时会重新创建窗口，因此恢复时页面会重新加载。
- 已通过独立测试版验证 single-instance 恢复不再卡住，但最终仍建议用正式安装包在真实安装目录完成一次人工回归。

## 备注

- 提交前已确认未包含敏感 token、cookie、API key。