### PR TITLE
fix: update codex guide step button styles for better text wrapping / 更新 Codex 引导中的字体包裹行为

### DIFF
--- a/apps/src/app/globals.css
+++ b/apps/src/app/globals.css
@@ -643,6 +643,12 @@
   box-shadow: inset 0 0 0 1px rgb(var(--primary-rgb) / 0.12), 0 10px 22px -20px rgb(var(--primary-rgb) / 0.36);
 }
 
+.codex-guide-step-button,
+.codex-guide-step-button * {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 [data-slot="badge"] {
   border-color: rgb(var(--primary-rgb) / 0.2);
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08);

--- a/apps/src/components/layout/codex-cli-onboarding-dialog.tsx
+++ b/apps/src/components/layout/codex-cli-onboarding-dialog.tsx
@@ -276,7 +276,7 @@ export function CodexCliOnboardingDialog({
                         variant="outline"
                         onClick={() => setCurrentStep(index)}
                         className={cn(
-                          "h-auto min-w-0 flex-col items-start justify-start gap-0 overflow-hidden rounded-md px-3 py-2.5 text-left whitespace-normal transition-colors",
+                          "codex-guide-step-button h-auto min-w-0 flex-col items-start justify-start gap-0 overflow-hidden rounded-md px-3 py-2.5 text-left whitespace-normal transition-colors",
                           index === currentStep
                             ? "border-primary/30 bg-primary/10 text-foreground shadow-sm"
                             : "border-border/60 bg-background/70 text-muted-foreground hover:bg-accent/50",


### PR DESCRIPTION
## 变更摘要

原有：

<img width="769" height="520" alt="image" src="https://github.com/user-attachments/assets/b5505cf5-9349-43d8-8ab9-5974ebaeefd2" />

现在：

<img width="735" height="514" alt="image" src="https://github.com/user-attachments/assets/3e28ad80-f6ef-479a-9fd2-743b077ad45e" />

## 改动范围

- [x] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- 

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [ ] 其他本地验证已说明

已执行的实际验证：

```text

```

未执行的验证与原因：

```text

```

## 风险与影响面

- 

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
