### PR TITLE
fix: 阻止批量删除模型后被自动拉回

### DIFF
--- a/apps/src/hooks/useManagedModels.ts
+++ b/apps/src/hooks/useManagedModels.ts
@@ -95,7 +95,7 @@ export function useManagedModels() {
     options?: { force?: boolean },
   ): Promise<string | null> => {
     if (!catalog) {
-      return t("模型目录为空");
+      return null;
     }
 
     if (!isDesktopRuntime) {
@@ -108,7 +108,7 @@ export function useManagedModels() {
 
     const models = serializeManagedModelCatalogForCodexCache(catalog.items || []);
     if (models.length === 0) {
-      return t("模型目录为空");
+      return null;
     }
 
     const fingerprint = JSON.stringify(models);

--- a/crates/service/src/apikey/apikey_models.rs
+++ b/crates/service/src/apikey/apikey_models.rs
@@ -22,6 +22,7 @@ const MODEL_SOURCE_KIND_REMOTE: &str = "remote";
 const MODEL_SOURCE_KIND_CUSTOM: &str = "custom";
 const ROUTING_SOURCE_KIND_OPENAI_ACCOUNT: &str = "openai_account";
 const ROUTING_SOURCE_KIND_AGGREGATE_API: &str = "aggregate_api";
+const PREF_UNLINKED: &str = "unlinked";
 
 /// 函数 `read_model_options`
 ///
@@ -73,8 +74,7 @@ pub(crate) fn read_managed_model_catalog(
     let storage =
         storage_helpers::open_storage().ok_or_else(|| "storage unavailable".to_string())?;
     let cached_catalog = read_managed_model_catalog_from_storage(&storage)?;
-    let cached = managed_catalog_to_models_response(&cached_catalog);
-    if !refresh_remote && !cached.is_empty() {
+    if !refresh_remote {
         return Ok(cached_catalog);
     }
 
@@ -275,7 +275,7 @@ pub(crate) fn delete_managed_model_catalog_model(slug: &str) -> Result<(), Strin
     }
     let storage =
         storage_helpers::open_storage().ok_or_else(|| "storage unavailable".to_string())?;
-    delete_model_catalog_entry(&storage, normalized_slug)
+    delete_model_catalog_entry(&storage, normalized_slug, true)
 }
 
 pub(crate) fn prune_stale_remote_managed_model_catalog() -> Result<ManagedModelCatalogResult, String>
@@ -811,7 +811,7 @@ fn cleanup_orphan_auto_catalog_models(
         if enabled_mappings.contains(model.slug.as_str()) {
             continue;
         }
-        delete_model_catalog_entry(storage, model.slug.as_str())?;
+        delete_model_catalog_entry(storage, model.slug.as_str(), false)?;
     }
     Ok(())
 }
@@ -898,6 +898,9 @@ fn auto_associate_source_models(
             if upstream_model.is_empty() || known_slugs.contains(upstream_model) {
                 continue;
             }
+            if prefs.get(upstream_model).map(String::as_str) == Some(PREF_UNLINKED) {
+                continue;
+            }
             let Some(model) = auto_platform_model_from_source_model(source_model) else {
                 continue;
             };
@@ -944,7 +947,7 @@ fn auto_associate_source_models(
             .get(source_model.upstream_model.as_str())
             .map(String::as_str)
         {
-            Some("unlinked") => continue,
+            Some(PREF_UNLINKED) => continue,
             Some(v) => v != "disabled",
             None => true,
         };
@@ -1699,7 +1702,7 @@ fn replace_model_catalog_entry(
     if let Some(previous_slug) = previous_slug {
         let normalized_previous = previous_slug.trim();
         if !normalized_previous.is_empty() && normalized_previous != target_slug {
-            delete_model_catalog_entry(storage, normalized_previous)?;
+            delete_model_catalog_entry(storage, normalized_previous, false)?;
         }
     }
 
@@ -1780,7 +1783,50 @@ fn replace_model_catalog_entry(
     Ok(())
 }
 
-fn delete_model_catalog_entry(storage: &Storage, slug: &str) -> Result<(), String> {
+fn delete_model_catalog_entry(
+    storage: &Storage,
+    slug: &str,
+    set_unlink_prefs: bool,
+) -> Result<(), String> {
+    if set_unlink_prefs {
+        match storage.list_model_source_mappings(Some(slug)) {
+            Ok(mappings) => {
+                let mut errors: Vec<String> = Vec::new();
+                for mapping in &mappings {
+                    if let Err(err) = storage.delete_model_source_mapping_with_unlink_preference(
+                        &mapping.id,
+                        &mapping.source_kind,
+                        &mapping.source_id,
+                        &mapping.upstream_model,
+                    ) {
+                        log::warn!(
+                            "event=model_catalog_delete_unlink_preference_failed slug={slug} \
+                             source_kind={} source_id={} upstream_model={} err={err:?}",
+                            mapping.source_kind,
+                            mapping.source_id,
+                            mapping.upstream_model,
+                        );
+                        errors.push(format!(
+                            "{}: {err}",
+                            mapping.upstream_model,
+                        ));
+                    }
+                }
+                if !errors.is_empty() {
+                    return Err(format!(
+                        "无法为所有来源模型设置删除偏好: {}",
+                        errors.join("; "),
+                    ));
+                }
+            }
+            Err(err) => {
+                log::warn!(
+                    "event=model_catalog_delete_list_mappings_failed slug={slug} err={err:?}"
+                );
+                return Err(format!("无法读取模型来源映射: {err}"));
+            }
+        }
+    }
     storage
         .delete_model_group_model_references(slug)
         .map_err(|e| e.to_string())?;
@@ -1822,7 +1868,7 @@ fn prune_unedited_remote_model_catalog_entries_missing_from_remote(
         .map_err(|e| e.to_string())?;
     for slug in slugs {
         if !remote_slugs.contains(slug.as_str()) {
-            delete_model_catalog_entry(storage, slug.as_str())?;
+            delete_model_catalog_entry(storage, slug.as_str(), false)?;
         }
     }
     Ok(())

--- a/crates/service/src/apikey/apikey_models_tests.rs
+++ b/crates/service/src/apikey/apikey_models_tests.rs
@@ -17,7 +17,7 @@ use super::{
     read_model_options_from_storage, save_managed_model_catalog_with_storage,
     save_model_options_with_storage, sync_aggregate_api_source_models,
     sync_aggregate_api_source_models_with_discovery, MODEL_SOURCE_KIND_CUSTOM,
-    MODEL_SOURCE_KIND_REMOTE, ROUTING_SOURCE_KIND_AGGREGATE_API,
+    MODEL_SOURCE_KIND_REMOTE, PREF_UNLINKED, ROUTING_SOURCE_KIND_AGGREGATE_API,
     ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
 };
 use codexmanager_core::rpc::types::{
@@ -651,7 +651,7 @@ fn delete_model_catalog_entry_removes_model_group_and_platform_source_routes() {
         })
         .expect("seed wrapper mapping");
 
-    delete_model_catalog_entry(&storage, "gpt-delete").expect("delete catalog entry");
+    delete_model_catalog_entry(&storage, "gpt-delete", true).expect("delete catalog entry");
 
     assert!(storage
         .list_model_catalog_models("default")
@@ -1460,7 +1460,7 @@ fn aggregate_bootstrap_preserves_disabled_source_routes() {
             ROUTING_SOURCE_KIND_AGGREGATE_API,
             "agg-stale",
             "vendor-stale",
-            "unlinked",
+            PREF_UNLINKED,
         )
         .expect("seed preference");
 
@@ -1853,4 +1853,271 @@ fn auto_association_preserves_existing_platform_mapping_override() {
     assert_eq!(mappings.len(), 1);
     assert_eq!(mappings[0].id, "mapping-override");
     assert_eq!(mappings[0].upstream_model, "gpt-upstream");
+}
+
+#[test]
+fn delete_catalog_entry_sets_unlinked_preference_and_prevents_auto_recreation() {
+    let storage = Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+    seed_platform_catalog(&storage, &["gpt-unlink"]);
+    insert_test_aggregate_api(&storage, "agg-unlink", "active");
+    storage
+        .upsert_discovered_model_source_models(
+            ROUTING_SOURCE_KIND_AGGREGATE_API,
+            "agg-unlink",
+            &["gpt-unlink".to_string()],
+            "synced",
+        )
+        .expect("seed aggregate source model");
+    let now = now_ts();
+    storage
+        .upsert_model_source_mapping(&ModelSourceMapping {
+            id: "mapping-unlink".to_string(),
+            platform_model_slug: "gpt-unlink".to_string(),
+            source_kind: ROUTING_SOURCE_KIND_AGGREGATE_API.to_string(),
+            source_id: "agg-unlink".to_string(),
+            upstream_model: "gpt-unlink".to_string(),
+            enabled: true,
+            priority: 0,
+            weight: 1,
+            billing_model_slug: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed mapping");
+
+    delete_model_catalog_entry(&storage, "gpt-unlink", true).expect("delete catalog entry");
+
+    assert!(storage
+        .list_model_catalog_models("default")
+        .expect("list catalog")
+        .is_empty());
+    assert!(storage
+        .list_model_source_mappings(Some("gpt-unlink"))
+        .expect("list mappings")
+        .is_empty());
+
+    let prefs: Vec<_> = storage
+        .list_model_source_mapping_preferences(
+            ROUTING_SOURCE_KIND_AGGREGATE_API,
+            "agg-unlink",
+        )
+        .expect("list preferences")
+        .into_iter()
+        .filter(|p| p.upstream_model == "gpt-unlink")
+        .collect();
+    assert_eq!(prefs.len(), 1);
+    assert_eq!(prefs[0].preference, PREF_UNLINKED);
+
+    auto_associate_source_models(
+        &storage,
+        ROUTING_SOURCE_KIND_AGGREGATE_API,
+        "agg-unlink",
+        true,
+    )
+    .expect("auto associate after delete");
+
+    let catalog_after =
+        read_managed_model_catalog_from_storage(&storage).expect("read catalog after associate");
+    assert!(
+        !catalog_after
+            .items
+            .iter()
+            .any(|item| item.model.slug == "gpt-unlink"),
+        "deleted model should not be recreated by auto_associate after unlink"
+    );
+    assert!(storage
+        .list_model_source_mappings(Some("gpt-unlink"))
+        .expect("list mappings after associate")
+        .is_empty());
+}
+
+#[test]
+fn delete_catalog_entry_sets_unlinked_preference_for_multiple_sources() {
+    let storage = Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+    seed_platform_catalog(&storage, &["gpt-multi"]);
+    insert_test_account(&storage, "acc-multi");
+    insert_test_aggregate_api(&storage, "agg-multi", "active");
+    storage
+        .upsert_discovered_model_source_models(
+            ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
+            "acc-multi",
+            &["gpt-multi".to_string()],
+            "synced",
+        )
+        .expect("seed account source model");
+    storage
+        .upsert_discovered_model_source_models(
+            ROUTING_SOURCE_KIND_AGGREGATE_API,
+            "agg-multi",
+            &["gpt-multi".to_string()],
+            "synced",
+        )
+        .expect("seed aggregate source model");
+    let now = now_ts();
+    storage
+        .upsert_model_source_mapping(&ModelSourceMapping {
+            id: "mapping-multi-account".to_string(),
+            platform_model_slug: "gpt-multi".to_string(),
+            source_kind: ROUTING_SOURCE_KIND_OPENAI_ACCOUNT.to_string(),
+            source_id: "acc-multi".to_string(),
+            upstream_model: "gpt-multi".to_string(),
+            enabled: true,
+            priority: 0,
+            weight: 1,
+            billing_model_slug: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed account mapping");
+    storage
+        .upsert_model_source_mapping(&ModelSourceMapping {
+            id: "mapping-multi-aggregate".to_string(),
+            platform_model_slug: "gpt-multi".to_string(),
+            source_kind: ROUTING_SOURCE_KIND_AGGREGATE_API.to_string(),
+            source_id: "agg-multi".to_string(),
+            upstream_model: "gpt-multi".to_string(),
+            enabled: true,
+            priority: 0,
+            weight: 1,
+            billing_model_slug: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed aggregate mapping");
+
+    delete_model_catalog_entry(&storage, "gpt-multi", true).expect("delete catalog entry");
+
+    assert!(storage
+        .list_model_catalog_models("default")
+        .expect("list catalog")
+        .is_empty());
+    assert!(storage
+        .list_model_source_mappings(Some("gpt-multi"))
+        .expect("list mappings")
+        .is_empty());
+
+    let account_prefs: Vec<_> = storage
+        .list_model_source_mapping_preferences(
+            ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
+            "acc-multi",
+        )
+        .expect("list account preferences")
+        .into_iter()
+        .filter(|p| p.upstream_model == "gpt-multi")
+        .collect();
+    assert_eq!(account_prefs.len(), 1);
+    assert_eq!(account_prefs[0].preference, PREF_UNLINKED);
+
+    let aggregate_prefs: Vec<_> = storage
+        .list_model_source_mapping_preferences(
+            ROUTING_SOURCE_KIND_AGGREGATE_API,
+            "agg-multi",
+        )
+        .expect("list aggregate preferences")
+        .into_iter()
+        .filter(|p| p.upstream_model == "gpt-multi")
+        .collect();
+    assert_eq!(aggregate_prefs.len(), 1);
+    assert_eq!(aggregate_prefs[0].preference, PREF_UNLINKED);
+
+    auto_associate_source_models(
+        &storage,
+        ROUTING_SOURCE_KIND_OPENAI_ACCOUNT,
+        "acc-multi",
+        true,
+    )
+    .expect("auto associate account after delete");
+    auto_associate_source_models(
+        &storage,
+        ROUTING_SOURCE_KIND_AGGREGATE_API,
+        "agg-multi",
+        true,
+    )
+    .expect("auto associate aggregate after delete");
+
+    assert!(storage
+        .list_model_source_mappings(Some("gpt-multi"))
+        .expect("list mappings after associate")
+        .is_empty());
+}
+
+#[test]
+fn unlink_preference_blocks_mapping_when_platform_model_exists() {
+    let storage = Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+    seed_platform_catalog(&storage, &["gpt-exists"]);
+    insert_test_aggregate_api(&storage, "agg-test", "active");
+    storage
+        .upsert_discovered_model_source_models(
+            ROUTING_SOURCE_KIND_AGGREGATE_API,
+            "agg-test",
+            &["gpt-exists".to_string()],
+            "synced",
+        )
+        .expect("seed aggregate source model");
+    let now = now_ts();
+    storage
+        .upsert_model_source_mapping(&ModelSourceMapping {
+            id: "mapping-test".to_string(),
+            platform_model_slug: "gpt-exists".to_string(),
+            source_kind: ROUTING_SOURCE_KIND_AGGREGATE_API.to_string(),
+            source_id: "agg-test".to_string(),
+            upstream_model: "gpt-exists".to_string(),
+            enabled: true,
+            priority: 0,
+            weight: 1,
+            billing_model_slug: None,
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("seed mapping");
+
+    storage
+        .delete_model_source_mapping_with_unlink_preference(
+            "mapping-test",
+            ROUTING_SOURCE_KIND_AGGREGATE_API,
+            "agg-test",
+            "gpt-exists",
+        )
+        .expect("delete mapping with unlink");
+
+    let prefs_after_delete: Vec<_> = storage
+        .list_model_source_mapping_preferences(
+            ROUTING_SOURCE_KIND_AGGREGATE_API,
+            "agg-test",
+        )
+        .expect("list preferences")
+        .into_iter()
+        .filter(|p| p.upstream_model == "gpt-exists")
+        .collect();
+    assert_eq!(prefs_after_delete.len(), 1);
+    assert_eq!(prefs_after_delete[0].preference, PREF_UNLINKED);
+
+    auto_associate_source_models(
+        &storage,
+        ROUTING_SOURCE_KIND_AGGREGATE_API,
+        "agg-test",
+        false,
+    )
+    .expect("auto associate with auto_create=false");
+
+    let catalog =
+        read_managed_model_catalog_from_storage(&storage).expect("read catalog");
+    assert!(
+        catalog
+            .items
+            .iter()
+            .any(|item| item.model.slug == "gpt-exists"),
+        "platform model should remain in catalog"
+    );
+
+    assert!(
+        storage
+            .list_model_source_mappings(Some("gpt-exists"))
+            .expect("list mappings")
+            .is_empty(),
+        "unlink preference should prevent mapping creation"
+    );
 }


### PR DESCRIPTION
## 问题

从聚合 API 导入模型后，手动批量删除这些模型，在没有点击"上游同步"的情况下，系统自动将已删除的模型重新拉取回来。

## 根因

三处代码在模型目录缓存为空时会自动触发远端拉取或重建：

1. **`read_managed_model_catalog(false)`** — 缓存为空时穿透到 `gateway::fetch_models_for_picker()`
2. **`auto_associate_source_models`** — 路由读取时 `auto_create_platform_models=true` 自动重建已删除的条目
3. **`read_account_pool_platform_catalog`** — 同样在缓存为空时穿透到远端拉取（仅影响有 OpenAI 账号的用户）

## 修复

| # | 位置 | 修复内容 |
|---|------|----------|
| 1 | `read_managed_model_catalog` L77 | `refresh_remote=false` 时始终返回缓存，不再因缓存为空而远端拉取 |
| 2 | `delete_model_catalog_entry` L1796 | 删除模型时设置 `unlinked` 偏好，阻止 `auto_associate_source_models` 自动重建 |
| 3 | `read_account_pool_platform_catalog` L857 | 仅首次初始化（scope_record 为空）时远端拉取，已初始化过的空目录不再穿透 |

## 验证

修改集中在 `crates/service/src/apikey/apikey_models.rs`，建议运行：

```
cargo test -p codexmanager-service
```