### PR TITLE
在平台密钥列表显示最近调用时间

### DIFF
--- a/apps/src/app/apikeys/page.tsx
+++ b/apps/src/app/apikeys/page.tsx
@@ -69,6 +69,7 @@ import {
   estimateQuotaLimitUsd,
   formatQuotaLimitUsd,
 } from "@/lib/utils/api-key-quota";
+import { formatLocalMinuteFromSeconds } from "@/lib/utils/time";
 import { formatCompactNumber } from "@/lib/utils/usage";
 import type { ApiKeyOwner, AppUser } from "@/types";
 
@@ -648,6 +649,7 @@ export default function ApiKeysPage() {
                 <TableHead>{t("轮转策略")}</TableHead>
                 <TableHead>{t("绑定模型")}</TableHead>
                 <TableHead>{t("Token / 金额")}</TableHead>
+                <TableHead>{t("最近调用")}</TableHead>
                 <TableHead>{t("状态")}</TableHead>
                 <TableHead className="table-sticky-action-head w-[144px] text-center">
                   {t("操作")}
@@ -667,6 +669,7 @@ export default function ApiKeysPage() {
                       <TableCell><Skeleton className="h-4 w-20" /></TableCell>
                       <TableCell><Skeleton className="h-4 w-28" /></TableCell>
                       <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                      <TableCell><Skeleton className="h-4 w-32" /></TableCell>
                       <TableCell><Skeleton className="h-6 w-16 rounded-full" /></TableCell>
                       <TableCell className="table-sticky-action-cell text-center">
                         <Skeleton className="mx-auto h-8 w-8" />
@@ -675,7 +678,7 @@ export default function ApiKeysPage() {
                 ))
               ) : apiKeys.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={showMemberOwnership ? 9 : 8} className="h-48 text-center">
+                  <TableCell colSpan={showMemberOwnership ? 10 : 9} className="h-48 text-center">
                     <div className="flex flex-col items-center justify-center gap-2 text-muted-foreground">
                       <Plus className="h-8 w-8 opacity-20" />
                       <p>{t("创建密钥")}</p>
@@ -827,6 +830,9 @@ export default function ApiKeysPage() {
                                   )} / ${formatQuotaLimitUsd(quotaLimitUsd)}`}
                           </div>
                         </div>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                        {formatLocalMinuteFromSeconds(key.lastUsedAt, t("从未调用"))}
                       </TableCell>
                       <TableCell>
                         <div className="flex items-center gap-2">

--- a/apps/src/lib/i18n/messages/en.ts
+++ b/apps/src/lib/i18n/messages/en.ts
@@ -175,6 +175,8 @@ export const EN_MESSAGES: MessageCatalog = {
   聚合API轮转: "Aggregate API rotation",
   "混合轮转（账号优先）": "Hybrid rotation (accounts first)",
   "总使用 Token": "Total token usage",
+  最近调用: "Last called",
+  从未调用: "Never called",
   总费用: "Total cost",
   按全部平台密钥累计: "Aggregated across all API keys",
   协议: "Protocol",

--- a/apps/src/lib/i18n/messages/ko.ts
+++ b/apps/src/lib/i18n/messages/ko.ts
@@ -1024,6 +1024,8 @@ export const KO_MESSAGES: MessageCatalog = {
   "中 (medium)": "중간 (medium)",
   总费用: "총 비용",
   "总使用 Token": "총 Token 사용량",
+  最近调用: "최근 호출",
+  从未调用: "호출 없음",
   "走 Claude 语义，": "Claude 의미 사용,",
   "Fast 会映射为上游 priority；未设置时跟随请求。":
     "Fast는 업스트림 priority로 매핑되며, 미설정 시 요청을 따릅니다.",

--- a/apps/src/lib/i18n/messages/ru.ts
+++ b/apps/src/lib/i18n/messages/ru.ts
@@ -1030,6 +1030,8 @@ export const RU_MESSAGES: MessageCatalog = {
   "中 (medium)": "Средний (medium)",
   总费用: "Общая стоимость",
   "总使用 Token": "Общий расход Token",
+  最近调用: "Последний вызов",
+  从未调用: "Никогда не вызывался",
   "走 Claude 语义，": "Использует семантику Claude,",
   "Fast 会映射为上游 priority；未设置时跟随请求。":
     "Fast будет сопоставлен с upstream priority; если не задано — следует запросу.",

--- a/apps/src/lib/utils/time.ts
+++ b/apps/src/lib/utils/time.ts
@@ -75,3 +75,21 @@ export function formatLocalDateTimeFromSeconds(
     hour12: false,
   }).format(date);
 }
+
+export function formatLocalMinuteFromSeconds(
+  timestamp: number | null | undefined,
+  emptyLabel = "未知",
+): string {
+  if (!timestamp) return emptyLabel;
+  const date = new Date(timestamp * 1000);
+  if (Number.isNaN(date.getTime())) return emptyLabel;
+
+  return new Intl.DateTimeFormat(getPreferredLocale(), {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}


### PR DESCRIPTION
## 改动文件

- `apps/src/app/apikeys/page.tsx`
- `apps/src/lib/utils/time.ts`
- `apps/src/lib/i18n/messages/en.ts`
- `apps/src/lib/i18n/messages/ko.ts`
- `apps/src/lib/i18n/messages/ru.ts`

## 解决问题

平台密钥列表目前只能看到每把 key 的累计 Token 和状态，无法直接判断最近一次是否被调用。本次在平台密钥表格中增加“最近调用”列，直接展示已有 `lastUsedAt` 字段对应的本地日期时间；未调用过时显示“从未调用”。

## 影响范围

- 仅影响前端平台密钥页面展示。
- 复用已有 `ApiKey.lastUsedAt` 数据字段，不修改 API、数据库结构或后端逻辑。
- 补充英文、韩文、俄文文案。

## 验证

- `pnpm -C apps install --registry=https://registry.npmmirror.com`
- `pnpm -C apps run build`
- `pnpm -C apps run test:runtime`

说明：首次构建前本地缺少 `apps/node_modules`，直接 `pnpm -C apps run build` 会因 `next` 未安装失败；安装依赖后上述构建和 runtime 测试均通过。

## 风险

风险较低。新增列使用已有字段并在空值或无效时间时回退到空态文案；未调整轮转、计费、状态开关等业务逻辑。