### PR TITLE
修复 Responses Lite 与图片工具自动注入冲突

### DIFF
--- a/crates/service/src/gateway/upstream/headers/codex_headers.rs
+++ b/crates/service/src/gateway/upstream/headers/codex_headers.rs
@@ -431,6 +431,7 @@ fn append_passthrough_codex_headers(
 ) {
     for (name, value) in passthrough_headers {
         if !name.eq_ignore_ascii_case(X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER_NAME)
+            || crate::gateway::runtime_config::codex_image_generation_auto_inject_tool_enabled()
             || headers
                 .iter()
                 .any(|(existing, _)| existing.eq_ignore_ascii_case(name))

--- a/crates/service/src/gateway/upstream/headers/codex_headers_tests.rs
+++ b/crates/service/src/gateway/upstream/headers/codex_headers_tests.rs
@@ -9,6 +9,8 @@ use crate::gateway::{
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const CODEXMANAGER_DB_PATH_ENV: &str = "CODEXMANAGER_DB_PATH";
+const CODEX_IMAGE_GENERATION_AUTO_INJECT_TOOL_ENV: &str =
+    "CODEXMANAGER_CODEX_IMAGE_GENERATION_AUTO_INJECT_TOOL";
 
 struct RuntimeEnvGuard {
     name: &'static str,
@@ -219,6 +221,45 @@ fn build_codex_upstream_headers_keeps_final_affinity_shape() {
     assert_eq!(
         header_value(&headers, "x-openai-internal-codex-responses-lite"),
         Some("true")
+    );
+}
+
+#[test]
+fn build_codex_upstream_headers_omits_responses_lite_when_image_tool_is_auto_injected() {
+    let _guard = crate::test_env_guard();
+    let _inject_guard = RuntimeEnvGuard::set(CODEX_IMAGE_GENERATION_AUTO_INJECT_TOOL_ENV, "1");
+    let passthrough = vec![(
+        "x-openai-internal-codex-responses-lite".to_string(),
+        "true".to_string(),
+    )];
+
+    let headers = build_codex_upstream_headers(CodexUpstreamHeaderInput {
+        auth_token: "token-123",
+        chatgpt_account_id: Some("account-123"),
+        incoming_user_agent: None,
+        incoming_originator: None,
+        preserve_client_identity: false,
+        incoming_session_id: None,
+        incoming_window_id: None,
+        incoming_client_request_id: None,
+        incoming_subagent: None,
+        incoming_beta_features: None,
+        incoming_turn_metadata: None,
+        incoming_parent_thread_id: None,
+        incoming_responsesapi_include_timing_metrics: None,
+        incoming_inference_call_id: None,
+        incoming_oai_attestation: None,
+        passthrough_codex_headers: passthrough.as_slice(),
+        fallback_session_id: None,
+        incoming_turn_state: None,
+        include_turn_state: true,
+        strip_session_affinity: false,
+        has_body: true,
+    });
+
+    assert_eq!(
+        header_value(&headers, "x-openai-internal-codex-responses-lite"),
+        None
     );
 }
 


### PR DESCRIPTION
## 问题

当客户端带上 `X-OpenAI-Internal-Codex-Responses-Lite`，同时设置 `CODEXMANAGER_CODEX_IMAGE_GENERATION_AUTO_INJECT_TOOL=1` 时，网关会继续发送 Lite 请求头，并自动加入 `image_generation` 工具。上游 Lite 模式不支持该工具类型，因此返回 400：

```text
X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.
```

## 修改

- 图片工具自动注入开启时，不再向上游发送 Responses Lite 请求头。
- 自动注入关闭时，保持现有 Lite 请求头透传行为。
- 增加回归测试覆盖两种配置。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codexmanager-service --lib -- --test-threads=1`
- 结果：1154 passed，0 failed。
- macOS arm64 APP 与 DMG 构建成功。