### PR TITLE
fix(admin): 管理员用量分析面板输入数值排除缓存命中

### DIFF
--- a/apps/src/app/page.tsx
+++ b/apps/src/app/page.tsx
@@ -974,7 +974,7 @@ function AdminUsageAnalyticsCard({
                 {isTodayOnlyRange ? t("输入 / 输出") : t("区间输入 / 输出")}
               </div>
               <div className="mt-1 font-semibold">
-                {formatCompactTokenAmount(rangeUsage.inputTokens)} /{" "}
+                {formatCompactTokenAmount(rangeUsage.inputTokens - rangeUsage.cachedInputTokens)} /{" "}
                 {formatCompactTokenAmount(rangeUsage.outputTokens)}
               </div>
             </div>


### PR DESCRIPTION
**背景**

管理员用量分析面板折线图下方"输入 / 输出"卡片列示的输入 token 量包含了被缓存命中的部分，而相邻的"缓存 / 推理"卡片已单独展示缓存命中量，两者存在重叠，不符合直觉。

**原因**

1. **定价不同：** 缓存命中 token 与新输入 token 单价差异很大，混在一起会模糊实际成本构成
2. **口径一致：** 首页"今日Token"合计已排除缓存（`(input - cached) + output`），此处也应同步
3. **互不重叠：** 修改后四个指标（输入、输出、缓存、推理）数值互不包含，逻辑清晰

**改动**

将"输入"数值从 `inputTokens` 改为 `inputTokens - cachedInputTokens`，标签保持"输入 / 输出"不变。

**改动文件**

- `apps/src/app/page.tsx` — 一行数值计算变更
