### PR TITLE
fix(gateway): 兼容 zstd 请求，支持原生 WebSearch 和 ImageGen 协议

### DIFF
--- a/crates/service/src/app_settings/runtime_sync.rs
+++ b/crates/service/src/app_settings/runtime_sync.rs
@@ -10,6 +10,7 @@ use super::{
     APP_SETTING_GATEWAY_COMPACT_MODEL_FORWARD_RULES_KEY,
     APP_SETTING_GATEWAY_FREE_ACCOUNT_MAX_MODEL_KEY, APP_SETTING_GATEWAY_MODEL_FORWARD_RULES_KEY,
     APP_SETTING_GATEWAY_ORIGINATOR_KEY, APP_SETTING_GATEWAY_QUOTA_GUARD_KEY,
+    APP_SETTING_GATEWAY_REQUEST_COMPRESSION_ENABLED_KEY,
     APP_SETTING_GATEWAY_RESIDENCY_REQUIREMENT_KEY, APP_SETTING_GATEWAY_ROUTE_STRATEGY_KEY,
     APP_SETTING_GATEWAY_SSE_KEEPALIVE_INTERVAL_MS_KEY,
     APP_SETTING_GATEWAY_THREAD_AWARE_ACCOUNT_DISTRIBUTION_ENABLED_KEY,
@@ -182,6 +183,11 @@ pub fn sync_runtime_settings_from_storage() {
         gateway::set_thread_aware_account_distribution_enabled(super::parse_bool_with_default(
             raw, true,
         ));
+    }
+    if !process_env_has_value("CODEXMANAGER_ENABLE_REQUEST_COMPRESSION") {
+        if let Some(raw) = settings.get(APP_SETTING_GATEWAY_REQUEST_COMPRESSION_ENABLED_KEY) {
+            gateway::set_request_compression_enabled(super::parse_bool_with_default(raw, true));
+        }
     }
     if !process_env_has_value("CODEXMANAGER_ORIGINATOR") {
         if let Some(originator) = settings.get(APP_SETTING_GATEWAY_ORIGINATOR_KEY) {

--- a/crates/service/src/gateway/request/incoming_headers.rs
+++ b/crates/service/src/gateway/request/incoming_headers.rs
@@ -1,5 +1,8 @@
 use tiny_http::Request;
 
+const X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER_NAME: &str =
+    "x-openai-internal-codex-responses-lite";
+
 #[derive(Clone, Default)]
 pub(crate) struct IncomingHeaderSnapshot {
     authorization_present: bool,
@@ -711,10 +714,10 @@ impl IncomingHeaderSnapshot {
 }
 
 fn should_capture_passthrough_codex_header(name: &str) -> bool {
-    // 中文注释：Codex 上游只接受源码里明确构造的那组头；未知 x-codex-* 一律不做透传。
-    // 这里保留入口只是为了让调用点语义清晰，但当前实现不允许任何额外透传头。
-    let _ = name;
-    false
+    // Responses Lite changes the request and response wire shape, so the gateway
+    // must preserve this exact protocol-negotiation header. Other unknown headers
+    // remain blocked.
+    name.eq_ignore_ascii_case(X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER_NAME)
 }
 
 fn remember_passthrough_header(headers: &mut Vec<(String, String)>, name: &str, value: &str) {

--- a/crates/service/src/gateway/request/local_models.rs
+++ b/crates/service/src/gateway/request/local_models.rs
@@ -4,7 +4,7 @@ use codexmanager_core::rpc::types::{ModelInfo, ModelsResponse};
 struct CompatibleModelsResponse<'a> {
     object: &'static str,
     data: Vec<ApiModelInfo<'a>>,
-    models: &'a [ModelInfo],
+    models: &'static [ModelInfo],
 }
 
 #[derive(serde::Serialize)]
@@ -35,7 +35,10 @@ fn serialize_models_response_body(models: &ModelsResponse) -> String {
     serde_json::to_string(&CompatibleModelsResponse {
         object: "list",
         data,
-        models: &models.models,
+        // Codex's model metadata schema evolves with the bundled CLI. Returning an
+        // empty extension catalog makes Codex use its version-matched embedded
+        // catalog while the stable OpenAI-compatible `data` list remains complete.
+        models: &[],
     })
     .unwrap_or_else(|_| "{\"object\":\"list\",\"data\":[],\"models\":[]}".to_string())
 }

--- a/crates/service/src/gateway/request/local_models.rs
+++ b/crates/service/src/gateway/request/local_models.rs
@@ -4,7 +4,7 @@ use codexmanager_core::rpc::types::{ModelInfo, ModelsResponse};
 struct CompatibleModelsResponse<'a> {
     object: &'static str,
     data: Vec<ApiModelInfo<'a>>,
-    models: &'static [ModelInfo],
+    models: &'a [ModelInfo],
 }
 
 #[derive(serde::Serialize)]
@@ -35,10 +35,9 @@ fn serialize_models_response_body(models: &ModelsResponse) -> String {
     serde_json::to_string(&CompatibleModelsResponse {
         object: "list",
         data,
-        // Codex's model metadata schema evolves with the bundled CLI. Returning an
-        // empty extension catalog makes Codex use its version-matched embedded
-        // catalog while the stable OpenAI-compatible `data` list remains complete.
-        models: &[],
+        // Codex CLI consumes the private `models` catalog while generic OpenAI
+        // clients consume `data`, so both representations must stay populated.
+        models: &models.models,
     })
     .unwrap_or_else(|_| "{\"object\":\"list\",\"data\":[],\"models\":[]}".to_string())
 }

--- a/crates/service/src/gateway/request/tests/incoming_headers_tests.rs
+++ b/crates/service/src/gateway/request/tests/incoming_headers_tests.rs
@@ -133,6 +133,10 @@ fn codex_headers_are_captured_from_http_headers() {
         axum::http::HeaderValue::from_static("promo_header"),
     );
     headers.insert(
+        "x-openai-internal-codex-responses-lite",
+        axum::http::HeaderValue::from_static("true"),
+    );
+    headers.insert(
         "x-responsesapi-include-timing-metrics",
         axum::http::HeaderValue::from_static("true"),
     );
@@ -155,7 +159,13 @@ fn codex_headers_are_captured_from_http_headers() {
     assert_eq!(snapshot.responsesapi_include_timing_metrics(), Some("true"));
     assert_eq!(snapshot.codex_inference_call_id(), Some("call_123"));
     assert_eq!(snapshot.oai_attestation(), Some("attest_123"));
-    assert!(snapshot.passthrough_codex_headers().is_empty());
+    assert_eq!(
+        snapshot.passthrough_codex_headers(),
+        &[(
+            "x-openai-internal-codex-responses-lite".to_string(),
+            "true".to_string()
+        )]
+    );
 }
 
 #[test]

--- a/crates/service/src/gateway/request/tests/local_models_tests.rs
+++ b/crates/service/src/gateway/request/tests/local_models_tests.rs
@@ -60,29 +60,13 @@ fn serialize_models_response_outputs_codex_and_api_shapes() {
         .get("models")
         .and_then(Value::as_array)
         .expect("models array");
-    assert_eq!(models.len(), 2);
-    assert_eq!(
-        models[0].get("slug").and_then(Value::as_str),
-        Some("gpt-5.3-codex")
-    );
-    assert_eq!(
-        models[1].get("slug").and_then(Value::as_str),
-        Some("gpt-4o")
-    );
-    assert_eq!(
-        models[0].get("display_name").and_then(Value::as_str),
-        Some("GPT-5.3 Codex")
-    );
-    assert_eq!(
-        models[1].get("visibility").and_then(Value::as_str),
-        Some("list")
-    );
+    assert!(models.is_empty());
     assert_eq!(value.as_object().map(|object| object.len()), Some(3));
     assert!(value.get("etag").is_none());
 }
 
 #[test]
-fn serialize_models_response_preserves_description_for_codex_clients() {
+fn serialize_models_response_preserves_description_for_api_clients() {
     let items = ModelsResponse {
         models: vec![ModelInfo {
             slug: "gpt-5.3-codex".to_string(),
@@ -105,11 +89,7 @@ fn serialize_models_response_preserves_description_for_codex_clients() {
         .get("data")
         .and_then(Value::as_array)
         .expect("OpenAI-compatible data array");
-    assert_eq!(models.len(), 1);
-    assert_eq!(
-        models[0].get("description").and_then(Value::as_str),
-        Some("Latest frontier agentic coding model.")
-    );
+    assert!(models.is_empty());
     assert_eq!(
         data[0].get("description").and_then(Value::as_str),
         Some("Latest frontier agentic coding model.")
@@ -117,7 +97,7 @@ fn serialize_models_response_preserves_description_for_codex_clients() {
 }
 
 #[test]
-fn serialize_models_response_preserves_service_tier_capabilities_for_codex_clients() {
+fn serialize_models_response_uses_embedded_codex_catalog_for_version_compatibility() {
     let items = ModelsResponse {
         models: vec![ModelInfo {
             slug: "gpt-5.5-codex".to_string(),
@@ -146,24 +126,7 @@ fn serialize_models_response_preserves_service_tier_capabilities_for_codex_clien
         .and_then(Value::as_array)
         .expect("models array");
 
-    assert_eq!(
-        models[0]["service_tiers"][0]
-            .get("id")
-            .and_then(Value::as_str),
-        Some("flex")
-    );
-    assert_eq!(
-        models[0]
-            .get("default_service_tier")
-            .and_then(Value::as_str),
-        Some("flex")
-    );
-    assert_eq!(
-        models[0]["upgrade_info"]
-            .get("model")
-            .and_then(Value::as_str),
-        Some("gpt-5.5-codex")
-    );
+    assert!(models.is_empty());
 }
 
 #[test]
@@ -186,11 +149,7 @@ fn serialize_models_response_does_not_invent_codex_image_tool_model() {
         .and_then(Value::as_array)
         .expect("models array");
 
-    assert_eq!(models.len(), 1);
-    assert_eq!(
-        models[0].get("slug").and_then(Value::as_str),
-        Some("gpt-5.4-mini")
-    );
+    assert!(models.is_empty());
 }
 
 #[test]

--- a/crates/service/src/gateway/request/tests/local_models_tests.rs
+++ b/crates/service/src/gateway/request/tests/local_models_tests.rs
@@ -60,13 +60,29 @@ fn serialize_models_response_outputs_codex_and_api_shapes() {
         .get("models")
         .and_then(Value::as_array)
         .expect("models array");
-    assert!(models.is_empty());
+    assert_eq!(models.len(), 2);
+    assert_eq!(
+        models[0].get("slug").and_then(Value::as_str),
+        Some("gpt-5.3-codex")
+    );
+    assert_eq!(
+        models[1].get("slug").and_then(Value::as_str),
+        Some("gpt-4o")
+    );
+    assert_eq!(
+        models[0].get("display_name").and_then(Value::as_str),
+        Some("GPT-5.3 Codex")
+    );
+    assert_eq!(
+        models[1].get("visibility").and_then(Value::as_str),
+        Some("list")
+    );
     assert_eq!(value.as_object().map(|object| object.len()), Some(3));
     assert!(value.get("etag").is_none());
 }
 
 #[test]
-fn serialize_models_response_preserves_description_for_api_clients() {
+fn serialize_models_response_preserves_description_for_codex_and_api_clients() {
     let items = ModelsResponse {
         models: vec![ModelInfo {
             slug: "gpt-5.3-codex".to_string(),
@@ -89,7 +105,11 @@ fn serialize_models_response_preserves_description_for_api_clients() {
         .get("data")
         .and_then(Value::as_array)
         .expect("OpenAI-compatible data array");
-    assert!(models.is_empty());
+    assert_eq!(models.len(), 1);
+    assert_eq!(
+        models[0].get("description").and_then(Value::as_str),
+        Some("Latest frontier agentic coding model.")
+    );
     assert_eq!(
         data[0].get("description").and_then(Value::as_str),
         Some("Latest frontier agentic coding model.")
@@ -97,7 +117,7 @@ fn serialize_models_response_preserves_description_for_api_clients() {
 }
 
 #[test]
-fn serialize_models_response_uses_embedded_codex_catalog_for_version_compatibility() {
+fn serialize_models_response_preserves_service_tier_capabilities_for_codex_clients() {
     let items = ModelsResponse {
         models: vec![ModelInfo {
             slug: "gpt-5.5-codex".to_string(),
@@ -126,7 +146,24 @@ fn serialize_models_response_uses_embedded_codex_catalog_for_version_compatibili
         .and_then(Value::as_array)
         .expect("models array");
 
-    assert!(models.is_empty());
+    assert_eq!(
+        models[0]["service_tiers"][0]
+            .get("id")
+            .and_then(Value::as_str),
+        Some("flex")
+    );
+    assert_eq!(
+        models[0]
+            .get("default_service_tier")
+            .and_then(Value::as_str),
+        Some("flex")
+    );
+    assert_eq!(
+        models[0]["upgrade_info"]
+            .get("model")
+            .and_then(Value::as_str),
+        Some("gpt-5.5-codex")
+    );
 }
 
 #[test]
@@ -149,7 +186,11 @@ fn serialize_models_response_does_not_invent_codex_image_tool_model() {
         .and_then(Value::as_array)
         .expect("models array");
 
-    assert!(models.is_empty());
+    assert_eq!(models.len(), 1);
+    assert_eq!(
+        models[0].get("slug").and_then(Value::as_str),
+        Some("gpt-5.4-mini")
+    );
 }
 
 #[test]

--- a/crates/service/src/gateway/upstream/headers/codex_headers.rs
+++ b/crates/service/src/gateway/upstream/headers/codex_headers.rs
@@ -5,6 +5,8 @@ const X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER_NAME: &str =
     "x-responsesapi-include-timing-metrics";
 const X_CODEX_INFERENCE_CALL_ID_HEADER_NAME: &str = "x-codex-inference-call-id";
 const X_OAI_ATTESTATION_HEADER_NAME: &str = "x-oai-attestation";
+const X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER_NAME: &str =
+    "x-openai-internal-codex-responses-lite";
 
 fn anchor_fingerprint_or_dash(value: Option<&str>) -> String {
     value
@@ -420,13 +422,18 @@ fn resolve_window_id(
 fn append_passthrough_codex_headers(
     headers: &mut Vec<(String, String)>,
     passthrough_headers: &[(String, String)],
-    enabled: bool,
+    _enabled: bool,
 ) {
-    // 中文注释：Codex wire shape 不接受额外透传头；这里保留参数只为兼容调用签名，
-    // 但实际行为是完全丢弃。
-    let _ = headers;
-    let _ = passthrough_headers;
-    let _ = enabled;
+    for (name, value) in passthrough_headers {
+        if !name.eq_ignore_ascii_case(X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER_NAME)
+            || headers
+                .iter()
+                .any(|(existing, _)| existing.eq_ignore_ascii_case(name))
+        {
+            continue;
+        }
+        headers.push((name.clone(), value.clone()));
+    }
 }
 
 /// 函数 `resolve_client_request_id`

--- a/crates/service/src/gateway/upstream/headers/codex_headers_tests.rs
+++ b/crates/service/src/gateway/upstream/headers/codex_headers_tests.rs
@@ -114,10 +114,16 @@ fn build_codex_upstream_headers_keeps_final_affinity_shape() {
     let _guard = crate::test_env_guard();
     let _ = set_originator("codex_cli_rs_tests").expect("set originator");
     let _ = set_codex_user_agent_version("0.999.0").expect("set ua version");
-    let passthrough = vec![(
-        "x-codex-other-limit-name".to_string(),
-        "promo_header_a".to_string(),
-    )];
+    let passthrough = vec![
+        (
+            "x-codex-other-limit-name".to_string(),
+            "promo_header_a".to_string(),
+        ),
+        (
+            "x-openai-internal-codex-responses-lite".to_string(),
+            "true".to_string(),
+        ),
+    ];
 
     let headers = build_codex_upstream_headers(CodexUpstreamHeaderInput {
         auth_token: "token-123",
@@ -204,6 +210,10 @@ fn build_codex_upstream_headers_keeps_final_affinity_shape() {
         Some("thread-parent-a")
     );
     assert_eq!(header_value(&headers, "x-codex-other-limit-name"), None);
+    assert_eq!(
+        header_value(&headers, "x-openai-internal-codex-responses-lite"),
+        Some("true")
+    );
 }
 
 /// 函数 `build_codex_upstream_headers_clears_turn_state_when_affinity_diverges`

--- a/crates/service/src/http/proxy_runtime.rs
+++ b/crates/service/src/http/proxy_runtime.rs
@@ -1,10 +1,12 @@
 use axum::body::{to_bytes, Body};
 use axum::extract::State;
-use axum::http::{header, Request as HttpRequest, Response, StatusCode};
+use axum::http::{header, HeaderMap, Request as HttpRequest, Response, StatusCode};
 use axum::routing::{any, get, post};
 use axum::Router;
+use bytes::Bytes;
 use reqwest::Client;
 use std::io;
+use std::io::Read;
 
 use crate::http::proxy_bridge::run_proxy_server;
 use crate::http::proxy_request::{build_target_url, filter_request_headers};
@@ -100,6 +102,79 @@ fn front_proxy_worker_threads() -> usize {
     .max(1)
 }
 
+#[derive(Debug)]
+struct IncomingBodyDecodeError {
+    status: StatusCode,
+    message: String,
+}
+
+fn has_zstd_content_encoding(headers: &HeaderMap) -> bool {
+    headers
+        .get_all(header::CONTENT_ENCODING)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .any(|value| value.trim().eq_ignore_ascii_case("zstd"))
+}
+
+fn has_zstd_magic(body: &[u8]) -> bool {
+    body.starts_with(&[0x28, 0xB5, 0x2F, 0xFD])
+}
+
+fn decode_zstd_body(
+    body: &[u8],
+    max_body_bytes: usize,
+) -> Result<Vec<u8>, IncomingBodyDecodeError> {
+    let decoder =
+        zstd::stream::read::Decoder::new(body).map_err(|err| IncomingBodyDecodeError {
+            status: StatusCode::BAD_REQUEST,
+            message: crate::gateway::bilingual_error(
+                "zstd 请求体解压失败",
+                format!("invalid zstd request body: {err}"),
+            ),
+        })?;
+    let mut decoded = Vec::new();
+    let read_result = if max_body_bytes == 0 {
+        let mut decoder = decoder;
+        decoder.read_to_end(&mut decoded)
+    } else {
+        let mut limited = decoder.take(max_body_bytes.saturating_add(1) as u64);
+        limited.read_to_end(&mut decoded)
+    };
+    read_result.map_err(|err| IncomingBodyDecodeError {
+        status: StatusCode::BAD_REQUEST,
+        message: crate::gateway::bilingual_error(
+            "zstd 请求体解压失败",
+            format!("invalid zstd request body: {err}"),
+        ),
+    })?;
+    if max_body_bytes > 0 && decoded.len() > max_body_bytes {
+        return Err(IncomingBodyDecodeError {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            message: crate::gateway::bilingual_error(
+                "请求体过大",
+                format!("request body too large after zstd decompression: >{max_body_bytes}"),
+            ),
+        });
+    }
+    Ok(decoded)
+}
+
+fn normalize_incoming_request_body(
+    headers: &mut HeaderMap,
+    body: Bytes,
+    max_body_bytes: usize,
+) -> Result<Bytes, IncomingBodyDecodeError> {
+    if body.is_empty() || (!has_zstd_content_encoding(headers) && !has_zstd_magic(body.as_ref())) {
+        return Ok(body);
+    }
+
+    let decoded = decode_zstd_body(body.as_ref(), max_body_bytes)?;
+    headers.remove(header::CONTENT_ENCODING);
+    headers.remove(header::CONTENT_LENGTH);
+    Ok(Bytes::from(decoded))
+}
+
 /// 函数 `proxy_handler`
 ///
 /// 作者: gaohongshun
@@ -144,7 +219,7 @@ async fn proxy_handler(
         }
     }
 
-    let outbound_headers = filter_request_headers(&parts.headers);
+    let mut outbound_headers = filter_request_headers(&parts.headers);
     let read_limit = if max_body_bytes == 0 {
         usize::MAX
     } else {
@@ -172,6 +247,26 @@ async fn proxy_handler(
             );
         }
     };
+    let encoded_body_bytes = body_bytes.len();
+    let body_bytes =
+        match normalize_incoming_request_body(&mut outbound_headers, body_bytes, max_body_bytes) {
+            Ok(body) => body,
+            Err(err) => {
+                log_proxy_error(err.status, target_url.as_str(), err.message.as_str());
+                return text_error_response(
+                    err.status,
+                    crate::gateway::error_message_for_client(prefer_raw_errors, err.message),
+                );
+            }
+        };
+    if body_bytes.len() != encoded_body_bytes {
+        log::info!(
+            "event=front_proxy_request_decompressed path={} algorithm=zstd pre_bytes={} post_bytes={}",
+            parts.uri.path(),
+            encoded_body_bytes,
+            body_bytes.len()
+        );
+    }
 
     let mut builder = state.client.request(parts.method, target_url.as_str());
     builder = builder.headers(outbound_headers);

--- a/crates/service/src/http/proxy_runtime.rs
+++ b/crates/service/src/http/proxy_runtime.rs
@@ -14,8 +14,13 @@ use crate::http::proxy_response::{merge_upstream_headers, text_error_response};
 
 const DEFAULT_FRONT_PROXY_MAX_BLOCKING_THREADS: usize = 32;
 const DEFAULT_FRONT_PROXY_WORKER_THREADS: usize = 2;
+const ZSTD_MAX_BODY_BYTES: usize = 64 * 1024 * 1024;
+const ZSTD_MAX_CONCURRENT_DECODES: usize = 4;
 const ENV_FRONT_PROXY_MAX_BLOCKING_THREADS: &str = "CODEXMANAGER_FRONT_PROXY_MAX_BLOCKING_THREADS";
 const ENV_FRONT_PROXY_WORKER_THREADS: &str = "CODEXMANAGER_FRONT_PROXY_WORKER_THREADS";
+
+static ZSTD_DECODE_SEMAPHORE: tokio::sync::Semaphore =
+    tokio::sync::Semaphore::const_new(ZSTD_MAX_CONCURRENT_DECODES);
 
 #[derive(Clone)]
 struct ProxyState {
@@ -121,10 +126,28 @@ fn has_zstd_magic(body: &[u8]) -> bool {
     body.starts_with(&[0x28, 0xB5, 0x2F, 0xFD])
 }
 
-fn decode_zstd_body(
-    body: &[u8],
-    max_body_bytes: usize,
-) -> Result<Vec<u8>, IncomingBodyDecodeError> {
+fn zstd_body_limit(max_body_bytes: usize) -> usize {
+    if max_body_bytes == 0 {
+        ZSTD_MAX_BODY_BYTES
+    } else {
+        max_body_bytes.min(ZSTD_MAX_BODY_BYTES)
+    }
+}
+
+fn try_acquire_zstd_decode_permit(
+) -> Result<tokio::sync::SemaphorePermit<'static>, IncomingBodyDecodeError> {
+    ZSTD_DECODE_SEMAPHORE
+        .try_acquire()
+        .map_err(|_| IncomingBodyDecodeError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: crate::gateway::bilingual_error(
+                "zstd 解压任务繁忙",
+                "zstd request decoder is busy; retry later",
+            ),
+        })
+}
+
+fn decode_zstd_body(body: &[u8], decode_limit: usize) -> Result<Vec<u8>, IncomingBodyDecodeError> {
     let decoder =
         zstd::stream::read::Decoder::new(body).map_err(|err| IncomingBodyDecodeError {
             status: StatusCode::BAD_REQUEST,
@@ -134,13 +157,8 @@ fn decode_zstd_body(
             ),
         })?;
     let mut decoded = Vec::new();
-    let read_result = if max_body_bytes == 0 {
-        let mut decoder = decoder;
-        decoder.read_to_end(&mut decoded)
-    } else {
-        let mut limited = decoder.take(max_body_bytes.saturating_add(1) as u64);
-        limited.read_to_end(&mut decoded)
-    };
+    let mut limited = decoder.take(decode_limit.saturating_add(1) as u64);
+    let read_result = limited.read_to_end(&mut decoded);
     read_result.map_err(|err| IncomingBodyDecodeError {
         status: StatusCode::BAD_REQUEST,
         message: crate::gateway::bilingual_error(
@@ -148,28 +166,45 @@ fn decode_zstd_body(
             format!("invalid zstd request body: {err}"),
         ),
     })?;
-    if max_body_bytes > 0 && decoded.len() > max_body_bytes {
+    if decoded.len() > decode_limit {
         return Err(IncomingBodyDecodeError {
             status: StatusCode::PAYLOAD_TOO_LARGE,
             message: crate::gateway::bilingual_error(
                 "请求体过大",
-                format!("request body too large after zstd decompression: >{max_body_bytes}"),
+                format!("request body too large after zstd decompression: >{decode_limit}"),
             ),
         });
     }
     Ok(decoded)
 }
 
-fn normalize_incoming_request_body(
+async fn normalize_incoming_request_body(
     headers: &mut HeaderMap,
     body: Bytes,
     max_body_bytes: usize,
+    decode_permit: Option<tokio::sync::SemaphorePermit<'static>>,
 ) -> Result<Bytes, IncomingBodyDecodeError> {
     if body.is_empty() || (!has_zstd_content_encoding(headers) && !has_zstd_magic(body.as_ref())) {
         return Ok(body);
     }
 
-    let decoded = decode_zstd_body(body.as_ref(), max_body_bytes)?;
+    let permit = match decode_permit {
+        Some(permit) => permit,
+        None => try_acquire_zstd_decode_permit()?,
+    };
+    let decode_limit = zstd_body_limit(max_body_bytes);
+    let decoded = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        decode_zstd_body(body.as_ref(), decode_limit)
+    })
+    .await
+    .map_err(|err| IncomingBodyDecodeError {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        message: crate::gateway::bilingual_error(
+            "zstd 解压任务失败",
+            format!("zstd request decoder task failed: {err}"),
+        ),
+    })??;
     headers.remove(header::CONTENT_ENCODING);
     headers.remove(header::CONTENT_LENGTH);
     Ok(Bytes::from(decoded))
@@ -195,6 +230,26 @@ async fn proxy_handler(
     let prefer_raw_errors = crate::gateway::prefers_raw_errors_for_http_headers(&parts.headers);
     let target_url = build_target_url(&state.backend_base_url, &parts.uri);
     let max_body_bytes = crate::gateway::front_proxy_max_body_bytes();
+    let declared_zstd = has_zstd_content_encoding(&parts.headers);
+    let zstd_decode_permit = if declared_zstd {
+        match try_acquire_zstd_decode_permit() {
+            Ok(permit) => Some(permit),
+            Err(err) => {
+                log_proxy_error(err.status, target_url.as_str(), err.message.as_str());
+                return text_error_response(
+                    err.status,
+                    crate::gateway::error_message_for_client(prefer_raw_errors, err.message),
+                );
+            }
+        }
+    } else {
+        None
+    };
+    let request_body_limit = if declared_zstd {
+        zstd_body_limit(max_body_bytes)
+    } else {
+        max_body_bytes
+    };
 
     if let Some(content_length) = parts
         .headers
@@ -202,7 +257,7 @@ async fn proxy_handler(
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.trim().parse::<u64>().ok())
     {
-        if max_body_bytes > 0 && content_length > max_body_bytes as u64 {
+        if request_body_limit > 0 && content_length > request_body_limit as u64 {
             let message = crate::gateway::bilingual_error(
                 "请求体过大",
                 format!("request body too large: content-length={content_length}"),
@@ -220,20 +275,20 @@ async fn proxy_handler(
     }
 
     let mut outbound_headers = filter_request_headers(&parts.headers);
-    let read_limit = if max_body_bytes == 0 {
+    let read_limit = if request_body_limit == 0 {
         usize::MAX
     } else {
-        max_body_bytes
+        request_body_limit
     };
     let body_bytes = match to_bytes(body, read_limit).await {
         Ok(bytes) => bytes,
         Err(_) => {
-            let message = if max_body_bytes == 0 {
+            let message = if request_body_limit == 0 {
                 crate::gateway::bilingual_error("请求体过大", "request body too large")
             } else {
                 crate::gateway::bilingual_error(
                     "请求体过大",
-                    format!("request body too large: content-length>{max_body_bytes}"),
+                    format!("request body too large: content-length>{request_body_limit}"),
                 )
             };
             log_proxy_error(
@@ -248,17 +303,23 @@ async fn proxy_handler(
         }
     };
     let encoded_body_bytes = body_bytes.len();
-    let body_bytes =
-        match normalize_incoming_request_body(&mut outbound_headers, body_bytes, max_body_bytes) {
-            Ok(body) => body,
-            Err(err) => {
-                log_proxy_error(err.status, target_url.as_str(), err.message.as_str());
-                return text_error_response(
-                    err.status,
-                    crate::gateway::error_message_for_client(prefer_raw_errors, err.message),
-                );
-            }
-        };
+    let body_bytes = match normalize_incoming_request_body(
+        &mut outbound_headers,
+        body_bytes,
+        max_body_bytes,
+        zstd_decode_permit,
+    )
+    .await
+    {
+        Ok(body) => body,
+        Err(err) => {
+            log_proxy_error(err.status, target_url.as_str(), err.message.as_str());
+            return text_error_response(
+                err.status,
+                crate::gateway::error_message_for_client(prefer_raw_errors, err.message),
+            );
+        }
+    };
     if body_bytes.len() != encoded_body_bytes {
         log::info!(
             "event=front_proxy_request_decompressed path={} algorithm=zstd pre_bytes={} post_bytes={}",

--- a/crates/service/src/http/tests/proxy_runtime_tests.rs
+++ b/crates/service/src/http/tests/proxy_runtime_tests.rs
@@ -1,10 +1,11 @@
 use super::{
     build_backend_base_url, build_local_backend_client, front_proxy_max_blocking_threads,
-    front_proxy_worker_threads, proxy_handler, ProxyState,
+    front_proxy_worker_threads, normalize_incoming_request_body, proxy_handler, ProxyState,
 };
 use axum::body::{to_bytes, Body};
 use axum::extract::State;
-use axum::http::{Request as HttpRequest, StatusCode};
+use axum::http::{header, HeaderMap, HeaderValue, Request as HttpRequest, StatusCode};
+use bytes::Bytes;
 use codexmanager_core::storage::{Account, ApiKey, Storage, Token, UsageSnapshotRecord};
 use futures_util::{SinkExt, StreamExt};
 use reqwest::Client;
@@ -140,6 +141,81 @@ fn front_proxy_worker_threads_allow_explicit_override() {
     let _worker_guard = EnvGuard::set("CODEXMANAGER_FRONT_PROXY_WORKER_THREADS", "3");
 
     assert_eq!(front_proxy_worker_threads(), 3);
+}
+
+#[test]
+fn zstd_request_body_is_decoded_and_transport_headers_are_removed() {
+    let plain = br#"{"model":"gpt-5.6-sol","input":"long resume"}"#;
+    let compressed =
+        zstd::stream::encode_all(std::io::Cursor::new(plain), 3).expect("compress request body");
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_ENCODING, HeaderValue::from_static("zstd"));
+    headers.insert(
+        header::CONTENT_LENGTH,
+        HeaderValue::from_str(compressed.len().to_string().as_str()).expect("content length"),
+    );
+
+    let decoded = normalize_incoming_request_body(
+        &mut headers,
+        Bytes::from(compressed),
+        /*max_body_bytes*/ 0,
+    )
+    .expect("decode zstd request body");
+
+    assert_eq!(decoded.as_ref(), plain);
+    assert!(!headers.contains_key(header::CONTENT_ENCODING));
+    assert!(!headers.contains_key(header::CONTENT_LENGTH));
+}
+
+#[test]
+fn zstd_magic_is_decoded_when_intermediate_proxy_drops_encoding_header() {
+    let plain = br#"{"model":"gpt-5.6-sol","stream":true}"#;
+    let compressed =
+        zstd::stream::encode_all(std::io::Cursor::new(plain), 3).expect("compress request body");
+    let mut headers = HeaderMap::new();
+
+    let decoded = normalize_incoming_request_body(
+        &mut headers,
+        Bytes::from(compressed),
+        /*max_body_bytes*/ 0,
+    )
+    .expect("decode zstd request body from magic");
+
+    assert_eq!(decoded.as_ref(), plain);
+}
+
+#[test]
+fn invalid_zstd_request_body_returns_400() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_ENCODING, HeaderValue::from_static("zstd"));
+
+    let err = normalize_incoming_request_body(
+        &mut headers,
+        Bytes::from_static(b"not-zstd"),
+        /*max_body_bytes*/ 0,
+    )
+    .expect_err("invalid zstd should fail locally");
+
+    assert_eq!(err.status, StatusCode::BAD_REQUEST);
+    assert!(err.message.contains("invalid zstd request body"));
+}
+
+#[test]
+fn decompressed_zstd_request_body_respects_front_proxy_limit() {
+    let compressed = zstd::stream::encode_all(std::io::Cursor::new(vec![b'x'; 64]), 3)
+        .expect("compress request body");
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_ENCODING, HeaderValue::from_static("zstd"));
+
+    let err = normalize_incoming_request_body(
+        &mut headers,
+        Bytes::from(compressed),
+        /*max_body_bytes*/ 32,
+    )
+    .expect_err("decoded body above limit should fail locally");
+
+    assert_eq!(err.status, StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(err.message.contains("after zstd decompression"));
 }
 
 /// 函数 `request_without_content_length_over_limit_returns_413`

--- a/crates/service/src/http/tests/proxy_runtime_tests.rs
+++ b/crates/service/src/http/tests/proxy_runtime_tests.rs
@@ -1,6 +1,7 @@
 use super::{
     build_backend_base_url, build_local_backend_client, front_proxy_max_blocking_threads,
-    front_proxy_worker_threads, normalize_incoming_request_body, proxy_handler, ProxyState,
+    front_proxy_worker_threads, normalize_incoming_request_body, proxy_handler, zstd_body_limit,
+    IncomingBodyDecodeError, ProxyState, ZSTD_MAX_BODY_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::extract::State;
@@ -72,6 +73,23 @@ impl Drop for EnvGuard {
             std::env::remove_var(self.key);
         }
     }
+}
+
+fn normalize_body_for_test(
+    headers: &mut HeaderMap,
+    body: Bytes,
+    max_body_bytes: usize,
+) -> Result<Bytes, IncomingBodyDecodeError> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("zstd test runtime")
+        .block_on(normalize_incoming_request_body(
+            headers,
+            body,
+            max_body_bytes,
+            None,
+        ))
 }
 
 /// 函数 `backend_base_url_uses_http_scheme`
@@ -155,7 +173,7 @@ fn zstd_request_body_is_decoded_and_transport_headers_are_removed() {
         HeaderValue::from_str(compressed.len().to_string().as_str()).expect("content length"),
     );
 
-    let decoded = normalize_incoming_request_body(
+    let decoded = normalize_body_for_test(
         &mut headers,
         Bytes::from(compressed),
         /*max_body_bytes*/ 0,
@@ -174,7 +192,7 @@ fn zstd_magic_is_decoded_when_intermediate_proxy_drops_encoding_header() {
         zstd::stream::encode_all(std::io::Cursor::new(plain), 3).expect("compress request body");
     let mut headers = HeaderMap::new();
 
-    let decoded = normalize_incoming_request_body(
+    let decoded = normalize_body_for_test(
         &mut headers,
         Bytes::from(compressed),
         /*max_body_bytes*/ 0,
@@ -189,7 +207,7 @@ fn invalid_zstd_request_body_returns_400() {
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_ENCODING, HeaderValue::from_static("zstd"));
 
-    let err = normalize_incoming_request_body(
+    let err = normalize_body_for_test(
         &mut headers,
         Bytes::from_static(b"not-zstd"),
         /*max_body_bytes*/ 0,
@@ -207,7 +225,7 @@ fn decompressed_zstd_request_body_respects_front_proxy_limit() {
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_ENCODING, HeaderValue::from_static("zstd"));
 
-    let err = normalize_incoming_request_body(
+    let err = normalize_body_for_test(
         &mut headers,
         Bytes::from(compressed),
         /*max_body_bytes*/ 32,
@@ -216,6 +234,41 @@ fn decompressed_zstd_request_body_respects_front_proxy_limit() {
 
     assert_eq!(err.status, StatusCode::PAYLOAD_TOO_LARGE);
     assert!(err.message.contains("after zstd decompression"));
+}
+
+#[test]
+fn zstd_body_limit_is_always_bounded() {
+    assert_eq!(zstd_body_limit(0), ZSTD_MAX_BODY_BYTES);
+    assert_eq!(zstd_body_limit(32), 32);
+    assert_eq!(zstd_body_limit(usize::MAX), ZSTD_MAX_BODY_BYTES);
+}
+
+#[test]
+fn zero_front_proxy_limit_rejects_oversized_declared_zstd_body() {
+    let _guard = crate::test_env_guard();
+    let _ = crate::gateway::front_proxy_max_body_bytes();
+    let _body_limit_guard = EnvGuard::set("CODEXMANAGER_FRONT_PROXY_MAX_BODY_BYTES", "0");
+    crate::gateway::reload_runtime_config_from_env();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let state = ProxyState {
+        backend_base_url: "http://127.0.0.1:1".to_string(),
+        client: build_local_backend_client().expect("client"),
+    };
+    let oversized = ZSTD_MAX_BODY_BYTES.saturating_add(1);
+    let request = HttpRequest::builder()
+        .method("POST")
+        .uri("/v1/responses")
+        .header(header::CONTENT_ENCODING, "zstd")
+        .header(header::CONTENT_LENGTH, oversized.to_string())
+        .body(Body::empty())
+        .expect("request");
+
+    let response = runtime.block_on(proxy_handler(State(state), request));
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }
 
 /// 函数 `request_without_content_length_over_limit_returns_413`

--- a/crates/service/tests/app_settings.rs
+++ b/crates/service/tests/app_settings.rs
@@ -1263,6 +1263,7 @@ fn sync_runtime_settings_from_storage_applies_saved_runtime_values() {
                 .and_then(|value| value.as_str()),
             Some("spark*=gpt-5.4-mini")
         );
+        assert!(!codexmanager_service::current_gateway_request_compression_enabled());
         assert_eq!(
             snapshot
                 .get("gatewayOriginator")


### PR DESCRIPTION
## 变更摘要

### 问题现象

- Codex 使用 ChatGPT 账号登录、同时把自定义 provider 指向 Codex Manager 时，**provider 显示名需要保持为 `OpenAI` 才会启用原生 WebSearch、ImageGen 等能力。**
- 而目前在provider显示名为`OpenAI`时，Codex 会向 Codex Manager 的最外层 HTTP 代理发送 `Content-Encoding: zstd` 的请求体。当前代理直接转发压缩字节，内部 gateway 随后按 JSON 读取；重建上游请求头时又没有保留对应编码，最终会出现：
  - `model` 和 request shape 解析为空；
  - 压缩字节被当作文本估算，日志中出现约 200 万 input token 的异常值；
  - 上游收到“声明为 JSON、内容实际为 zstd”的请求，返回 404/502；
  - 原生 WebSearch、ImageGen 以及超长会话续写失败。
- 此外还有三处协议兼容缺口：
  - 已保存的 `gateway.request_compression_enabled` 在进程重启时没有同步回 runtime；
  - `x-openai-internal-codex-responses-lite` 协议协商头会被通用头过滤逻辑丢弃；
  - `/v1/models` 返回的私有 `models` 扩展元数据可能落后于 Codex 内置 CLI 的 schema，旧元数据会覆盖客户端自带的版本匹配模型目录，导致原生工具能力缺失。

### 解决方法

1. **在 front proxy 边界规范化 zstd 请求体**
   - 同时识别 `Content-Encoding: zstd` 和 zstd frame magic `28 b5 2f fd`，兼容中间代理丢失编码头的情况；
   - 解压后再交给内部 gateway，并移除旧的 `Content-Encoding`、`Content-Length`；
   - 对解压后的大小继续应用 `front_proxy_max_body_bytes`，避免压缩体绕过请求体限制；
   - 损坏的 zstd 在本地返回 400，解压后超限返回 413；
   - 仅记录压缩前后字节数，不记录请求正文：`event=front_proxy_request_decompressed`。
2. **恢复持久化传输设置**
   - 启动同步 runtime settings 时，在没有显式 `CODEXMANAGER_ENABLE_REQUEST_COMPRESSION` 环境变量的前提下，恢复数据库中的请求压缩开关。
3. **精确透传 Responses Lite 协议头**
   - 只允许 `x-openai-internal-codex-responses-lite` 进入并透传到 Codex upstream；其他未知 `x-codex-*` / 协议头仍保持拦截，避免扩大透传面。
4. **避免私有模型 schema 覆盖客户端内置目录**
   - `/v1/models` 的标准 OpenAI-compatible `data` 列表保持完整；
   - 私有 `models` 扩展返回空数组，让各版本 Codex 使用自身携带、与 CLI 版本匹配的模型元数据。

### 效果

- Codex 可以继续使用 ChatGPT 账号登录和原生会话能力，主模型请求仍经 Codex Manager 转发，同时恢复原生 WebSearch 与 ImageGen。
- ImageGen 实机回归严格请求 `gpt-image-2` 并返回有效 PNG。
- 精确复放故障前长会话时，Codex -> CM 请求约 8.43 MB zstd，解压为约 12.42 MB JSON（526 个 input items）；模型可正确解析，CM -> upstream 不再携带压缩编码，turn 正常完成，404/502 为 0。
- HTTP 请求体压缩与 token 上下文压缩是两层独立机制；本改动没有改动 Codex 原生自动/手动 context compaction，相关回归保持通过。

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [x] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/http/proxy_runtime.rs`
- `crates/service/src/http/tests/proxy_runtime_tests.rs`
- `crates/service/src/app_settings/runtime_sync.rs`
- `crates/service/tests/app_settings.rs`
- `crates/service/src/gateway/request/incoming_headers.rs`
- `crates/service/src/gateway/request/local_models.rs`
- `crates/service/src/gateway/request/tests/incoming_headers_tests.rs`
- `crates/service/src/gateway/request/tests/local_models_tests.rs`
- `crates/service/src/gateway/upstream/headers/codex_headers.rs`
- `crates/service/src/gateway/upstream/headers/codex_headers_tests.rs`

## 验证

- [x] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
PASS  cargo fmt --all -- --check
PASS  pnpm -C apps run test
      108 passed
PASS  pnpm -C apps run build
      Next.js static export completed

PASS  cargo test -p codexmanager-service http::proxy_runtime::tests:: -- --test-threads=1
      18 passed（含 zstd header、magic fallback、损坏体 400、解压后超限 413）
PASS  cargo test -p codexmanager-service gateway::incoming_headers::tests:: -- --test-threads=1
      8 passed
PASS  cargo test -p codexmanager-service gateway::upstream::header_profile::headers_impl::codex_headers::tests:: -- --test-threads=1
      9 passed
PASS  cargo test -p codexmanager-service gateway::local_models::tests:: -- --test-threads=1
      6 passed
PASS  cargo test -p codexmanager-service --lib -- --test-threads=1
      1048 passed
PASS  cargo test -p codexmanager-service --test app_settings -- --test-threads=1
      29 passed
PASS  cargo test -p codexmanager-service --test gateway_logs -- --test-threads=1
      30 passed

PASS  cargo test --workspace -- --test-threads=1 --skip rpc_chatgpt_auth_tokens_login_enqueues_usage_refresh
      1588 passed，0 failed；仅跳过下述 main 基线抖动用例

PASS  隔离端到端回归（同一修复逻辑）
      - 原生 WebSearch 返回真实搜索结果
      - 原生 ImageGen 使用 gpt-image-2 并返回有效 1536x1024 PNG
      - 自动/手动 context compaction 与 remote compaction 通过
      - 精确长会话复放连续 3 轮完成，0 次 404/502
```

`cargo test --workspace` 的完整命令已实际执行；本 PR 涉及的测试以及 Service lib 全部通过，但仓库当前 main 的既有异步测试 `rpc_chatgpt_auth_tokens_login_enqueues_usage_refresh` 会间歇出现 Tokio runtime drop / 等待 usage snapshot 超时。该失败已在未应用本 PR 的干净 `main`（`3e38d2a3`）上用单测命令独立复现，因此上方 workspace 复验跳过了这一项。

未执行的验证与原因：

```text
pnpm -C apps run test:ui
本 PR 没有前端、交互或导航改动；已执行前端 runtime test 与 production build。
```

## 风险与影响面

- zstd 解压发生在 front proxy，请求会产生对应的 CPU 与解压后内存开销；解压输出受现有 body limit 约束，超限会在进入内部 gateway 前返回 413。
- 通过 zstd magic 进行兜底识别仅作用于具有标准 frame magic 的二进制体；普通 JSON 不会命中。
- 私有 `models` 扩展改为空数组后，依赖该非标准字段的客户端会改用自身默认目录；标准 `/v1/models.data` 仍完整保留，因此 OpenAI-compatible 客户端的模型枚举不受影响。
- Responses Lite 仅增加一个精确 allowlist 项，其他未知协议头仍不透传。
- 不涉及前端、Tauri、数据库 schema、认证 token 存储或已安装 App 文件。

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
- 本变更未新增依赖；workspace 已有 `zstd`。

## 截图

截图表明目前在provider显示名为`OpenAI`时，可正常使用官方WebSocket和ImageGen请求。

<img width="793" height="367" alt="截屏2026-07-19 11 12 54" src="https://github.com/user-attachments/assets/f8335d7a-4f4b-467b-b730-81ca6d956c08" />
<img width="790" height="819" alt="截屏2026-07-19 11 12 47" src="https://github.com/user-attachments/assets/f891ed75-d1b3-4568-85c7-c4a3361ec519" />
<img width="408" height="121" alt="截屏2026-07-19 11 09 49" src="https://github.com/user-attachments/assets/b6f7b7b0-fcb5-455f-b715-ba059e65c810" />

