### PR TITLE
Restore compact model forwarding settings

### DIFF
--- a/apps/src/app/settings/page.tsx
+++ b/apps/src/app/settings/page.tsx
@@ -313,6 +313,10 @@ function AdminSettingsPage() {
   const [modelForwardRuleRowsDraft, setModelForwardRuleRowsDraft] = useState<
     ReturnType<typeof parseModelForwardRules> | null
   >(null);
+  const [
+    compactModelForwardRuleRowsDraft,
+    setCompactModelForwardRuleRowsDraft,
+  ] = useState<ReturnType<typeof parseModelForwardRules> | null>(null);
   const [lastUpdateCheck, setLastUpdateCheck] =
     useState<UpdateCheckResult | null>(null);
   const [updateDialogCheck, setUpdateDialogCheck] =
@@ -403,6 +407,10 @@ function AdminSettingsPage() {
   const modelForwardRuleRows = ensureModelForwardRuleRows(
     modelForwardRuleRowsDraft ??
       parseModelForwardRules(snapshot?.modelForwardRules || ""),
+  );
+  const compactModelForwardRuleRows = ensureModelForwardRuleRows(
+    compactModelForwardRuleRowsDraft ??
+      parseModelForwardRules(snapshot?.compactModelForwardRules || ""),
   );
   usePageTransitionReady(
     "/settings/",
@@ -758,6 +766,37 @@ function AdminSettingsPage() {
         modelForwardRules: nextSerialized,
       })
       .then(() => setModelForwardRuleRowsDraft(null))
+      .catch(() => undefined);
+  };
+  const updateCompactModelForwardRuleRows = (
+    updater: (rows: ReturnType<typeof parseModelForwardRules>) => ReturnType<
+      typeof parseModelForwardRules
+    >,
+  ) => {
+    const sourceRows =
+      compactModelForwardRuleRowsDraft ??
+      parseModelForwardRules(snapshot?.compactModelForwardRules || "");
+    setCompactModelForwardRuleRowsDraft(
+      updater(ensureModelForwardRuleRows(sourceRows)),
+    );
+  };
+  const commitCompactModelForwardRulesDraft = () => {
+    if (compactModelForwardRuleRowsDraft == null) return;
+    const nextSerialized = serializeModelForwardRules(
+      compactModelForwardRuleRowsDraft,
+    );
+    if (
+      nextSerialized.trim() ===
+      (snapshot?.compactModelForwardRules || "").trim()
+    ) {
+      setCompactModelForwardRuleRowsDraft(null);
+      return;
+    }
+    void updateSettings
+      .mutateAsync({
+        compactModelForwardRules: nextSerialized,
+      })
+      .then(() => setCompactModelForwardRuleRowsDraft(null))
       .catch(() => undefined);
   };
   const transportInputValues = {
@@ -1783,6 +1822,30 @@ function AdminSettingsPage() {
                 <p className="text-[10px] text-muted-foreground">
                   {t("左边匹配请求模型，右边填写转发目标；支持")} <code>*</code>{" "}
                   {t("通配。平台 Key 没有强绑模型时，会先按这里把请求模型改写，再进入账号路由。")}
+                </p>
+              </div>
+
+              <div className="grid gap-2">
+                <Label>{t("压缩模型转发规则")}</Label>
+                <ModelForwardRulesEditor
+                  rows={compactModelForwardRuleRows}
+                  sourcePlaceholder={t("例如：gpt-5.4")}
+                  targetPlaceholder={t("例如：gpt-5.4-openai-compact")}
+                  sourceLabel={t("源模型")}
+                  targetLabel={t("目标模型")}
+                  addButtonLabel={t("新增规则")}
+                  deleteButtonLabel={t("删除条目")}
+                  onRowsChange={(updater) =>
+                    updateCompactModelForwardRuleRows((rows) =>
+                      ensureModelForwardRuleRows(updater(rows)),
+                    )
+                  }
+                  onCommit={commitCompactModelForwardRulesDraft}
+                />
+                <p className="text-[10px] text-muted-foreground">
+                  {t(
+                    "仅对 /v1/responses/compact 生效；命中后会在 compact 请求里优先改写模型。",
+                  )}
                 </p>
               </div>
 


### PR DESCRIPTION
Restores the compact model forwarding rules editor in Settings so persisted compactModelForwardRules can be reviewed and updated.