### PR TITLE
[codex] add banked reset credits support

### DIFF
--- a/apps/src-tauri/src/commands/registry.rs
+++ b/apps/src-tauri/src/commands/registry.rs
@@ -115,6 +115,8 @@ macro_rules! invoke_handler {
             crate::commands::usage::service_usage_list,
             crate::commands::usage::service_usage_aggregate,
             crate::commands::usage::service_usage_refresh,
+            crate::commands::usage::service_usage_reset_credits_read,
+            crate::commands::usage::service_usage_reset_credits_consume,
             // api key
             crate::commands::aggregate_api::service_aggregate_api_list,
             crate::commands::aggregate_api::service_aggregate_api_read_secret,

--- a/apps/src-tauri/src/commands/usage.rs
+++ b/apps/src-tauri/src/commands/usage.rs
@@ -73,3 +73,21 @@ pub async fn service_usage_refresh(
     let params = account_id.map(|id| serde_json::json!({ "accountId": id }));
     rpc_call_in_background("account/usage/refresh", addr, params).await
 }
+
+#[tauri::command]
+pub async fn service_usage_reset_credits_read(
+    addr: Option<String>,
+    account_id: String,
+) -> Result<serde_json::Value, String> {
+    let params = serde_json::json!({ "accountId": account_id });
+    rpc_call_in_background("account/usage/resetCredits/read", addr, Some(params)).await
+}
+
+#[tauri::command]
+pub async fn service_usage_reset_credits_consume(
+    addr: Option<String>,
+    account_id: String,
+) -> Result<serde_json::Value, String> {
+    let params = serde_json::json!({ "accountId": account_id });
+    rpc_call_in_background("account/usage/resetCredits/consume", addr, Some(params)).await
+}

--- a/apps/src/app/accounts/accounts-page-view.tsx
+++ b/apps/src/app/accounts/accounts-page-view.tsx
@@ -16,6 +16,7 @@ import {
   Pin,
   Plus,
   RefreshCw,
+  RotateCcw,
   Search,
   Trash2,
   Zap,
@@ -148,6 +149,7 @@ export interface AccountsPageViewProps {
   quotaSecondaryDraft: string;
   isRefreshingAllAccounts: boolean;
   isRefreshingAccountId: string | null;
+  isResettingAccountId: string | null;
   isRefreshingRtAccountId: string | null;
   isRefreshingAllRtAccounts: boolean;
   isExporting: boolean;
@@ -208,6 +210,7 @@ export interface AccountsPageViewProps {
   importByFile: () => void;
   importByDirectory: () => void;
   refreshAccount: (accountId: string) => void;
+  resetAccountUsage: (accountId: string) => void;
   clearPreferredAccount: (accountId: string) => void;
   setPreferredAccount: (accountId: string) => void;
   toggleAccountStatus: (
@@ -257,6 +260,7 @@ export function AccountsPageView(props: AccountsPageViewProps) {
     quotaSecondaryDraft,
     isRefreshingAllAccounts,
     isRefreshingAccountId,
+    isResettingAccountId,
     isRefreshingRtAccountId,
     isRefreshingAllRtAccounts,
     isExporting,
@@ -314,6 +318,7 @@ export function AccountsPageView(props: AccountsPageViewProps) {
     importByFile,
     importByDirectory,
     refreshAccount,
+    resetAccountUsage,
     clearPreferredAccount,
     setPreferredAccount,
     toggleAccountStatus,
@@ -843,6 +848,8 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                   }`;
                   const isRefreshingCurrentAccount =
                     isRefreshingAccountId === account.id;
+                  const isResettingCurrentAccount =
+                    isResettingAccountId === account.id;
                   const isRefreshingCurrentRt =
                     isRefreshingRtAccountId === account.id;
                   const filteredIndex =
@@ -1012,6 +1019,24 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                                   )}
                                 />
                                 {t("刷新用量")}
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                className="gap-2"
+                                disabled={
+                                  !isServiceReady ||
+                                  isRefreshingAllAccounts ||
+                                  isRefreshingCurrentAccount ||
+                                  isResettingCurrentAccount
+                                }
+                                onClick={() => resetAccountUsage(account.id)}
+                              >
+                                <RotateCcw
+                                  className={cn(
+                                    "h-4 w-4",
+                                    isResettingCurrentAccount && "animate-spin",
+                                  )}
+                                />
+                                {t("触发免费重置")}
                               </DropdownMenuItem>
                               <DropdownMenuItem
                                 className="gap-2"

--- a/apps/src/app/accounts/page.tsx
+++ b/apps/src/app/accounts/page.tsx
@@ -54,6 +54,7 @@ export default function AccountsPage() {
     isLoading,
     isServiceReady,
     refreshAccount,
+    resetAccountUsage,
     refreshAccountRt,
     refreshAllAccountRt,
     refreshAllAccounts,
@@ -66,6 +67,7 @@ export default function AccountsPage() {
     exportAccounts,
     warmupAccounts,
     isRefreshingAccountId,
+    isResettingAccountId,
     isRefreshingAllAccounts,
     isExporting,
     isWarmingUpAccounts,
@@ -653,6 +655,7 @@ const toggleCleanupStatus = (rawStatus: string) => {
       quotaSecondaryDraft={quotaSecondaryDraft}
       isRefreshingAllAccounts={isRefreshingAllAccounts}
       isRefreshingAccountId={isRefreshingAccountId}
+      isResettingAccountId={isResettingAccountId}
       isRefreshingRtAccountId={isRefreshingRtAccountId}
       isRefreshingAllRtAccounts={isRefreshingAllRtAccounts}
       isExporting={isExporting}
@@ -710,6 +713,7 @@ const toggleCleanupStatus = (rawStatus: string) => {
       importByFile={importByFile}
       importByDirectory={importByDirectory}
       refreshAccount={refreshAccount}
+      resetAccountUsage={resetAccountUsage}
       clearPreferredAccount={clearPreferredAccount}
       setPreferredAccount={setPreferredAccount}
       toggleAccountStatus={toggleAccountStatus}

--- a/apps/src/hooks/useAccounts.ts
+++ b/apps/src/hooks/useAccounts.ts
@@ -28,6 +28,9 @@ type AccountExportPayload = Parameters<typeof accountClient.export>[0];
 type ExportResult = Awaited<ReturnType<typeof accountClient.export>>;
 type WarmupPayload = Parameters<typeof accountClient.warmup>[0];
 type WarmupResult = Awaited<ReturnType<typeof accountClient.warmup>>;
+type ResetCreditsResult = Awaited<
+  ReturnType<typeof accountClient.consumeRateLimitResetCredits>
+>;
 type RefreshAllRtResult = Awaited<
   ReturnType<typeof accountClient.refreshAllChatgptAuthTokens>
 >;
@@ -477,6 +480,48 @@ export function useAccounts() {
     },
   });
 
+  const resetCreditsMutation = useMutation({
+    mutationFn: async (accountId: string): Promise<{
+      canceled?: boolean;
+      skipped?: boolean;
+      availableCount?: number;
+      result?: ResetCreditsResult;
+    }> => {
+      const credits = await accountClient.readRateLimitResetCredits(accountId);
+      const availableCount = Number(credits?.availableCount || 0);
+      if (availableCount <= 0) {
+        return { skipped: true, availableCount };
+      }
+      const confirmed =
+        typeof window === "undefined" ||
+        window.confirm(
+          t("当前账号有 {count} 次免费重置可用，确定消耗 1 次并刷新用量吗？", {
+            count: availableCount,
+          }),
+        );
+      if (!confirmed) {
+        return { canceled: true, availableCount };
+      }
+      const result = await accountClient.consumeRateLimitResetCredits(accountId);
+      return { result, availableCount };
+    },
+    onSuccess: async (payload) => {
+      if (payload?.canceled) {
+        toast.info(t("已取消免费重置"));
+        return;
+      }
+      if (payload?.skipped) {
+        toast.info(t("当前账号没有可用免费重置"));
+        return;
+      }
+      await invalidateUsageData();
+      toast.success(t("免费重置已触发，账号用量已刷新"));
+    },
+    onError: (error: unknown) => {
+      toast.error(`${t("免费重置失败")}: ${getAppErrorMessage(error)}`);
+    },
+  });
+
   const refreshAccountRtMutation = useMutation({
     mutationFn: (accountId: string) =>
       accountClient.refreshChatgptAuthTokens(accountId),
@@ -826,6 +871,15 @@ export function useAccounts() {
       }
       refreshAccountRtMutation.mutate(targetAccountId);
     },
+    resetAccountUsage: (accountId: string) => {
+      if (!ensureServiceReady("免费重置")) return;
+      const targetAccountId = accountId.trim();
+      if (!targetAccountId) {
+        toast.error(t("未找到当前账号，请刷新后重试"));
+        return;
+      }
+      resetCreditsMutation.mutate(targetAccountId);
+    },
     refreshAllAccountRt: () => {
       if (!ensureServiceReady("刷新 AT/RT")) return;
       if (!accounts.length) {
@@ -918,6 +972,10 @@ export function useAccounts() {
     isRefreshingAccountId:
       refreshAccountMutation.isPending && typeof refreshAccountMutation.variables === "string"
         ? refreshAccountMutation.variables
+        : "",
+    isResettingAccountId:
+      resetCreditsMutation.isPending && typeof resetCreditsMutation.variables === "string"
+        ? resetCreditsMutation.variables
         : "",
     isRefreshingRtAccountId:
       refreshAccountRtMutation.isPending &&

--- a/apps/src/lib/api/account-client.ts
+++ b/apps/src/lib/api/account-client.ts
@@ -80,6 +80,20 @@ export interface AccountWarmupPayload {
   message?: string;
 }
 
+export interface RateLimitResetCreditsResult {
+  availableCount: number;
+  totalEarnedCount: number;
+  credits: unknown[];
+  raw?: unknown;
+}
+
+export interface RateLimitResetConsumeResult {
+  consumed: boolean;
+  creditId: string;
+  redeemRequestId: string;
+  response?: unknown;
+}
+
 export interface AccountDeleteByStatusesPayload {
   statuses: string[];
 }
@@ -514,6 +528,28 @@ export const accountClient = {
           ? { accountId: targetAccountId, account_id: targetAccountId }
           : {}
       )
+    );
+  },
+  async readRateLimitResetCredits(
+    accountId: string
+  ): Promise<RateLimitResetCreditsResult> {
+    const result = await invoke<RateLimitResetCreditsResult>(
+      "service_usage_reset_credits_read",
+      withAddr({ accountId: accountId.trim() })
+    );
+    return {
+      availableCount: Number(result?.availableCount || 0),
+      totalEarnedCount: Number(result?.totalEarnedCount || 0),
+      credits: Array.isArray(result?.credits) ? result.credits : [],
+      raw: result?.raw,
+    };
+  },
+  async consumeRateLimitResetCredits(
+    accountId: string
+  ): Promise<RateLimitResetConsumeResult> {
+    return await invoke<RateLimitResetConsumeResult>(
+      "service_usage_reset_credits_consume",
+      withAddr({ accountId: accountId.trim() })
     );
   },
   async aggregateUsage(): Promise<UsageAggregateSummary> {

--- a/apps/src/lib/api/transport-web-commands/account.ts
+++ b/apps/src/lib/api/transport-web-commands/account.ts
@@ -96,5 +96,7 @@ export function createAccountWebCommands(postWebRpc: WebRpcCaller): Record<strin
     service_usage_list: { rpcMethod: "account/usage/list" },
     service_usage_refresh: { rpcMethod: "account/usage/refresh" },
     service_usage_aggregate: { rpcMethod: "account/usage/aggregate" },
+    service_usage_reset_credits_read: { rpcMethod: "account/usage/resetCredits/read" },
+    service_usage_reset_credits_consume: { rpcMethod: "account/usage/resetCredits/consume" },
   };
 }

--- a/apps/src/lib/i18n/messages/en.ts
+++ b/apps/src/lib/i18n/messages/en.ts
@@ -1034,6 +1034,14 @@ export const EN_MESSAGES: MessageCatalog = {
   账号用量已刷新: "Account usage refreshed",
   "账号长期未登录，refresh 已过期，已改为不可用状态":
     "Account inactive for a long time; refresh expired and marked unavailable.",
+  "当前账号有 {count} 次免费重置可用，确定消耗 1 次并刷新用量吗？":
+    "This account has {count} free reset(s). Consume 1 reset and refresh usage?",
+  已取消免费重置: "Free reset canceled",
+  当前账号没有可用免费重置: "This account has no available free reset.",
+  "免费重置已触发，账号用量已刷新":
+    "Free reset triggered and account usage refreshed.",
+  免费重置失败: "Free reset failed",
+  免费重置: "Free reset",
   "正在等待服务连接。": "Waiting for service connection.",
   "正在刷新...": "Refreshing...",
   "正在推导...": "Deriving...",
@@ -1374,6 +1382,7 @@ export const EN_MESSAGES: MessageCatalog = {
   "刷新 AT/RT": "Refresh AT/RT",
   "刷新全部 AT/RT": "Refresh all AT/RT",
   "刷新用量": "Refresh usage",
+  触发免费重置: "Trigger free reset",
   "路由策略": "Routing strategy",
   "路由来源": "Routing source",
   "客户端模型": "Client model",

--- a/crates/core/src/usage/mod.rs
+++ b/crates/core/src/usage/mod.rs
@@ -174,6 +174,16 @@ pub fn usage_endpoint(base_url: &str) -> String {
     }
 }
 
+pub fn rate_limit_reset_credits_endpoint(base_url: &str) -> String {
+    let base = normalize_base_url(base_url);
+    format!("{base}/wham/rate-limit-reset-credits")
+}
+
+pub fn rate_limit_reset_credits_consume_endpoint(base_url: &str) -> String {
+    let base = normalize_base_url(base_url);
+    format!("{base}/wham/rate-limit-reset-credits/consume")
+}
+
 /// 函数 `subscription_endpoint`
 ///
 /// 作者: gaohongshun

--- a/crates/core/tests/usage.rs
+++ b/crates/core/tests/usage.rs
@@ -1,4 +1,7 @@
-use codexmanager_core::usage::{accounts_check_endpoint, parse_usage_snapshot, usage_endpoint};
+use codexmanager_core::usage::{
+    accounts_check_endpoint, rate_limit_reset_credits_consume_endpoint,
+    rate_limit_reset_credits_endpoint, parse_usage_snapshot, usage_endpoint,
+};
 use serde_json::json;
 
 /// 函数 `usage_snapshot_parsed`
@@ -84,5 +87,17 @@ fn usage_snapshot_parsed() {
     assert_eq!(
         accounts_check_url,
         "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27"
+    );
+
+    let reset_credits_url = rate_limit_reset_credits_endpoint("https://chatgpt.com");
+    assert_eq!(
+        reset_credits_url,
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits"
+    );
+
+    let reset_consume_url = rate_limit_reset_credits_consume_endpoint("https://chatgpt.com");
+    assert_eq!(
+        reset_consume_url,
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume"
     );
 }

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -79,6 +79,7 @@ pub(crate) use usage::keepalive as usage_keepalive;
 pub(crate) use usage::list as usage_list;
 pub(crate) use usage::read as usage_read;
 pub(crate) use usage::refresh as usage_refresh;
+pub(crate) use usage::reset as usage_reset;
 pub(crate) use usage::scheduler as usage_scheduler;
 pub(crate) use usage::snapshot_store as usage_snapshot_store;
 pub(crate) use usage::token_refresh as usage_token_refresh;

--- a/crates/service/src/rpc_dispatch/mod.rs
+++ b/crates/service/src/rpc_dispatch/mod.rs
@@ -191,6 +191,8 @@ const MEMBER_METHOD_ALLOWLIST: &[&str] = &[
     "account/usage/list",
     "account/usage/read",
     "account/usage/refresh",
+    "account/usage/resetCredits/consume",
+    "account/usage/resetCredits/read",
     "account/warmup",
     "accountManager/password/change",
     "accountManager/profile/update",

--- a/crates/service/src/rpc_dispatch/usage.rs
+++ b/crates/service/src/rpc_dispatch/usage.rs
@@ -2,7 +2,7 @@ use codexmanager_core::rpc::types::{
     JsonRpcRequest, JsonRpcResponse, UsageListResult, UsageReadResult,
 };
 
-use crate::{usage_aggregate, usage_list, usage_read, usage_refresh};
+use crate::{usage_aggregate, usage_list, usage_read, usage_refresh, usage_reset};
 
 /// 函数 `try_handle`
 ///
@@ -42,6 +42,26 @@ pub(super) fn try_handle(req: &JsonRpcRequest) -> Option<JsonRpcResponse> {
                 None => usage_refresh::refresh_usage_for_all_accounts(),
             };
             super::ok_or_error(result)
+        }
+        "account/usage/resetCredits/read" => {
+            let account_id =
+                super::str_param(req, "accountId").or_else(|| super::str_param(req, "account_id"));
+            match account_id {
+                Some(account_id) => {
+                    super::value_or_error(usage_reset::read_rate_limit_reset_credits(account_id))
+                }
+                None => super::value_or_error::<()>(Err("accountId required".to_string())),
+            }
+        }
+        "account/usage/resetCredits/consume" => {
+            let account_id =
+                super::str_param(req, "accountId").or_else(|| super::str_param(req, "account_id"));
+            match account_id {
+                Some(account_id) => super::value_or_error(
+                    usage_reset::consume_rate_limit_reset_credits(account_id),
+                ),
+                None => super::value_or_error::<()>(Err("accountId required".to_string())),
+            }
         }
         _ => return None,
     };

--- a/crates/service/src/usage/mod.rs
+++ b/crates/service/src/usage/mod.rs
@@ -12,6 +12,8 @@ pub(crate) mod list;
 pub(crate) mod read;
 #[path = "usage_refresh.rs"]
 pub(crate) mod refresh;
+#[path = "usage_reset.rs"]
+pub(crate) mod reset;
 #[path = "usage_scheduler.rs"]
 pub(crate) mod scheduler;
 #[path = "usage_snapshot_store.rs"]

--- a/crates/service/src/usage/usage_http.rs
+++ b/crates/service/src/usage/usage_http.rs
@@ -1,5 +1,8 @@
 use chrono::DateTime;
-use codexmanager_core::usage::{accounts_check_endpoint, usage_endpoint};
+use codexmanager_core::usage::{
+    accounts_check_endpoint, rate_limit_reset_credits_consume_endpoint,
+    rate_limit_reset_credits_endpoint, usage_endpoint,
+};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use reqwest::Client;
 use std::collections::HashMap;
@@ -799,6 +802,15 @@ fn summarize_subscription_error_response(
     summarize_endpoint_error_response("subscription", status, headers, body, force_html_error)
 }
 
+fn summarize_reset_credits_error_response(
+    status: reqwest::StatusCode,
+    headers: &HeaderMap,
+    body: &str,
+    force_html_error: bool,
+) -> String {
+    summarize_endpoint_error_response("reset credits", status, headers, body, force_html_error)
+}
+
 fn extract_accounts_check_plan_type(entry: &AccountsCheckEntry) -> Option<String> {
     entry
         .account
@@ -1006,6 +1018,34 @@ pub(crate) fn fetch_usage_snapshot(
     run_usage_future(fetch_usage_snapshot_async(base_url, bearer, workspace_id))
 }
 
+pub(crate) fn fetch_rate_limit_reset_credits(
+    base_url: &str,
+    bearer: &str,
+    workspace_id: Option<&str>,
+) -> Result<serde_json::Value, String> {
+    run_usage_future(fetch_rate_limit_reset_credits_async(
+        base_url,
+        bearer,
+        workspace_id,
+    ))
+}
+
+pub(crate) fn consume_rate_limit_reset_credit(
+    base_url: &str,
+    bearer: &str,
+    workspace_id: Option<&str>,
+    credit_id: &str,
+    redeem_request_id: &str,
+) -> Result<serde_json::Value, String> {
+    run_usage_future(consume_rate_limit_reset_credit_async(
+        base_url,
+        bearer,
+        workspace_id,
+        credit_id,
+        redeem_request_id,
+    ))
+}
+
 /// 函数 `fetch_account_subscription`
 ///
 /// 作者: gaohongshun
@@ -1106,6 +1146,124 @@ async fn fetch_usage_snapshot_async(
     read_response_json(resp, USAGE_HTTP_TOTAL_TIMEOUT)
         .await
         .map_err(|e| format!("read usage endpoint json failed: {e}"))
+}
+
+async fn fetch_rate_limit_reset_credits_async(
+    base_url: &str,
+    bearer: &str,
+    workspace_id: Option<&str>,
+) -> Result<serde_json::Value, String> {
+    let url = rate_limit_reset_credits_endpoint(base_url);
+    let build_request = || {
+        let client = usage_http_client();
+        let mut req = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {bearer}"))
+            .header("Origin", "https://chatgpt.com")
+            .header("Referer", "https://chatgpt.com/")
+            .header("Accept", "application/json");
+        let request_headers = build_usage_request_headers(workspace_id);
+        if !request_headers.is_empty() {
+            req = req.headers(request_headers);
+        }
+        req
+    };
+    let resp = match build_request().send().await {
+        Ok(resp) => resp,
+        Err(first_err) => {
+            rebuild_usage_http_client();
+            let retried = build_request().send().await;
+            match retried {
+                Ok(resp) => resp,
+                Err(second_err) => {
+                    return Err(format!(
+                        "{}; retry_after_client_rebuild: {}",
+                        first_err, second_err
+                    ));
+                }
+            }
+        }
+    };
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = read_response_text(resp, USAGE_HTTP_TOTAL_TIMEOUT).await?;
+        return Err(summarize_reset_credits_error_response(
+            status, &headers, &body, false,
+        ));
+    }
+    let content_type = resp
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    if crate::gateway::is_html_content_type(content_type) {
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = read_response_text(resp, USAGE_HTTP_TOTAL_TIMEOUT).await?;
+        return Err(summarize_reset_credits_error_response(
+            status, &headers, &body, true,
+        ));
+    }
+    read_response_json(resp, USAGE_HTTP_TOTAL_TIMEOUT)
+        .await
+        .map_err(|e| format!("read reset credits endpoint json failed: {e}"))
+}
+
+async fn consume_rate_limit_reset_credit_async(
+    base_url: &str,
+    bearer: &str,
+    workspace_id: Option<&str>,
+    credit_id: &str,
+    redeem_request_id: &str,
+) -> Result<serde_json::Value, String> {
+    let url = rate_limit_reset_credits_consume_endpoint(base_url);
+    let body = serde_json::json!({
+        "credit_id": credit_id,
+        "redeem_request_id": redeem_request_id,
+    });
+    let build_request = || {
+        let client = usage_http_client();
+        let mut req = client
+            .post(&url)
+            .header("Authorization", format!("Bearer {bearer}"))
+            .header("Origin", "https://chatgpt.com")
+            .header("Referer", "https://chatgpt.com/")
+            .header("Accept", "application/json")
+            .json(&body);
+        let request_headers = build_usage_request_headers(workspace_id);
+        if !request_headers.is_empty() {
+            req = req.headers(request_headers);
+        }
+        req
+    };
+    let resp = build_request().send().await.map_err(|err| {
+        format!("reset credits consume request failed; status unknown: {err}")
+    })?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = read_response_text(resp, USAGE_HTTP_TOTAL_TIMEOUT).await?;
+        return Err(summarize_reset_credits_error_response(
+            status, &headers, &body, false,
+        ));
+    }
+    let content_type = resp
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    if crate::gateway::is_html_content_type(content_type) {
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = read_response_text(resp, USAGE_HTTP_TOTAL_TIMEOUT).await?;
+        return Err(summarize_reset_credits_error_response(
+            status, &headers, &body, true,
+        ));
+    }
+    read_response_json(resp, USAGE_HTTP_TOTAL_TIMEOUT)
+        .await
+        .map_err(|e| format!("read reset credits consume json failed: {e}"))
 }
 
 async fn fetch_accounts_check_response_async(

--- a/crates/service/src/usage/usage_reset.rs
+++ b/crates/service/src/usage/usage_reset.rs
@@ -1,0 +1,210 @@
+use codexmanager_core::auth::{DEFAULT_CLIENT_ID, DEFAULT_ISSUER};
+use codexmanager_core::storage::{Storage, Token};
+use rand::{distributions::Alphanumeric, Rng};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::storage_helpers::{open_storage, StorageHandle};
+use crate::usage_account_meta::{
+    clean_header_value, derive_account_meta, patch_account_meta, resolve_workspace_id_for_account,
+};
+use crate::usage_http::{consume_rate_limit_reset_credit, fetch_rate_limit_reset_credits};
+use crate::usage_refresh::refresh_usage_for_account;
+use crate::usage_token_refresh::{refresh_and_persist_access_token, token_refresh_ahead_secs};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RateLimitResetCreditsResult {
+    pub available_count: i64,
+    pub total_earned_count: i64,
+    pub credits: Vec<Value>,
+    pub raw: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RateLimitResetConsumeResult {
+    pub consumed: bool,
+    pub credit_id: String,
+    pub redeem_request_id: String,
+    pub response: Value,
+}
+
+struct ResetAccountContext {
+    storage: StorageHandle,
+    token: Token,
+    base_url: String,
+    workspace_id: Option<String>,
+}
+
+pub(crate) fn read_rate_limit_reset_credits(
+    account_id: &str,
+) -> Result<RateLimitResetCreditsResult, String> {
+    let context = load_reset_account_context(account_id)?;
+    fetch_rate_limit_reset_credits_for_context(&context)
+}
+
+pub(crate) fn consume_rate_limit_reset_credits(
+    account_id: &str,
+) -> Result<RateLimitResetConsumeResult, String> {
+    let context = load_reset_account_context(account_id)?;
+    let credits = fetch_rate_limit_reset_credits_for_context(&context)?;
+    if credits.available_count <= 0 {
+        return Err("no available rate limit reset credits".to_string());
+    }
+    let credit_id = select_credit_id(&credits.credits)
+        .ok_or_else(|| "available rate limit reset credit id not found".to_string())?;
+    let redeem_request_id = generate_redeem_request_id();
+    let token = context
+        .storage
+        .find_token_by_account_id(account_id)
+        .map_err(|e| e.to_string())?
+        .unwrap_or_else(|| context.token.clone());
+    let response = consume_rate_limit_reset_credit(
+        &context.base_url,
+        &token.access_token,
+        context.workspace_id.as_deref(),
+        &credit_id,
+        &redeem_request_id,
+    )?;
+    refresh_usage_for_account(account_id)?;
+    Ok(RateLimitResetConsumeResult {
+        consumed: true,
+        credit_id,
+        redeem_request_id,
+        response,
+    })
+}
+
+fn load_reset_account_context(account_id: &str) -> Result<ResetAccountContext, String> {
+    let storage = open_storage().ok_or_else(|| "storage unavailable".to_string())?;
+    let mut token = storage
+        .find_token_by_account_id(account_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "account token unavailable".to_string())?;
+    let workspace_id = resolve_reset_workspace_id(&storage, &mut token)?;
+    let base_url = std::env::var("CODEXMANAGER_USAGE_BASE_URL")
+        .unwrap_or_else(|_| "https://chatgpt.com".to_string());
+    Ok(ResetAccountContext {
+        storage,
+        token,
+        base_url,
+        workspace_id,
+    })
+}
+
+fn resolve_reset_workspace_id(
+    storage: &Storage,
+    token: &mut Token,
+) -> Result<Option<String>, String> {
+    let mut resolved_workspace_id = resolve_workspace_id_for_account(storage, &token.account_id);
+    let (derived_chatgpt_id, derived_workspace_id) = derive_account_meta(token);
+    if resolved_workspace_id.is_none() {
+        resolved_workspace_id = derived_workspace_id
+            .clone()
+            .or_else(|| derived_chatgpt_id.clone());
+    }
+    patch_account_meta(
+        storage,
+        &token.account_id,
+        derived_chatgpt_id,
+        derived_workspace_id,
+    );
+    Ok(clean_header_value(resolved_workspace_id))
+}
+
+fn fetch_rate_limit_reset_credits_for_context(
+    context: &ResetAccountContext,
+) -> Result<RateLimitResetCreditsResult, String> {
+    match fetch_rate_limit_reset_credits(
+        &context.base_url,
+        &context.token.access_token,
+        context.workspace_id.as_deref(),
+    ) {
+        Ok(value) => Ok(parse_rate_limit_reset_credits(value)),
+        Err(err) if should_retry_reset_request_with_token(&err) => {
+            let mut token = context.token.clone();
+            let issuer =
+                std::env::var("CODEXMANAGER_ISSUER").unwrap_or_else(|_| DEFAULT_ISSUER.to_string());
+            let client_id = std::env::var("CODEXMANAGER_CLIENT_ID")
+                .unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
+            refresh_and_persist_access_token(
+                &context.storage,
+                &mut token,
+                &issuer,
+                &client_id,
+                token_refresh_ahead_secs(),
+            )?;
+            let value = fetch_rate_limit_reset_credits(
+                &context.base_url,
+                &token.access_token,
+                context.workspace_id.as_deref(),
+            )?;
+            Ok(parse_rate_limit_reset_credits(value))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn parse_rate_limit_reset_credits(value: Value) -> RateLimitResetCreditsResult {
+    let available_count = value
+        .get("available_count")
+        .or_else(|| value.get("availableCount"))
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| {
+            value
+                .get("credits")
+                .and_then(Value::as_array)
+                .map(|items| items.len() as i64)
+                .unwrap_or(0)
+        });
+    let total_earned_count = value
+        .get("total_earned_count")
+        .or_else(|| value.get("totalEarnedCount"))
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let credits = value
+        .get("credits")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    RateLimitResetCreditsResult {
+        available_count,
+        total_earned_count,
+        credits,
+        raw: value,
+    }
+}
+
+fn select_credit_id(credits: &[Value]) -> Option<String> {
+    credits
+        .iter()
+        .filter_map(Value::as_object)
+        .find(|credit| {
+            !matches!(
+                credit.get("status").and_then(Value::as_str),
+                Some("redeemed") | Some("expired")
+            )
+        })
+        .and_then(|credit| credit.get("id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn should_retry_reset_request_with_token(err: &str) -> bool {
+    err.contains("status=401")
+        || err.contains("401 Unauthorized")
+        || err.contains("token_expired")
+        || err.contains("identity error code: token_expired")
+}
+
+fn generate_redeem_request_id() -> String {
+    let suffix = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(24)
+        .map(char::from)
+        .collect::<String>();
+    format!("codexmanager-{suffix}")
+}

--- a/crates/service/tests/rpc.rs
+++ b/crates/service/tests/rpc.rs
@@ -332,6 +332,14 @@ struct RecordedHeaderRequest {
     chatgpt_account_id: Option<String>,
 }
 
+#[derive(Debug)]
+struct RecordedHeaderBodyRequest {
+    path: String,
+    authorization: Option<String>,
+    chatgpt_account_id: Option<String>,
+    body: String,
+}
+
 fn start_mock_subscription_server(
     status: u16,
     response_body: String,
@@ -428,6 +436,156 @@ fn start_mock_usage_refresh_server(
             request
                 .respond(response)
                 .expect("respond usage refresh request");
+        }
+    });
+    (addr, rx, handle)
+}
+
+fn start_mock_reset_credits_read_server(
+    response_body: String,
+) -> (
+    String,
+    std::sync::mpsc::Receiver<RecordedHeaderRequest>,
+    thread::JoinHandle<()>,
+) {
+    let server = Server::http("127.0.0.1:0").expect("start mock reset credits server");
+    let addr = format!("http://{}", server.server_addr());
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = thread::spawn(move || {
+        let request = server
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reset credits server timeout")
+            .expect("receive reset credits request");
+        let path = request.url().to_string();
+        let authorization = request
+            .headers()
+            .iter()
+            .find(|header| header.field.equiv("Authorization"))
+            .map(|header| header.value.as_str().to_string());
+        let chatgpt_account_id = request
+            .headers()
+            .iter()
+            .find(|header| header.field.equiv("ChatGPT-Account-ID"))
+            .map(|header| header.value.as_str().to_string());
+        tx.send(RecordedHeaderRequest {
+            path: path.clone(),
+            authorization,
+            chatgpt_account_id,
+        })
+        .expect("send reset credits request");
+
+        let response_body = match path.as_str() {
+            "/backend-api/wham/rate-limit-reset-credits" => response_body,
+            other => panic!("unexpected reset credits path: {other}"),
+        };
+        let response = Response::from_string(response_body)
+            .with_status_code(StatusCode(200))
+            .with_header(
+                Header::from_bytes("Content-Type", "application/json")
+                    .expect("content-type header"),
+            );
+        request
+            .respond(response)
+            .expect("respond reset credits request");
+    });
+    (addr, rx, handle)
+}
+
+fn start_mock_reset_credits_consume_server() -> (
+    String,
+    std::sync::mpsc::Receiver<RecordedHeaderBodyRequest>,
+    thread::JoinHandle<()>,
+) {
+    let server = Server::http("127.0.0.1:0").expect("start mock reset consume server");
+    let addr = format!("http://{}", server.server_addr());
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = thread::spawn(move || {
+        for _ in 0..4 {
+            let mut request = server
+                .recv_timeout(Duration::from_secs(5))
+                .expect("reset consume server timeout")
+                .expect("receive reset consume request");
+            let path = request.url().to_string();
+            let authorization = request
+                .headers()
+                .iter()
+                .find(|header| header.field.equiv("Authorization"))
+                .map(|header| header.value.as_str().to_string());
+            let chatgpt_account_id = request
+                .headers()
+                .iter()
+                .find(|header| header.field.equiv("ChatGPT-Account-ID"))
+                .map(|header| header.value.as_str().to_string());
+            let mut body = String::new();
+            request
+                .as_reader()
+                .read_to_string(&mut body)
+                .expect("read reset consume request body");
+            tx.send(RecordedHeaderBodyRequest {
+                path: path.clone(),
+                authorization,
+                chatgpt_account_id,
+                body,
+            })
+            .expect("send reset consume request");
+
+            let response_body = match path.as_str() {
+                "/backend-api/wham/rate-limit-reset-credits" => serde_json::json!({
+                    "available_count": 1,
+                    "total_earned_count": 1,
+                    "credits": [
+                        {
+                            "id": "credit-consume-1",
+                            "status": "available",
+                            "title": "Free reset"
+                        }
+                    ]
+                })
+                .to_string(),
+                "/backend-api/wham/rate-limit-reset-credits/consume" => {
+                    serde_json::json!({ "ok": true }).to_string()
+                }
+                "/backend-api/accounts/check/v4-2023-04-27" => serde_json::json!({
+                    "accounts": {
+                        "org-reset-consume": {
+                            "account": {
+                                "plan_type": "plus",
+                                "is_default": true
+                            },
+                            "entitlement": {
+                                "subscription_plan": "plus",
+                                "has_active_subscription": true
+                            }
+                        }
+                    }
+                })
+                .to_string(),
+                "/backend-api/wham/usage" => serde_json::json!({
+                    "rate_limit": {
+                        "primary_window": {
+                            "used_percent": 0.0,
+                            "limit_window_seconds": 18000,
+                            "reset_at": 1776655889
+                        },
+                        "secondary_window": {
+                            "used_percent": 0.0,
+                            "limit_window_seconds": 604800,
+                            "reset_at": 1778038289
+                        }
+                    }
+                })
+                .to_string(),
+                other => panic!("unexpected reset consume path: {other}"),
+            };
+            let response = Response::from_string(response_body)
+                .with_status_code(StatusCode(200))
+                .with_header(
+                    Header::from_bytes("Content-Type", "application/json")
+                        .expect("content-type header"),
+                );
+            request
+                .respond(response)
+                .expect("respond reset consume request");
         }
     });
     (addr, rx, handle)
@@ -2245,6 +2403,200 @@ fn rpc_usage_refresh_persists_subscription_fields() {
     assert_eq!(extras[0]["source_key"], "codex_other");
     assert_eq!(extras[0]["limit_name"], "Spark");
     assert_eq!(extras[0]["primary_window"]["used_percent"], 40.0);
+}
+
+#[test]
+fn rpc_account_usage_reset_credits_read_returns_available_count() {
+    let ctx = RpcTestContext::new("rpc-reset-credits-read");
+    let storage = Storage::open(ctx.db_path()).expect("open db");
+    storage.init().expect("init schema");
+    let now = now_ts();
+    storage
+        .insert_account(&Account {
+            id: "acc-reset-read".to_string(),
+            label: "Reset Read".to_string(),
+            issuer: "https://auth.openai.com".to_string(),
+            chatgpt_account_id: Some("org-reset-read".to_string()),
+            workspace_id: Some("org-reset-read".to_string()),
+            group_name: None,
+            sort: 0,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("insert account");
+    storage
+        .insert_token(&Token {
+            account_id: "acc-reset-read".to_string(),
+            id_token: "id-token".to_string(),
+            access_token: "access-reset-read".to_string(),
+            refresh_token: "refresh-reset-read".to_string(),
+            api_key_access_token: None,
+            last_refresh: now,
+        })
+        .expect("insert token");
+
+    let response_body = serde_json::json!({
+        "available_count": 2,
+        "total_earned_count": 3,
+        "credits": [
+            {
+                "id": "credit-1",
+                "status": "available",
+                "title": "Free reset"
+            }
+        ]
+    });
+    let (reset_base_url, request_rx, request_join) = start_mock_reset_credits_read_server(
+        serde_json::to_string(&response_body).expect("serialize reset credits response"),
+    );
+    let _usage_base_url_guard =
+        EnvGuard::set("CODEXMANAGER_USAGE_BASE_URL", &format!("{reset_base_url}/backend-api"));
+
+    let read_req = JsonRpcRequest {
+        id: 83.into(),
+        method: "account/usage/resetCredits/read".to_string(),
+        params: Some(serde_json::json!({
+            "accountId": "acc-reset-read"
+        })),
+        trace: None,
+    };
+    let read_json = serde_json::to_string(&read_req).expect("serialize reset credits read");
+    let read_server = codexmanager_service::start_one_shot_server().expect("start server");
+    let read_resp = post_rpc(&read_server.addr, &read_json);
+    let result = read_resp.get("result").expect("reset credits result");
+    assert_eq!(
+        result.get("availableCount").and_then(|value| value.as_i64()),
+        Some(2)
+    );
+    assert_eq!(
+        result
+            .get("totalEarnedCount")
+            .and_then(|value| value.as_i64()),
+        Some(3)
+    );
+    assert_eq!(
+        result
+            .get("credits")
+            .and_then(|value| value.as_array())
+            .map(Vec::len),
+        Some(1)
+    );
+
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("receive reset credits request");
+    request_join.join().expect("join reset credits server");
+    assert_eq!(request.path, "/backend-api/wham/rate-limit-reset-credits");
+    assert_eq!(
+        request.authorization.as_deref(),
+        Some("Bearer access-reset-read")
+    );
+    assert_eq!(request.chatgpt_account_id.as_deref(), Some("org-reset-read"));
+}
+
+#[test]
+fn rpc_account_usage_reset_credits_consume_posts_credit_and_refreshes_usage() {
+    let ctx = RpcTestContext::new("rpc-reset-credits-consume");
+    let storage = Storage::open(ctx.db_path()).expect("open db");
+    storage.init().expect("init schema");
+    let now = now_ts();
+    storage
+        .insert_account(&Account {
+            id: "acc-reset-consume".to_string(),
+            label: "Reset Consume".to_string(),
+            issuer: "https://auth.openai.com".to_string(),
+            chatgpt_account_id: Some("org-reset-consume".to_string()),
+            workspace_id: Some("org-reset-consume".to_string()),
+            group_name: None,
+            sort: 0,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("insert account");
+    storage
+        .insert_token(&Token {
+            account_id: "acc-reset-consume".to_string(),
+            id_token: "id-token".to_string(),
+            access_token: "access-reset-consume".to_string(),
+            refresh_token: "refresh-reset-consume".to_string(),
+            api_key_access_token: None,
+            last_refresh: now,
+        })
+        .expect("insert token");
+
+    let (reset_base_url, request_rx, request_join) = start_mock_reset_credits_consume_server();
+    let _usage_base_url_guard =
+        EnvGuard::set("CODEXMANAGER_USAGE_BASE_URL", &format!("{reset_base_url}/backend-api"));
+
+    let consume_req = JsonRpcRequest {
+        id: 84.into(),
+        method: "account/usage/resetCredits/consume".to_string(),
+        params: Some(serde_json::json!({
+            "accountId": "acc-reset-consume"
+        })),
+        trace: None,
+    };
+    let consume_json = serde_json::to_string(&consume_req).expect("serialize reset consume");
+    let consume_server = codexmanager_service::start_one_shot_server().expect("start server");
+    let consume_resp = post_rpc(&consume_server.addr, &consume_json);
+    let result = consume_resp.get("result").expect("consume result");
+    assert_eq!(
+        result
+            .get("consumed")
+            .and_then(|value| value.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        result.get("creditId").and_then(|value| value.as_str()),
+        Some("credit-consume-1")
+    );
+
+    let read_request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("receive reset credits read request");
+    let consume_request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("receive reset credits consume request");
+    let subscription_request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("receive subscription refresh request");
+    let usage_request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("receive usage refresh request");
+    request_join.join().expect("join reset consume server");
+
+    assert_eq!(read_request.path, "/backend-api/wham/rate-limit-reset-credits");
+    assert_eq!(
+        consume_request.path,
+        "/backend-api/wham/rate-limit-reset-credits/consume"
+    );
+    assert_eq!(
+        consume_request.authorization.as_deref(),
+        Some("Bearer access-reset-consume")
+    );
+    assert_eq!(
+        consume_request.chatgpt_account_id.as_deref(),
+        Some("org-reset-consume")
+    );
+    let consume_body: serde_json::Value =
+        serde_json::from_str(&consume_request.body).expect("parse consume body");
+    assert_eq!(consume_body["credit_id"], "credit-consume-1");
+    assert!(consume_body["redeem_request_id"]
+        .as_str()
+        .is_some_and(|value| !value.trim().is_empty()));
+    assert_eq!(
+        subscription_request.path,
+        "/backend-api/accounts/check/v4-2023-04-27"
+    );
+    assert_eq!(usage_request.path, "/backend-api/wham/usage");
+
+    let refreshed = storage
+        .latest_usage_snapshot_for_account("acc-reset-consume")
+        .expect("read refreshed usage")
+        .expect("refreshed usage snapshot");
+    assert_eq!(refreshed.used_percent, Some(0.0));
 }
 
 /// 函数 `rpc_usage_read_empty`


### PR DESCRIPTION
## Summary

- Add account-level banked reset credits read/consume support for ChatGPT Codex rate-limit reset credits.
- Wire the full service RPC, Tauri command, Web command, typed frontend client, and accounts UI action path.
- Add a confirmed accounts-menu action so users can trigger one free reset only after the service reports available credits.

## Notes

The read endpoint was verified against local account tokens and returned the expected `available_count` / `credits` payload. The consume endpoint is implemented but was intentionally not exercised against the real upstream because it spends a reset credit.

## Validation

- `pnpm -C apps run build`
- `docker run --rm -v /tmp/Codex-Manager:/src -w /src rust:1-bookworm cargo build --locked -p codexmanager-service --release`
- `docker run --rm -v /tmp/Codex-Manager:/src -w /src rust:1-bookworm cargo build --locked -p codexmanager-web --release`
- Local web shell smoke test against a DB snapshot: accounts page loaded 3 accounts and exposed the `触发免费重置` menu item.
- Read-only RPC smoke test: `account/usage/resetCredits/read` returned `availableCount: 2` for the test account with available credits.

## Known Existing Test Noise

`pnpm -C apps run test:runtime` still has unrelated existing failures on `main` around dashboard/i18n coverage. The new reset-credit i18n coverage issue found during development was fixed.
