### PR TITLE
fix Codex session and thread headers

### DIFF
--- a/crates/service/src/gateway/request/incoming_headers.rs
+++ b/crates/service/src/gateway/request/incoming_headers.rs
@@ -77,7 +77,10 @@ impl IncomingHeaderSnapshot {
                 }
                 continue;
             }
-            if snapshot.session_id.is_none() && name.eq_ignore_ascii_case("session_id") {
+            if snapshot.session_id.is_none()
+                && (name.eq_ignore_ascii_case("session-id")
+                    || name.eq_ignore_ascii_case("session_id"))
+            {
                 if !value.is_empty() {
                     snapshot.session_id = Some(value.to_string());
                 }
@@ -176,7 +179,10 @@ impl IncomingHeaderSnapshot {
                 remember_passthrough_header(&mut snapshot.passthrough_codex_headers, name, value);
                 continue;
             }
-            if snapshot.conversation_id.is_none() && name.eq_ignore_ascii_case("conversation_id") {
+            if snapshot.conversation_id.is_none()
+                && (name.eq_ignore_ascii_case("thread-id")
+                    || name.eq_ignore_ascii_case("conversation_id"))
+            {
                 if !value.is_empty() {
                     snapshot.conversation_id = Some(value.to_string());
                 }
@@ -236,7 +242,9 @@ impl IncomingHeaderSnapshot {
                 }
                 continue;
             }
-            if snapshot.session_id.is_none() && header.field.equiv("session_id") {
+            if snapshot.session_id.is_none()
+                && (header.field.equiv("session-id") || header.field.equiv("session_id"))
+            {
                 let value = header.value.as_str().trim();
                 if !value.is_empty() {
                     snapshot.session_id = Some(value.to_string());
@@ -346,7 +354,9 @@ impl IncomingHeaderSnapshot {
                 }
                 continue;
             }
-            if snapshot.conversation_id.is_none() && header.field.equiv("conversation_id") {
+            if snapshot.conversation_id.is_none()
+                && (header.field.equiv("thread-id") || header.field.equiv("conversation_id"))
+            {
                 let value = header.value.as_str().trim();
                 if !value.is_empty() {
                     snapshot.conversation_id = Some(value.to_string());

--- a/crates/service/src/gateway/request/tests/incoming_headers_tests.rs
+++ b/crates/service/src/gateway/request/tests/incoming_headers_tests.rs
@@ -90,6 +90,43 @@ fn session_id_is_preferred_for_sticky_key_material() {
     assert_eq!(snapshot.sticky_key_material(), Some("session-thread-1"));
 }
 
+#[test]
+fn current_codex_hyphenated_headers_are_captured() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        "session-id",
+        axum::http::HeaderValue::from_static("session-current"),
+    );
+    headers.insert(
+        "thread-id",
+        axum::http::HeaderValue::from_static("thread-current"),
+    );
+
+    let snapshot = IncomingHeaderSnapshot::from_http_headers(&headers);
+
+    assert_eq!(snapshot.session_id(), Some("session-current"));
+    assert_eq!(snapshot.conversation_id(), Some("thread-current"));
+    assert_eq!(snapshot.sticky_key_material(), Some("session-current"));
+}
+
+#[test]
+fn current_codex_hyphenated_headers_are_captured_from_tiny_http_requests() {
+    let request: tiny_http::Request = tiny_http::TestRequest::new()
+        .with_header(
+            tiny_http::Header::from_bytes("session-id", "session-current").expect("session header"),
+        )
+        .with_header(
+            tiny_http::Header::from_bytes("thread-id", "thread-current").expect("thread header"),
+        )
+        .into();
+
+    let snapshot = IncomingHeaderSnapshot::from_request(&request);
+
+    assert_eq!(snapshot.session_id(), Some("session-current"));
+    assert_eq!(snapshot.conversation_id(), Some("thread-current"));
+    assert_eq!(snapshot.sticky_key_material(), Some("session-current"));
+}
+
 /// 函数 `codex_headers_are_captured_from_http_headers`
 ///
 /// 作者: gaohongshun

--- a/crates/service/src/gateway/upstream/attempt_flow/transport.rs
+++ b/crates/service/src/gateway/upstream/attempt_flow/transport.rs
@@ -217,6 +217,8 @@ fn apply_gemini_codex_compat_header_profile(
     remove_header(headers, "x-codex-turn-state");
     remove_header(headers, "x-codex-parent-thread-id");
     remove_header(headers, "x-openai-subagent");
+    remove_header(headers, "session-id");
+    remove_header(headers, "thread-id");
     if !has_header(headers, "session_id") {
         headers.push(("Session_id".to_string(), random_cpa_session_id()));
     }

--- a/crates/service/src/gateway/upstream/attempt_flow/transport_tests.rs
+++ b/crates/service/src/gateway/upstream/attempt_flow/transport_tests.rs
@@ -333,6 +333,8 @@ fn gemini_codex_compat_header_profile_matches_cpa_executor_shape() {
             "parent-thread".to_string(),
         ),
         ("x-openai-subagent".to_string(), "subagent".to_string()),
+        ("session-id".to_string(), "session-current".to_string()),
+        ("thread-id".to_string(), "thread-current".to_string()),
     ];
 
     apply_gemini_codex_compat_header_profile(&mut headers, None);
@@ -347,6 +349,8 @@ fn gemini_codex_compat_header_profile_matches_cpa_executor_shape() {
     assert_eq!(header_value(&headers, "x-codex-turn-state"), None);
     assert_eq!(header_value(&headers, "x-codex-parent-thread-id"), None);
     assert_eq!(header_value(&headers, "x-openai-subagent"), None);
+    assert_eq!(header_value(&headers, "session-id"), None);
+    assert_eq!(header_value(&headers, "thread-id"), None);
     assert_eq!(header_value(&headers, "session_id").map(str::len), Some(36));
 }
 

--- a/crates/service/src/gateway/upstream/headers/codex_headers.rs
+++ b/crates/service/src/gateway/upstream/headers/codex_headers.rs
@@ -141,8 +141,13 @@ pub(crate) fn build_codex_upstream_headers(
             residency_requirement,
         ));
     }
-    if let Some(client_request_id) = resolve_client_request_id(input.incoming_client_request_id) {
-        headers.push(("x-client-request-id".to_string(), client_request_id));
+    let resolved_client_request_id = resolve_client_request_id(input.incoming_client_request_id);
+    if let Some(client_request_id) = resolved_client_request_id.as_deref() {
+        headers.push((
+            "x-client-request-id".to_string(),
+            client_request_id.to_string(),
+        ));
+        headers.push(("thread-id".to_string(), client_request_id.to_string()));
     }
     if let Some(subagent) = input
         .incoming_subagent
@@ -217,7 +222,7 @@ pub(crate) fn build_codex_upstream_headers(
         input.strip_session_affinity,
     );
     if let Some(session_id) = resolved_session_id.as_deref() {
-        headers.push(("session_id".to_string(), session_id.to_string()));
+        headers.push(("session-id".to_string(), session_id.to_string()));
     }
     if let Some(window_id) = resolve_window_id(
         input.incoming_window_id,
@@ -328,10 +333,10 @@ pub(crate) fn build_codex_compact_upstream_headers(
         input.strip_session_affinity,
     );
     if let Some(session_id) = resolved_session_id.clone() {
-        headers.push(("session_id".to_string(), session_id));
+        headers.push(("session-id".to_string(), session_id));
     }
     if let Some(thread_id) = normalize_non_empty(input.thread_id) {
-        headers.push(("thread_id".to_string(), thread_id.to_string()));
+        headers.push(("thread-id".to_string(), thread_id.to_string()));
     }
     if let Some(window_id) = resolve_window_id(
         input.incoming_window_id,

--- a/crates/service/src/gateway/upstream/headers/codex_headers_tests.rs
+++ b/crates/service/src/gateway/upstream/headers/codex_headers_tests.rs
@@ -188,9 +188,15 @@ fn build_codex_upstream_headers_keeps_final_affinity_shape() {
         Some("conversation-anchor")
     );
     assert_eq!(
-        header_value(&headers, "session_id"),
+        header_value(&headers, "session-id"),
         Some("conversation-anchor")
     );
+    assert_eq!(
+        header_value(&headers, "thread-id"),
+        Some("conversation-anchor")
+    );
+    assert_eq!(header_value(&headers, "session_id"), None);
+    assert_eq!(header_value(&headers, "thread_id"), None);
     assert_eq!(
         header_value(&headers, "x-codex-window-id"),
         Some("conversation-anchor:7")
@@ -257,7 +263,11 @@ fn build_codex_upstream_headers_clears_turn_state_when_affinity_diverges() {
         Some("conversation-anchor")
     );
     assert_eq!(
-        header_value(&headers, "session_id"),
+        header_value(&headers, "session-id"),
+        Some("conversation-anchor")
+    );
+    assert_eq!(
+        header_value(&headers, "thread-id"),
         Some("conversation-anchor")
     );
     assert_eq!(
@@ -327,10 +337,12 @@ fn build_codex_compact_upstream_headers_use_session_fallback_only() {
     );
     assert_eq!(header_value(&headers, "x-client-request-id"), None);
     assert_eq!(
-        header_value(&headers, "session_id"),
+        header_value(&headers, "session-id"),
         Some("conversation-anchor")
     );
-    assert_eq!(header_value(&headers, "thread_id"), Some("thread-anchor-c"));
+    assert_eq!(header_value(&headers, "thread-id"), Some("thread-anchor-c"));
+    assert_eq!(header_value(&headers, "session_id"), None);
+    assert_eq!(header_value(&headers, "thread_id"), None);
     assert_eq!(
         header_value(&headers, "x-codex-window-id"),
         Some("conversation-anchor:0")
@@ -383,7 +395,8 @@ fn build_codex_upstream_headers_rebuilds_mismatched_window_id_from_session() {
         has_body: true,
     });
 
-    assert_eq!(header_value(&headers, "session_id"), Some("session-anchor"));
+    assert_eq!(header_value(&headers, "session-id"), Some("session-anchor"));
+    assert_eq!(header_value(&headers, "thread-id"), Some("request-anchor"));
     assert_eq!(
         header_value(&headers, "x-codex-window-id"),
         Some("session-anchor:0")
@@ -486,5 +499,5 @@ fn build_codex_compact_upstream_headers_omits_thread_id_when_missing() {
         has_body: false,
     });
 
-    assert_eq!(header_value(&headers, "thread_id"), None);
+    assert_eq!(header_value(&headers, "thread-id"), None);
 }

--- a/crates/service/tests/gateway/availability/upstream_headers.rs
+++ b/crates/service/tests/gateway/availability/upstream_headers.rs
@@ -208,7 +208,7 @@ fn codex_header_profile_sets_required_headers_for_stream() {
         Some("turn-state")
     );
     assert!(find_header(&headers, "Conversation_id").is_none());
-    assert!(find_header(&headers, "session_id").is_none());
+    assert!(find_header(&headers, "session-id").is_none());
     assert!(find_header(&headers, "x-codex-window-id").is_none());
 }
 
@@ -328,11 +328,11 @@ fn codex_compact_header_profile_matches_remote_compact_shape() {
     );
     assert!(find_header(&headers, "Version").is_none());
     assert_eq!(
-        find_header(&headers, "session_id").as_deref(),
+        find_header(&headers, "session-id").as_deref(),
         Some("session-compact")
     );
     assert_eq!(
-        find_header(&headers, "thread_id").as_deref(),
+        find_header(&headers, "thread-id").as_deref(),
         Some("thread-compact")
     );
     assert!(find_header(&headers, "Cookie").is_none());
@@ -431,7 +431,7 @@ fn codex_compact_header_profile_omits_session_without_thread_anchor() {
         has_body: true,
     });
 
-    assert!(find_header(&headers, "session_id").is_none());
+    assert!(find_header(&headers, "session-id").is_none());
 }
 
 /// 函数 `codex_header_profile_uses_dynamic_originator_and_residency_requirement`
@@ -542,11 +542,11 @@ fn codex_header_profile_regenerates_session_on_failover() {
     });
 
     assert_ne!(
-        find_header(&headers, "session_id").as_deref(),
+        find_header(&headers, "session-id").as_deref(),
         Some("sticky-session")
     );
     assert_eq!(
-        find_header(&headers, "session_id").as_deref(),
+        find_header(&headers, "session-id").as_deref(),
         Some("fallback-session")
     );
     assert_eq!(
@@ -597,7 +597,7 @@ fn codex_header_profile_uses_fallback_session_when_incoming_missing() {
     });
 
     assert_eq!(
-        find_header(&headers, "session_id").as_deref(),
+        find_header(&headers, "session-id").as_deref(),
         Some("fallback-session")
     );
     assert_eq!(
@@ -731,7 +731,7 @@ fn codex_header_profile_can_disable_affinity_headers() {
     assert!(find_header(&headers, "x-codex-turn-state").is_none());
     assert!(find_header(&headers, "Conversation_id").is_none());
     assert_eq!(
-        find_header(&headers, "session_id").as_deref(),
+        find_header(&headers, "session-id").as_deref(),
         Some("sticky-session")
     );
     assert_eq!(
@@ -780,7 +780,7 @@ fn codex_header_profile_does_not_invent_client_request_id_on_failover() {
     });
 
     assert_ne!(
-        find_header(&headers, "session_id").as_deref(),
+        find_header(&headers, "session-id").as_deref(),
         Some("sticky-session")
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

- accept Codex's current `session-id` and `thread-id` request headers while retaining the legacy underscore aliases on input
- emit `session-id`, `thread-id`, and `x-client-request-id` with the current Responses API header shape
- keep the Gemini CPA compatibility path on its required legacy `Session_id` header

## Root cause

Current Codex clients send hyphenated session and thread headers. Codex Manager 0.4.0 only parsed and emitted the older underscore spellings, so it lost the native thread anchor and reconstructed an upstream header set that the Codex Responses endpoint rejected. The fallback endpoint then returned 404, which was the error surfaced to the client.

## Test plan

- `cargo test -p codexmanager-service current_codex_hyphenated_headers_are_captured -- --nocapture`
- `cargo test -q -p codexmanager-service -- --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --check`
- `pnpm -C apps run build:desktop`
- `pnpm dlx @tauri-apps/cli@2.10.1 build --bundles app`
- local smoke test with Codex CLI 0.144.0-alpha.4 through `http://localhost:48760/v1`: `gpt-5.5` returned HTTP 200
