### PR TITLE
fix: 修复模型路由中聚合API绑定被账号映射覆盖的问题

### DIFF
--- a/crates/service/src/apikey/apikey_models.rs
+++ b/crates/service/src/apikey/apikey_models.rs
@@ -882,13 +882,28 @@ fn auto_associate_source_models(
     source_id: &str,
     auto_create_platform_models: bool,
 ) -> Result<(), String> {
-    let existing_source_platform_mappings = storage
+    let all_mappings: Vec<codexmanager_core::storage::ModelSourceMapping> = storage
         .list_model_source_mappings(None)
-        .map_err(|err| format!("list model mappings failed: {err}"))?
-        .into_iter()
+        .map_err(|err| format!("list model mappings failed: {err}"))?;
+
+    let existing_source_platform_mappings = all_mappings
+        .iter()
         .filter(|mapping| mapping.source_kind == source_kind && mapping.source_id == source_id)
-        .map(|mapping| mapping.platform_model_slug)
+        .map(|mapping| mapping.platform_model_slug.clone())
         .collect::<HashSet<_>>();
+
+    let aggregate_api_model_slugs: HashSet<String> =
+        if source_kind == ROUTING_SOURCE_KIND_OPENAI_ACCOUNT {
+            all_mappings
+                .iter()
+                .filter(|mapping| {
+                    mapping.source_kind == ROUTING_SOURCE_KIND_AGGREGATE_API && mapping.enabled
+                })
+                .map(|mapping| mapping.platform_model_slug.clone())
+                .collect()
+        } else {
+            HashSet::new()
+        };
 
     let prefs: std::collections::HashMap<String, String> = storage
         .list_model_source_mapping_preferences(source_kind, source_id)
@@ -961,6 +976,11 @@ fn auto_associate_source_models(
     let now = now_ts();
     for source_model in &source_models {
         if !platform_slugs.contains(source_model.upstream_model.as_str()) {
+            continue;
+        }
+        if source_kind == ROUTING_SOURCE_KIND_OPENAI_ACCOUNT
+            && aggregate_api_model_slugs.contains(source_model.upstream_model.as_str())
+        {
             continue;
         }
         if existing_source_platform_mappings.contains(source_model.upstream_model.as_str()) {

--- a/crates/service/src/gateway/upstream/proxy.rs
+++ b/crates/service/src/gateway/upstream/proxy.rs
@@ -201,6 +201,14 @@ fn direct_upstream_model_matches_route(
         if !matches_source_kind(source_kind) {
             continue;
         }
+        let has_conflicting_mapping = storage
+            .list_enabled_model_source_mappings_for_platform(model)
+            .map_err(|err| err.to_string())?
+            .into_iter()
+            .any(|m| m.source_kind != source_kind);
+        if has_conflicting_mapping {
+            continue;
+        }
         let ids = storage
             .list_available_source_model_ids_by_upstream_model(source_kind, model)
             .map_err(|err| err.to_string())?;

--- a/crates/service/src/gateway/upstream/support/candidates.rs
+++ b/crates/service/src/gateway/upstream/support/candidates.rs
@@ -8,14 +8,18 @@ pub(in super::super) enum CandidateSkipReason {
 }
 
 fn account_source_ids_for_model(storage: &Storage, model: &str) -> Result<HashSet<String>, String> {
-    let mut account_source_ids = storage
+    let all_mappings = storage
         .list_enabled_model_source_mappings_for_platform(model)
-        .map_err(|err| format!("list model source mappings failed: {err}"))?
+        .map_err(|err| format!("list model source mappings failed: {err}"))?;
+    let has_aggregate_mapping = all_mappings
+        .iter()
+        .any(|mapping| mapping.source_kind == "aggregate_api");
+    let mut account_source_ids: HashSet<String> = all_mappings
         .into_iter()
         .filter(|mapping| mapping.source_kind == "openai_account")
         .map(|mapping| mapping.source_id)
-        .collect::<HashSet<_>>();
-    if account_source_ids.is_empty() {
+        .collect();
+    if account_source_ids.is_empty() && !has_aggregate_mapping {
         account_source_ids.extend(
             storage
                 .list_available_source_model_ids_by_upstream_model("openai_account", model)


### PR DESCRIPTION
## 问题描述

从聚合 API 导入的模型，在模型路由中只绑定了聚合 API 时，使用**混合轮转**或**账号轮转**模式请求该模型，仍然会命中 OpenAI 账号后端，而非用户配置的聚合 API 链接。

只有将平台密钥整体设置为「聚合 API 轮转」才能正确命中聚合 API。

### 版本对比

| 版本 | 混合轮转 + 仅绑聚合API | 说明 |
|------|----------------------|------|
| v0.3.8 | 正确命中聚合 API ✅ | 无回退逻辑，账号候选为空时正常 fallback |
| v0.3.9 | 错误命中账号 ❌ | commit 8139ad20 新增的回退逻辑导致 |

## 根因分析

commit `8139ad20` 在 v0.3.9 中为 `account_source_ids_for_model` 和 `direct_upstream_model_matches_route` 新增了 `list_available_source_model_ids_by_upstream_model` 回退逻辑：

1. **`account_source_ids_for_model`**：显式映射不存在时，直接查 `model_source_models` 表通过源模型名匹配账号。而 `bootstrap_account_pool_model_routes` 会把所有平台模型名以 `openai_account` 类型插入每个账号的源模型表，导致所有账号都被匹配到。

2. **`auto_associate_source_models`**：在账号 bootstrap 中无条件为所有平台模型创建 `openai_account` 映射，覆盖用户只绑定聚合 API 的意图。

### 问题链路

```
请求模型 M（用户只绑定了聚合 API，混合轮转）
  → bootstrap_account_pool_model_routes: 为所有账号创建 M 的 openai_account 映射
  → account_source_ids_for_model: 找到账号映射 → 候选非空
  → prepare_candidates: 账号候选存在 → 请求走账号 ❌
  → 混合轮转的聚合 API fallback 永远无法触发
```

## 修复内容

三处改动，相互配合：

1. **`apikey_models.rs`** — `auto_associate_source_models`：当 `source_kind` 为 `openai_account` 时，预先构建「已有聚合 API 映射的平台模型名」集合，在循环中为账号自动创建映射前检查并跳过。

2. **`candidates.rs`** — `account_source_ids_for_model`：在 fallback 到 `list_available_source_model_ids_by_upstream_model` 之前，增加 `has_aggregate_mapping` 判断，有聚合映射时跳过账号回退。

3. **`proxy.rs`** — `direct_upstream_model_matches_route`：在循环中检查当前 source_kind 是否存在其他类型的显式映射，有冲突则跳过。

### 修复后预期

| 模式 | 模型绑定 | 预期行为 |
|------|---------|---------|
| 混合轮转 | 仅聚合API | fallback 到聚合API ✅ |
| 混合轮转 | 仅账号 | 命中账号 ✅ |
| 混合轮转 | 账号+聚合 | 先账号后聚合 ✅ |
| 账号轮转 | 仅聚合API | 503 提示不可用 ✅ |