### PR TITLE
fix macOS Carbon compatibility metadata

### DIFF
--- a/apps/src-tauri/Info.plist
+++ b/apps/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>LSRequiresCarbon</key>
+  <false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- override Tauri's generated `LSRequiresCarbon` value to `false` for the macOS application bundle
- prevent native Apple Silicon builds from being presented as legacy Intel/Carbon applications by newer macOS versions

## Root cause

The Tauri bundler currently writes `LSRequiresCarbon = true` into the generated macOS `Info.plist`. CodexManager is a native arm64 application and does not require Carbon, so that metadata is incorrect and can trigger the macOS warning about future Intel application support.

## Test plan

- `plutil -lint apps/src-tauri/Info.plist`
- `pnpm dlx @tauri-apps/cli@2.10.1 build --bundles app --target aarch64-apple-darwin`
- verified the generated executable is a Mach-O arm64 binary
- verified the generated application `Info.plist` contains `LSRequiresCarbon = false`
- launched the locally signed bundle and verified the CodexManager window and gateway service start normally
