### PR TITLE
fix: fix white fill issue

### DIFF
--- a/apps/src/components/layout/sidebar.tsx
+++ b/apps/src/components/layout/sidebar.tsx
@@ -88,7 +88,7 @@ const NavItem = memo(({
       "group/nav relative flex min-h-10 items-center gap-3 overflow-hidden rounded-md border border-transparent px-3 py-2 text-[13px] transition-colors duration-200 hover:border-primary/20 hover:bg-primary/5 hover:text-primary",
       !isSidebarOpen && "justify-center px-0",
       isActive
-        ? "border-primary/25 bg-primary/10 text-primary shadow-[inset_3px_0_0_rgb(var(--primary-rgb)/0.8),0_10px_22px_-20px_rgb(var(--primary-rgb)/0.34)]"
+        ? "border-primary/25 bg-primary/10 text-primary shadow-[0_10px_22px_-20px_rgb(var(--primary-rgb)/0.34)]"
         : "text-muted-foreground",
     )}
   >
@@ -255,7 +255,7 @@ export function Sidebar() {
             isSidebarOpen ? "text-left" : "justify-center"
           )}
         >
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-primary/20 bg-white text-primary shadow-sm">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-primary/20 bg-card text-primary shadow-sm">
             {logoFailed ? (
               <span className="text-sm font-bold">CM</span>
             ) : (


### PR DESCRIPTION
修复 Desktop（Windows 11）默认外观下，CodexManager Logo 及选中侧边栏项图标左侧出现异常白色填充的问题（上游 qxcnm/Codex-Manager#353）。

## 变更摘要

- **Logo 容器**：`bg-white` → `bg-card`，改为主题自适应背景，消除深色/自定义主题下的硬编码白色填充
- **选中导航项阴影**：移除 `inset_3px_0_0_rgb(var(--primary-rgb)/0.8)`；在 `dark` 主题中 `--primary-rgb: 255 255 255`，该 inset shadow 字面为白色，直接造成选中项左侧 3 px 白色填充。已有 `absolute left-0 w-0.5 rounded-full bg-primary` span 承担左侧视觉指示，inset shadow 冗余

原来CodexManager图标以及被选中的哪个侧边栏项目的图标出现了奇怪的白色填充在图标左侧。

<img width="193" height="551" alt="Image" src="https://github.com/user-attachments/assets/fcd55704-04b2-483e-a37d-f9e7a278060e" />

目前：

<img width="179" height="172" alt="image" src="https://github.com/user-attachments/assets/a781b070-0138-4a8a-826a-97a5ce470689" />

Fix #353

```tsx
// before
"border-primary/25 bg-primary/10 text-primary shadow-[inset_3px_0_0_rgb(var(--primary-rgb)/0.8),0_10px_22px_-20px_rgb(var(--primary-rgb)/0.34)]"

// after — inset 移除，外侧 glow 保留
"border-primary/25 bg-primary/10 text-primary shadow-[0_10px_22px_-20px_rgb(var(--primary-rgb)/0.34)]"
```

## 改动范围

- [x] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `apps/src/components/layout/sidebar.tsx`

## 验证

- [ ] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [ ] 其他本地验证已说明

已执行的实际验证：

```text
pnpm -C apps run build
✓ Compiled successfully in 5.1s
✓ Generating static pages (16/16) — 0 errors
```

未执行的验证与原因：

```text
pnpm -C apps run test        — 无对应样式单元测试
pnpm -C apps run test:ui     — 需要完整 Desktop 运行时环境
cargo test --workspace       — 纯前端样式改动，无 Rust 变更
```

## 风险与影响面

- 仅修改两处 Tailwind class，无逻辑变更
- 亮色主题不受影响：`bg-card` ≈ 白色；default 主题 `--primary-rgb` 为蓝色，原 inset shadow 为蓝色而非白色
- 深色主题修复白色填充，hover / active 左侧 accent（`w-0.5` span）保留，视觉一致

## 备注

- 提交前请确认未包含敏感 token、cookie、API key