### PR TITLE
fix: 修复混合轮转下模型仅配置聚合 API 路由仍请求账号池

### DIFF
--- a/crates/service/src/gateway/upstream/proxy.rs
+++ b/crates/service/src/gateway/upstream/proxy.rs
@@ -1,5 +1,6 @@
 use crate::apikey_profile::PROTOCOL_ANTHROPIC_NATIVE;
 use crate::gateway::request_log::RequestLogUsage;
+use codexmanager_core::storage::ManagedModelV2;
 use std::time::Instant;
 use tiny_http::Request;
 
@@ -88,11 +89,19 @@ fn request_deadline_for_path(
 
 fn should_try_provider_executor_aggregate_route(
     execution_plan: super::executor::GatewayUpstreamExecutionPlan,
+    configured_model: Option<&ManagedModelV2>,
 ) -> bool {
-    matches!(
-        execution_plan.route_kind,
-        GatewayUpstreamRouteKind::AggregateApi
-    )
+    match execution_plan.route_kind {
+        GatewayUpstreamRouteKind::AggregateApi => true,
+        // 若模型没有配置本地池就直接请求聚合api
+        GatewayUpstreamRouteKind::HybridAccountFirst => {
+            configured_model.is_some_and(|model: &ManagedModelV2| {
+                has_enabled_aggregate_api_route(model)
+                    && !has_enabled_default_account_pool_route(model)
+            })
+        }
+        GatewayUpstreamRouteKind::AccountRotation => false,
+    }
 }
 
 fn is_hybrid_account_first_route(
@@ -106,14 +115,17 @@ fn is_hybrid_account_first_route(
 
 fn respond_when_account_candidates_empty(
     execution_plan: super::executor::GatewayUpstreamExecutionPlan,
+    configured_model: Option<&ManagedModelV2>,
 ) -> bool {
-    !is_hybrid_account_first_route(execution_plan)
+    !should_fallback_to_aggregate_after_account_exhaustion(execution_plan, configured_model)
 }
 
 fn should_fallback_to_aggregate_after_account_exhaustion(
     execution_plan: super::executor::GatewayUpstreamExecutionPlan,
+    configured_model: Option<&ManagedModelV2>,
 ) -> bool {
     is_hybrid_account_first_route(execution_plan)
+        && configured_model.is_none_or(has_enabled_aggregate_api_route)
 }
 
 fn low_quota_candidate_mode_for_protocol(
@@ -143,16 +155,29 @@ fn route_kind_label(value: GatewayUpstreamRouteKind) -> &'static str {
     }
 }
 
-fn model_route_error(
+fn has_enabled_default_account_pool_route(model: &ManagedModelV2) -> bool {
+    model.routes.iter().any(|route| {
+        route.enabled && route.source_kind == "account_pool" && route.source_id == "default"
+    })
+}
+
+fn has_enabled_aggregate_api_route(model: &ManagedModelV2) -> bool {
+    model
+        .routes
+        .iter()
+        .any(|route| route.enabled && route.source_kind == "aggregate_api")
+}
+
+fn validate_model_route(
     storage: &codexmanager_core::storage::Storage,
     key_id: &str,
     model: Option<&str>,
     execution_plan: super::executor::GatewayUpstreamExecutionPlan,
-) -> Result<(), (u16, String)> {
+) -> Result<Option<ManagedModelV2>, (u16, String)> {
     let Some(model) = model.map(str::trim).filter(|value| !value.is_empty()) else {
-        return Ok(());
+        return Ok(None);
     };
-    let managed_model = storage
+    let managed_model: Option<ManagedModelV2> = storage
         .get_enabled_model_v2(model)
         .map_err(|err| (500, format!("model_catalog_v2_read_failed: {err}")))?;
     let Some(managed_model) = managed_model else {
@@ -181,26 +206,20 @@ fn model_route_error(
         }
         return Err((403, err));
     }
-    let route_source_kinds = source_kinds_for_route(execution_plan);
-    if !managed_model.routes.iter().any(|route| {
-        route.enabled
-            && route_source_kinds
-                .iter()
-                .any(|source_kind| route.source_kind == *source_kind)
-    }) {
+    let route_enabled = match execution_plan.route_kind {
+        GatewayUpstreamRouteKind::AccountRotation => {
+            has_enabled_default_account_pool_route(&managed_model)
+        }
+        GatewayUpstreamRouteKind::AggregateApi => has_enabled_aggregate_api_route(&managed_model),
+        GatewayUpstreamRouteKind::HybridAccountFirst => {
+            has_enabled_default_account_pool_route(&managed_model)
+                || has_enabled_aggregate_api_route(&managed_model)
+        }
+    };
+    if !route_enabled {
         return Err((503, format!("model_unavailable: {model}")));
     }
-    Ok(())
-}
-
-fn source_kinds_for_route(
-    execution_plan: super::executor::GatewayUpstreamExecutionPlan,
-) -> Vec<&'static str> {
-    match execution_plan.route_kind {
-        GatewayUpstreamRouteKind::AccountRotation => vec!["account_pool"],
-        GatewayUpstreamRouteKind::AggregateApi => vec!["aggregate_api"],
-        GatewayUpstreamRouteKind::HybridAccountFirst => vec!["account_pool", "aggregate_api"],
-    }
+    Ok(Some(managed_model))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -727,38 +746,46 @@ pub(in super::super) fn proxy_validated_request(
         route_kind_label(execution_plan.route_kind),
     );
 
-    if let Err((status_code, message)) = model_route_error(
+    let configured_model = match validate_model_route(
         &storage,
         key_id.as_str(),
         model_for_log.as_deref(),
         execution_plan,
     ) {
-        return respond_model_route_error(
-            request,
-            &storage,
-            trace_id.as_str(),
-            key_id.as_str(),
-            original_path.as_str(),
-            path.as_str(),
-            request_method.as_str(),
-            response_adapter,
-            service_tier_for_log.as_deref(),
-            effective_service_tier_for_log.as_deref(),
-            service_tier_source_for_log.as_deref(),
-            gateway_mode_for_log.as_deref(),
-            client_model_for_log.as_deref(),
-            model_for_log.as_deref(),
-            model_source_for_log.as_deref(),
-            client_reasoning_for_log.as_deref(),
-            reasoning_for_log.as_deref(),
-            reasoning_source_for_log.as_deref(),
-            started_at,
-            status_code,
-            message,
-        );
-    }
+        Ok(configured_model) => configured_model,
+        Err((status_code, message)) => {
+            return respond_model_route_error(
+                request,
+                &storage,
+                trace_id.as_str(),
+                key_id.as_str(),
+                original_path.as_str(),
+                path.as_str(),
+                request_method.as_str(),
+                response_adapter,
+                service_tier_for_log.as_deref(),
+                effective_service_tier_for_log.as_deref(),
+                service_tier_source_for_log.as_deref(),
+                gateway_mode_for_log.as_deref(),
+                client_model_for_log.as_deref(),
+                model_for_log.as_deref(),
+                model_source_for_log.as_deref(),
+                client_reasoning_for_log.as_deref(),
+                reasoning_for_log.as_deref(),
+                reasoning_source_for_log.as_deref(),
+                started_at,
+                status_code,
+                message,
+            );
+        }
+    };
 
-    if should_try_provider_executor_aggregate_route(execution_plan) {
+    if should_try_provider_executor_aggregate_route(execution_plan, configured_model.as_ref()) {
+        let (aggregate_path, aggregate_body) = if is_hybrid_account_first_route(execution_plan) {
+            (passthrough_path.as_str(), &passthrough_body)
+        } else {
+            (path.as_str(), &body)
+        };
         match resolve_aggregate_candidates_for_route(
             &storage,
             protocol_type.as_str(),
@@ -772,10 +799,10 @@ pub(in super::super) fn proxy_validated_request(
                     trace_id.as_str(),
                     key_id.as_str(),
                     original_path.as_str(),
-                    path.as_str(),
+                    aggregate_path,
                     request_method.as_str(),
                     &method,
-                    &body,
+                    aggregate_body,
                     client_is_stream,
                     gateway_mode_for_log.as_deref(),
                     client_model_for_log.as_deref(),
@@ -800,7 +827,7 @@ pub(in super::super) fn proxy_validated_request(
                     trace_id.as_str(),
                     key_id.as_str(),
                     original_path.as_str(),
-                    path.as_str(),
+                    aggregate_path,
                     request_method.as_str(),
                     super::super::ResponseAdapter::Passthrough,
                     service_tier_for_log.as_deref(),
@@ -835,7 +862,7 @@ pub(in super::super) fn proxy_validated_request(
         account_group_filter.as_deref(),
         account_plan_filter.as_deref(),
         low_quota_candidate_mode_for_protocol(protocol_type.as_str()),
-        respond_when_account_candidates_empty(execution_plan),
+        respond_when_account_candidates_empty(execution_plan, configured_model.as_ref()),
     ) {
         CandidatePrecheckResult::Ready {
             request,
@@ -924,7 +951,10 @@ pub(in super::super) fn proxy_validated_request(
         trace_id.as_str(),
     );
     let base = setup.upstream_base.as_str();
-    if should_fallback_to_aggregate_after_account_exhaustion(execution_plan) {
+    if should_fallback_to_aggregate_after_account_exhaustion(
+        execution_plan,
+        configured_model.as_ref(),
+    ) {
         prepared_hybrid_aggregate_candidates =
             Some(resolve_hybrid_aggregate_candidates_for_prepare(
                 &storage,
@@ -1036,7 +1066,10 @@ pub(in super::super) fn proxy_validated_request(
         skipped_inflight,
         last_attempt_error.as_deref(),
     );
-    if should_fallback_to_aggregate_after_account_exhaustion(execution_plan) {
+    if should_fallback_to_aggregate_after_account_exhaustion(
+        execution_plan,
+        configured_model.as_ref(),
+    ) {
         match take_or_resolve_aggregate_candidates(
             &mut prepared_hybrid_aggregate_candidates,
             &storage,

--- a/crates/service/src/gateway/upstream/proxy_tests.rs
+++ b/crates/service/src/gateway/upstream/proxy_tests.rs
@@ -1,15 +1,15 @@
 use super::{
-    exhausted_gateway_error_for_log, hybrid_route_error_message, model_route_error,
-    provider_upstream_hint, request_deadline_for_path, resolve_aggregate_candidates_for_route,
-    resolve_upstream_is_stream, respond_when_account_candidates_empty,
-    should_fallback_to_aggregate_after_account_exhaustion,
-    should_try_provider_executor_aggregate_route,
+    exhausted_gateway_error_for_log, has_enabled_aggregate_api_route,
+    has_enabled_default_account_pool_route, hybrid_route_error_message, provider_upstream_hint,
+    request_deadline_for_path, resolve_aggregate_candidates_for_route, resolve_upstream_is_stream,
+    respond_when_account_candidates_empty, should_fallback_to_aggregate_after_account_exhaustion,
+    should_try_provider_executor_aggregate_route, validate_model_route,
 };
 use crate::gateway::upstream::executor::{
     GatewayUpstreamExecutionPlan, GatewayUpstreamExecutorKind, GatewayUpstreamRouteKind,
 };
 use codexmanager_core::storage::{
-    now_ts, Account, AggregateApi, ManagedModelV2Upsert, ModelRouteV2, Storage,
+    now_ts, Account, AggregateApi, ManagedModelV2, ManagedModelV2Upsert, ModelRouteV2, Storage,
 };
 use std::time::{Duration, Instant};
 
@@ -143,6 +143,23 @@ fn add_model_route_v2(
         .expect("save V2 model route");
 }
 
+fn model_with_routes(routes: &[(&str, &str)]) -> ManagedModelV2 {
+    ManagedModelV2 {
+        routes: routes
+            .iter()
+            .map(|(source_kind, source_id)| ModelRouteV2 {
+                source_kind: (*source_kind).to_string(),
+                source_id: (*source_id).to_string(),
+                upstream_model: "test-upstream".to_string(),
+                enabled: true,
+                weight: 1,
+                ..Default::default()
+            })
+            .collect(),
+        ..Default::default()
+    }
+}
+
 #[test]
 fn aggregate_route_model_validation_accepts_model_override_candidate() {
     let storage = Storage::open_in_memory().expect("open storage");
@@ -156,7 +173,7 @@ fn aggregate_route_model_validation_accepts_model_override_candidate() {
         "MiniMax-M3",
     );
 
-    model_route_error(
+    validate_model_route(
         &storage,
         "key-route",
         Some("gpt-5.4"),
@@ -268,42 +285,61 @@ fn request_deadline_for_responses_uses_upstream_stream_semantics() {
 }
 
 #[test]
-fn only_explicit_aggregate_route_uses_aggregate_candidates() {
+fn aggregate_strategy_and_hybrid_aggregate_only_use_aggregate_candidates_directly() {
     assert!(should_try_provider_executor_aggregate_route(
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::Claude,
             route_kind: GatewayUpstreamRouteKind::AggregateApi,
-        }
+        },
+        None,
     ));
     assert!(should_try_provider_executor_aggregate_route(
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::Gemini,
             route_kind: GatewayUpstreamRouteKind::AggregateApi,
-        }
+        },
+        None,
     ));
     assert!(!should_try_provider_executor_aggregate_route(
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::Claude,
             route_kind: GatewayUpstreamRouteKind::AccountRotation,
-        }
+        },
+        None,
     ));
     assert!(should_try_provider_executor_aggregate_route(
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::CodexResponses,
             route_kind: GatewayUpstreamRouteKind::AggregateApi,
-        }
+        },
+        None,
     ));
     assert!(!should_try_provider_executor_aggregate_route(
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::Gemini,
             route_kind: GatewayUpstreamRouteKind::AccountRotation,
-        }
+        },
+        None,
     ));
     assert!(!should_try_provider_executor_aggregate_route(
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::CodexResponses,
             route_kind: GatewayUpstreamRouteKind::AccountRotation,
-        }
+        },
+        None,
+    ));
+
+    let hybrid = execution_plan(GatewayUpstreamRouteKind::HybridAccountFirst);
+    let aggregate_only = model_with_routes(&[("aggregate_api", "agg-test")]);
+    let dual_route =
+        model_with_routes(&[("account_pool", "default"), ("aggregate_api", "agg-test")]);
+    assert!(should_try_provider_executor_aggregate_route(
+        hybrid,
+        Some(&aggregate_only),
+    ));
+    assert!(!should_try_provider_executor_aggregate_route(
+        hybrid,
+        Some(&dual_route),
     ));
 }
 
@@ -322,9 +358,9 @@ fn hybrid_account_first_keeps_account_empty_for_aggregate_fallback() {
         route_kind: GatewayUpstreamRouteKind::AggregateApi,
     };
 
-    assert!(!respond_when_account_candidates_empty(hybrid));
-    assert!(respond_when_account_candidates_empty(account_only));
-    assert!(respond_when_account_candidates_empty(aggregate_only));
+    assert!(!respond_when_account_candidates_empty(hybrid, None));
+    assert!(respond_when_account_candidates_empty(account_only, None));
+    assert!(respond_when_account_candidates_empty(aggregate_only, None));
 }
 
 #[test]
@@ -333,19 +369,60 @@ fn only_hybrid_falls_back_to_aggregate_after_account_exhaustion() {
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::CodexResponses,
             route_kind: GatewayUpstreamRouteKind::HybridAccountFirst,
-        }
+        },
+        None,
     ));
     assert!(!should_fallback_to_aggregate_after_account_exhaustion(
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::CodexResponses,
             route_kind: GatewayUpstreamRouteKind::AccountRotation,
-        }
+        },
+        None,
     ));
     assert!(!should_fallback_to_aggregate_after_account_exhaustion(
         GatewayUpstreamExecutionPlan {
             executor_kind: GatewayUpstreamExecutorKind::CodexResponses,
             route_kind: GatewayUpstreamRouteKind::AggregateApi,
-        }
+        },
+        None,
+    ));
+}
+
+#[test]
+fn hybrid_account_only_does_not_fallback_to_aggregate() {
+    let hybrid = GatewayUpstreamExecutionPlan {
+        executor_kind: GatewayUpstreamExecutorKind::CodexResponses,
+        route_kind: GatewayUpstreamRouteKind::HybridAccountFirst,
+    };
+    let account_only = model_with_routes(&[("account_pool", "default")]);
+
+    assert!(respond_when_account_candidates_empty(
+        hybrid,
+        Some(&account_only),
+    ));
+    assert!(!should_fallback_to_aggregate_after_account_exhaustion(
+        hybrid,
+        Some(&account_only),
+    ));
+}
+
+#[test]
+fn hybrid_dual_route_keeps_account_first_and_aggregate_fallback() {
+    let hybrid = execution_plan(GatewayUpstreamRouteKind::HybridAccountFirst);
+    let dual_route =
+        model_with_routes(&[("account_pool", "default"), ("aggregate_api", "agg-test")]);
+
+    assert!(!should_try_provider_executor_aggregate_route(
+        hybrid,
+        Some(&dual_route),
+    ));
+    assert!(!respond_when_account_candidates_empty(
+        hybrid,
+        Some(&dual_route),
+    ));
+    assert!(should_fallback_to_aggregate_after_account_exhaustion(
+        hybrid,
+        Some(&dual_route),
     ));
 }
 
@@ -390,7 +467,7 @@ fn aggregate_route_model_validation_uses_explicit_v2_route() {
         "vendor-upstream",
     );
 
-    model_route_error(
+    validate_model_route(
         &storage,
         "key-route",
         Some("vendor-route"),
@@ -501,7 +578,7 @@ fn account_route_model_validation_ignores_aggregate_only_mapping() {
         "vendor-account-route",
     );
 
-    let err = model_route_error(
+    let err = validate_model_route(
         &storage,
         "key-route",
         Some("vendor-account-route"),
@@ -526,13 +603,133 @@ fn hybrid_model_validation_accepts_aggregate_mapping() {
         "vendor-hybrid-upstream",
     );
 
-    model_route_error(
+    let model = validate_model_route(
         &storage,
         "key-route",
         Some("vendor-hybrid"),
         execution_plan(GatewayUpstreamRouteKind::HybridAccountFirst),
     )
-    .expect("hybrid route should accept aggregate mapping");
+    .expect("hybrid route should accept aggregate mapping")
+    .expect("configured model");
+
+    assert!(!has_enabled_default_account_pool_route(&model));
+    assert!(has_enabled_aggregate_api_route(&model));
+}
+
+#[test]
+fn hybrid_model_validation_returns_dual_route_configuration() {
+    let storage = Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+    add_model_route_v2(
+        &storage,
+        "vendor-hybrid-dual",
+        "account_pool",
+        "default",
+        "vendor-hybrid-dual",
+    );
+    add_model_route_v2(
+        &storage,
+        "vendor-hybrid-dual",
+        "aggregate_api",
+        "agg-hybrid-dual",
+        "vendor-hybrid-upstream",
+    );
+
+    let model = validate_model_route(
+        &storage,
+        "key-route",
+        Some("vendor-hybrid-dual"),
+        execution_plan(GatewayUpstreamRouteKind::HybridAccountFirst),
+    )
+    .expect("hybrid route should accept both route kinds")
+    .expect("configured model");
+
+    assert!(has_enabled_default_account_pool_route(&model));
+    assert!(has_enabled_aggregate_api_route(&model));
+}
+
+#[test]
+fn hybrid_model_validation_ignores_non_default_account_pool_routes() {
+    let storage = Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+    add_model_route_v2(
+        &storage,
+        "vendor-hybrid-non-default-pool",
+        "account_pool",
+        "secondary",
+        "vendor-hybrid-non-default-pool",
+    );
+    add_model_route_v2(
+        &storage,
+        "vendor-hybrid-non-default-pool",
+        "aggregate_api",
+        "agg-hybrid-non-default-pool",
+        "vendor-hybrid-upstream",
+    );
+
+    let model = validate_model_route(
+        &storage,
+        "key-route",
+        Some("vendor-hybrid-non-default-pool"),
+        execution_plan(GatewayUpstreamRouteKind::HybridAccountFirst),
+    )
+    .expect("hybrid route should accept its aggregate route")
+    .expect("configured model");
+
+    assert!(!has_enabled_default_account_pool_route(&model));
+    assert!(has_enabled_aggregate_api_route(&model));
+}
+
+#[test]
+fn model_route_validation_ignores_disabled_routes() {
+    let storage = Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+    add_model_route_v2(
+        &storage,
+        "vendor-disabled-route",
+        "aggregate_api",
+        "agg-disabled",
+        "vendor-disabled-upstream",
+    );
+    let mut model = storage
+        .get_managed_model_v2("vendor-disabled-route")
+        .expect("read V2 model")
+        .expect("V2 model");
+    model.routes[0].enabled = false;
+    storage
+        .upsert_managed_model_v2(&ManagedModelV2Upsert {
+            previous_slug: Some("vendor-disabled-route".to_string()),
+            model,
+        })
+        .expect("disable V2 model route");
+
+    let error = validate_model_route(
+        &storage,
+        "key-route",
+        Some("vendor-disabled-route"),
+        execution_plan(GatewayUpstreamRouteKind::HybridAccountFirst),
+    )
+    .expect_err("disabled routes should be unavailable");
+
+    assert_eq!(error.0, 503);
+    assert!(error.1.contains("model_unavailable"));
+}
+
+#[test]
+fn model_route_validation_preserves_missing_model_default_paths() {
+    let storage = Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+
+    for route_kind in [
+        GatewayUpstreamRouteKind::AccountRotation,
+        GatewayUpstreamRouteKind::AggregateApi,
+        GatewayUpstreamRouteKind::HybridAccountFirst,
+    ] {
+        let configured_model =
+            validate_model_route(&storage, "key-route", None, execution_plan(route_kind))
+                .expect("requests without a model should keep the strategy default path");
+        assert!(configured_model.is_none());
+    }
 }
 
 #[test]
@@ -563,11 +760,15 @@ fn account_route_model_validation_accepts_direct_upstream_source_model() {
         )
         .expect("seed direct upstream source model");
 
-    model_route_error(
+    let model = validate_model_route(
         &storage,
         "key-route",
         Some("gpt-5.4-mini"),
         execution_plan(GatewayUpstreamRouteKind::AccountRotation),
     )
-    .expect("account route should accept direct upstream source model");
+    .expect("account route should accept direct upstream source model")
+    .expect("configured model");
+
+    assert!(has_enabled_default_account_pool_route(&model));
+    assert!(!has_enabled_aggregate_api_route(&model));
 }

--- a/crates/service/tests/gateway_logs.rs
+++ b/crates/service/tests/gateway_logs.rs
@@ -2,6 +2,8 @@
 mod anthropic;
 #[path = "gateway_logs/basic.rs"]
 mod basic;
+#[path = "gateway_logs/hybrid_routing.rs"]
+mod hybrid_routing;
 #[path = "gateway_logs/images.rs"]
 mod images;
 #[path = "gateway_logs/prompt_cache.rs"]

--- a/crates/service/tests/gateway_logs/hybrid_routing.rs
+++ b/crates/service/tests/gateway_logs/hybrid_routing.rs
@@ -1,0 +1,524 @@
+use super::*;
+use codexmanager_core::storage::AggregateApi;
+
+const MODEL: &str = "gpt-hybrid-route-test";
+const UPSTREAM_MODEL: &str = "gpt-hybrid-route-upstream";
+
+fn response_json(id: &str) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "id": id,
+        "model": MODEL,
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "ok" }]
+        }],
+        "usage": { "input_tokens": 2, "output_tokens": 1, "total_tokens": 3 }
+    }))
+    .expect("serialize upstream response")
+}
+
+fn insert_active_account(storage: &Storage, account_id: &str, now: i64) {
+    storage
+        .insert_account(&Account {
+            id: account_id.to_string(),
+            label: account_id.to_string(),
+            issuer: "https://auth.openai.com".to_string(),
+            chatgpt_account_id: Some(format!("chatgpt_{account_id}")),
+            workspace_id: None,
+            group_name: None,
+            sort: 0,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+        })
+        .expect("insert account");
+    storage
+        .insert_token(&Token {
+            account_id: account_id.to_string(),
+            id_token: String::new(),
+            access_token: format!("access_{account_id}"),
+            refresh_token: String::new(),
+            api_key_access_token: Some(format!("api_access_{account_id}")),
+            last_refresh: now,
+        })
+        .expect("insert token");
+}
+
+fn insert_aggregate_api(storage: &Storage, aggregate_id: &str, addr: &str, action: &str, now: i64) {
+    storage
+        .insert_aggregate_api(&AggregateApi {
+            id: aggregate_id.to_string(),
+            provider_type: "codex".to_string(),
+            supplier_name: Some("hybrid route test".to_string()),
+            sort: 0,
+            url: format!("http://{addr}/backend-api/codex"),
+            auth_type: "apikey".to_string(),
+            auth_params_json: None,
+            action: Some(action.to_string()),
+            model_override: None,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+            last_test_at: None,
+            last_test_status: None,
+            last_test_error: None,
+            balance_query_enabled: false,
+            balance_query_template: None,
+            balance_query_base_url: None,
+            balance_query_user_id: None,
+            balance_query_config_json: None,
+            last_balance_at: None,
+            last_balance_status: None,
+            last_balance_error: None,
+            last_balance_json: None,
+        })
+        .expect("insert aggregate API");
+    storage
+        .upsert_aggregate_api_secret(aggregate_id, "aggregate-secret")
+        .expect("insert aggregate API secret");
+}
+
+fn replace_with_aggregate_only_route(storage: &Storage, aggregate_id: &str) {
+    seed_model_catalog_models(storage, &[MODEL]);
+    let mut model = storage
+        .get_managed_model_v2(MODEL)
+        .expect("get V2 model")
+        .expect("V2 model exists");
+    model.routes = vec![ModelRouteV2 {
+        id: String::new(),
+        source_kind: "aggregate_api".to_string(),
+        source_id: aggregate_id.to_string(),
+        upstream_model: UPSTREAM_MODEL.to_string(),
+        enabled: true,
+        priority: 0,
+        weight: 1,
+    }];
+    storage
+        .upsert_managed_model_v2(&ManagedModelV2Upsert {
+            previous_slug: None,
+            model,
+        })
+        .expect("replace V2 model routes");
+}
+
+fn seed_dual_routes(storage: &Storage, aggregate_id: &str) {
+    seed_model_catalog_models(storage, &[MODEL]);
+    seed_model_catalog_route(
+        storage,
+        MODEL,
+        "aggregate_api",
+        aggregate_id,
+        UPSTREAM_MODEL,
+        0,
+    );
+}
+
+fn insert_hybrid_key(storage: &Storage, key_id: &str, platform_key: &str, now: i64) {
+    storage
+        .insert_api_key(&ApiKey {
+            id: key_id.to_string(),
+            name: Some(key_id.to_string()),
+            model_slug: Some(MODEL.to_string()),
+            reasoning_effort: None,
+            service_tier: None,
+            rotation_strategy: "hybrid_rotation".to_string(),
+            aggregate_api_id: None,
+            account_plan_filter: None,
+            aggregate_api_url: None,
+            client_type: "codex".to_string(),
+            protocol_type: "openai_compat".to_string(),
+            auth_scheme: "authorization_bearer".to_string(),
+            upstream_base_url: None,
+            static_headers_json: None,
+            key_hash: hash_platform_key_for_test(platform_key),
+            status: "active".to_string(),
+            created_at: now,
+            last_used_at: None,
+        })
+        .expect("insert hybrid API key");
+}
+
+#[test]
+fn hybrid_aggregate_only_skips_active_account_and_uses_aggregate_api() {
+    let _lock = test_env_guard();
+    let dir = new_test_dir("codexmanager-hybrid-aggregate-only");
+    let db_path: PathBuf = dir.join("codexmanager.db");
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+
+    let (local_addr, local_rx, local_join) = start_mock_upstream_sequence_lenient(
+        vec![(200, response_json("resp_local_should_not_run"))],
+        Duration::from_secs(2),
+    );
+    let local_base = format!("http://{local_addr}/backend-api/codex");
+    let _upstream_guard = EnvGuard::set("CODEXMANAGER_UPSTREAM_BASE_URL", &local_base);
+    let (aggregate_addr, aggregate_rx, aggregate_join) = start_mock_upstream_sequence_lenient(
+        vec![(200, response_json("resp_aggregate_only"))],
+        Duration::from_secs(2),
+    );
+
+    let storage = Storage::open(&db_path).expect("open db");
+    storage.init().expect("init db");
+    let now = now_ts();
+    let aggregate_id = "agg_hybrid_aggregate_only";
+    let key_id = "gk_hybrid_aggregate_only";
+    let platform_key = "pk_hybrid_aggregate_only";
+    insert_active_account(&storage, "acc_hybrid_aggregate_only", now);
+    insert_aggregate_api(&storage, aggregate_id, &aggregate_addr, "/responses", now);
+    replace_with_aggregate_only_route(&storage, aggregate_id);
+    insert_hybrid_key(&storage, key_id, platform_key, now);
+
+    let server = codexmanager_service::start_one_shot_server().expect("start server");
+    let request = serde_json::json!({
+        "model": MODEL,
+        "input": "hello",
+        "stream": false
+    });
+    let request = serde_json::to_string(&request).expect("serialize request");
+    let (status, response_body) = post_http_raw(
+        &server.addr,
+        "/v1/responses",
+        &request,
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &format!("Bearer {platform_key}")),
+        ],
+    );
+    server.join();
+    local_join.join().expect("join local upstream");
+    aggregate_join.join().expect("join aggregate upstream");
+
+    assert_eq!(status, 200, "gateway response: {response_body}");
+    assert!(response_body.contains("resp_aggregate_only"));
+    assert_eq!(
+        local_rx.try_iter().count(),
+        0,
+        "local account must be skipped"
+    );
+    let aggregate_requests = aggregate_rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(aggregate_requests.len(), 1, "aggregate API request count");
+    assert_eq!(aggregate_requests[0].path, "/backend-api/codex/responses");
+    let aggregate_body: serde_json::Value =
+        serde_json::from_slice(&decode_upstream_request_body(&aggregate_requests[0]))
+            .expect("parse aggregate request body");
+    assert_eq!(aggregate_body["model"], UPSTREAM_MODEL);
+
+    let log = storage
+        .list_request_logs(Some(&format!("key:={key_id}")), 10)
+        .expect("list request logs")
+        .into_iter()
+        .find(|item| item.request_path == "/v1/responses")
+        .expect("request log");
+    assert_eq!(log.status_code, Some(200));
+    assert_eq!(log.actual_source_kind.as_deref(), Some("aggregate_api"));
+    assert_eq!(log.actual_source_id.as_deref(), Some(aggregate_id));
+}
+
+#[test]
+fn hybrid_aggregate_only_streams_chat_completions_tool_calls_from_aggregate_api() {
+    let _lock = test_env_guard();
+    let dir = new_test_dir("codexmanager-hybrid-aggregate-only-chat-tools");
+    let db_path: PathBuf = dir.join("codexmanager.db");
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+
+    let (local_addr, local_rx, local_join) = start_mock_upstream_sequence_lenient(
+        vec![(200, response_json("resp_local_should_not_run"))],
+        Duration::from_secs(2),
+    );
+    let local_base = format!("http://{local_addr}/backend-api/codex");
+    let _upstream_guard = EnvGuard::set("CODEXMANAGER_UPSTREAM_BASE_URL", &local_base);
+    let tool_call_sse = concat!(
+        "data: {\"id\":\"chatcmpl_hybrid_tool\",\"object\":\"chat.completion.chunk\",\"created\":1775900000,\"model\":\"gpt-hybrid-route-test\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call_hybrid_1\",\"type\":\"function\",\"function\":{\"name\":\"get_answer\",\"arguments\":\"{\\\"question\\\":\\\"2+2\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"chatcmpl_hybrid_tool\",\"object\":\"chat.completion.chunk\",\"created\":1775900000,\"model\":\"gpt-hybrid-route-test\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let (aggregate_addr, aggregate_rx, aggregate_join) =
+        start_mock_upstream_sequence_lenient_with_content_types(
+            vec![(
+                200,
+                tool_call_sse.to_string(),
+                "text/event-stream".to_string(),
+            )],
+            Duration::from_secs(2),
+        );
+
+    let storage = Storage::open(&db_path).expect("open db");
+    storage.init().expect("init db");
+    let now = now_ts();
+    let aggregate_id = "agg_hybrid_aggregate_only_chat_tools";
+    let key_id = "gk_hybrid_aggregate_only_chat_tools";
+    let platform_key = "pk_hybrid_aggregate_only_chat_tools";
+    insert_active_account(&storage, "acc_hybrid_aggregate_only_chat_tools", now);
+    insert_aggregate_api(
+        &storage,
+        aggregate_id,
+        &aggregate_addr,
+        "/chat/completions",
+        now,
+    );
+    replace_with_aggregate_only_route(&storage, aggregate_id);
+    insert_hybrid_key(&storage, key_id, platform_key, now);
+
+    let server = codexmanager_service::start_one_shot_server().expect("start server");
+    let request = serde_json::json!({
+        "model": MODEL,
+        "messages": [{ "role": "user", "content": "answer with a tool" }],
+        "stream": true,
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "get_answer",
+                "description": "Return an answer",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "question": { "type": "string" } },
+                    "required": ["question"]
+                }
+            }
+        }]
+    });
+    let request = serde_json::to_string(&request).expect("serialize request");
+    let (status, response_body) = post_http_raw(
+        &server.addr,
+        "/v1/chat/completions",
+        &request,
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &format!("Bearer {platform_key}")),
+        ],
+    );
+    server.join();
+    local_join.join().expect("join local upstream");
+    aggregate_join.join().expect("join aggregate upstream");
+
+    assert_eq!(status, 200, "gateway response: {response_body}");
+    assert_eq!(
+        local_rx.try_iter().count(),
+        0,
+        "local account must be skipped"
+    );
+    let aggregate_requests = aggregate_rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(aggregate_requests.len(), 1, "aggregate API request count");
+    assert_eq!(
+        aggregate_requests[0].path,
+        "/backend-api/codex/chat/completions"
+    );
+    let aggregate_body: serde_json::Value =
+        serde_json::from_slice(&decode_upstream_request_body(&aggregate_requests[0]))
+            .expect("parse aggregate request body");
+    assert_eq!(aggregate_body["model"], UPSTREAM_MODEL);
+    assert!(aggregate_body["messages"].is_array());
+    assert!(aggregate_body["tools"].is_array());
+    assert!(
+        response_body.contains("\"tool_calls\""),
+        "chat completions response: {response_body}"
+    );
+    assert!(response_body.contains("\"id\":\"call_hybrid_1\""));
+    assert!(response_body.contains("\"name\":\"get_answer\""));
+    assert!(response_body.contains("{\\\"question\\\":\\\"2+2\\\"}"));
+    assert!(response_body.contains("\"finish_reason\":\"tool_calls\""));
+    assert!(response_body.contains("data: [DONE]"));
+}
+
+#[test]
+fn hybrid_dual_route_prefers_active_account_for_streaming_responses() {
+    let _lock = test_env_guard();
+    let dir = new_test_dir("codexmanager-hybrid-dual-account-first");
+    let db_path: PathBuf = dir.join("codexmanager.db");
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+
+    let account_sse = concat!(
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"account ok\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_hybrid_account\",\"model\":\"gpt-hybrid-route-test\",\"usage\":{\"input_tokens\":3,\"output_tokens\":1,\"total_tokens\":4}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+    let (local_addr, local_rx, local_join) =
+        start_mock_upstream_sequence_lenient_with_content_types(
+            vec![(
+                200,
+                account_sse.to_string(),
+                "text/event-stream".to_string(),
+            )],
+            Duration::from_secs(2),
+        );
+    let local_base = format!("http://{local_addr}/backend-api/codex");
+    let _upstream_guard = EnvGuard::set("CODEXMANAGER_UPSTREAM_BASE_URL", &local_base);
+    let (aggregate_addr, aggregate_rx, aggregate_join) = start_mock_upstream_sequence_lenient(
+        vec![(200, response_json("resp_aggregate_should_not_run"))],
+        Duration::from_secs(2),
+    );
+
+    let storage = Storage::open(&db_path).expect("open db");
+    storage.init().expect("init db");
+    let now = now_ts();
+    let aggregate_id = "agg_hybrid_dual_account_first";
+    let key_id = "gk_hybrid_dual_account_first";
+    let platform_key = "pk_hybrid_dual_account_first";
+    insert_active_account(&storage, "acc_hybrid_dual_account_first", now);
+    insert_aggregate_api(&storage, aggregate_id, &aggregate_addr, "/responses", now);
+    seed_dual_routes(&storage, aggregate_id);
+    insert_hybrid_key(&storage, key_id, platform_key, now);
+
+    let server = codexmanager_service::start_one_shot_server().expect("start server");
+    let request = serde_json::json!({
+        "model": MODEL,
+        "input": "hello",
+        "stream": true
+    });
+    let request = serde_json::to_string(&request).expect("serialize request");
+    let (status, response_body) = post_http_raw(
+        &server.addr,
+        "/v1/responses",
+        &request,
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &format!("Bearer {platform_key}")),
+        ],
+    );
+    server.join();
+    local_join.join().expect("join local upstream");
+    aggregate_join.join().expect("join aggregate upstream");
+
+    assert_eq!(status, 200, "gateway response: {response_body}");
+    assert!(response_body.contains("resp_hybrid_account"));
+    let local_requests = local_rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(local_requests.len(), 1, "local account request count");
+    assert_eq!(local_requests[0].path, "/backend-api/codex/responses");
+    let local_body: serde_json::Value =
+        serde_json::from_slice(&decode_upstream_request_body(&local_requests[0]))
+            .expect("parse local account request body");
+    assert_eq!(local_body["model"], MODEL);
+    assert_eq!(
+        aggregate_rx.try_iter().count(),
+        0,
+        "aggregate API must remain idle after account success"
+    );
+}
+
+#[test]
+fn hybrid_dual_route_falls_back_to_aggregate_when_account_pool_is_empty() {
+    let _lock = test_env_guard();
+    let dir = new_test_dir("codexmanager-hybrid-dual-empty-account-pool");
+    let db_path: PathBuf = dir.join("codexmanager.db");
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+
+    let (local_addr, local_rx, local_join) = start_mock_upstream_sequence_lenient(
+        vec![(200, response_json("resp_local_should_not_run"))],
+        Duration::from_secs(2),
+    );
+    let local_base = format!("http://{local_addr}/backend-api/codex");
+    let _upstream_guard = EnvGuard::set("CODEXMANAGER_UPSTREAM_BASE_URL", &local_base);
+    let (aggregate_addr, aggregate_rx, aggregate_join) = start_mock_upstream_sequence_lenient(
+        vec![(200, response_json("resp_hybrid_empty_account_fallback"))],
+        Duration::from_secs(2),
+    );
+
+    let storage = Storage::open(&db_path).expect("open db");
+    storage.init().expect("init db");
+    let now = now_ts();
+    let aggregate_id = "agg_hybrid_dual_empty_account_pool";
+    let key_id = "gk_hybrid_dual_empty_account_pool";
+    let platform_key = "pk_hybrid_dual_empty_account_pool";
+    insert_aggregate_api(&storage, aggregate_id, &aggregate_addr, "/responses", now);
+    seed_dual_routes(&storage, aggregate_id);
+    insert_hybrid_key(&storage, key_id, platform_key, now);
+
+    let server = codexmanager_service::start_one_shot_server().expect("start server");
+    let request = serde_json::json!({
+        "model": MODEL,
+        "input": "hello",
+        "stream": false
+    });
+    let request = serde_json::to_string(&request).expect("serialize request");
+    let (status, response_body) = post_http_raw(
+        &server.addr,
+        "/v1/responses",
+        &request,
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &format!("Bearer {platform_key}")),
+        ],
+    );
+    server.join();
+    local_join.join().expect("join local upstream");
+    aggregate_join.join().expect("join aggregate upstream");
+
+    assert_eq!(status, 200, "gateway response: {response_body}");
+    assert!(response_body.contains("resp_hybrid_empty_account_fallback"));
+    assert_eq!(
+        local_rx.try_iter().count(),
+        0,
+        "local account request count"
+    );
+    let aggregate_requests = aggregate_rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(aggregate_requests.len(), 1, "aggregate API request count");
+    assert_eq!(aggregate_requests[0].path, "/backend-api/codex/responses");
+    let aggregate_body: serde_json::Value =
+        serde_json::from_slice(&decode_upstream_request_body(&aggregate_requests[0]))
+            .expect("parse aggregate request body");
+    assert_eq!(aggregate_body["model"], UPSTREAM_MODEL);
+}
+
+#[test]
+fn hybrid_account_only_uses_account_and_ignores_unbound_aggregate_api() {
+    let _lock = test_env_guard();
+    let dir = new_test_dir("codexmanager-hybrid-account-only");
+    let db_path: PathBuf = dir.join("codexmanager.db");
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+
+    let (local_addr, local_rx, local_join) = start_mock_upstream_sequence_lenient(
+        vec![(200, response_json("resp_hybrid_account_only"))],
+        Duration::from_secs(2),
+    );
+    let local_base = format!("http://{local_addr}/backend-api/codex");
+    let _upstream_guard = EnvGuard::set("CODEXMANAGER_UPSTREAM_BASE_URL", &local_base);
+    let (aggregate_addr, aggregate_rx, aggregate_join) = start_mock_upstream_sequence_lenient(
+        vec![(200, response_json("resp_aggregate_should_not_run"))],
+        Duration::from_secs(2),
+    );
+
+    let storage = Storage::open(&db_path).expect("open db");
+    storage.init().expect("init db");
+    let now = now_ts();
+    let aggregate_id = "agg_hybrid_account_only_unbound";
+    let key_id = "gk_hybrid_account_only";
+    let platform_key = "pk_hybrid_account_only";
+    insert_active_account(&storage, "acc_hybrid_account_only", now);
+    insert_aggregate_api(&storage, aggregate_id, &aggregate_addr, "/responses", now);
+    seed_model_catalog_models(&storage, &[MODEL]);
+    insert_hybrid_key(&storage, key_id, platform_key, now);
+
+    let server = codexmanager_service::start_one_shot_server().expect("start server");
+    let request = serde_json::json!({
+        "model": MODEL,
+        "messages": [{ "role": "user", "content": "hello" }],
+        "stream": false
+    });
+    let request = serde_json::to_string(&request).expect("serialize request");
+    let (status, response_body) = post_http_raw(
+        &server.addr,
+        "/v1/chat/completions",
+        &request,
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &format!("Bearer {platform_key}")),
+        ],
+    );
+    server.join();
+    local_join.join().expect("join local upstream");
+    aggregate_join.join().expect("join aggregate upstream");
+
+    assert_eq!(status, 200, "gateway response: {response_body}");
+    let response: serde_json::Value =
+        serde_json::from_str(&response_body).expect("parse chat completions response");
+    assert_eq!(response["id"], "resp_hybrid_account_only");
+    assert_eq!(response["choices"][0]["message"]["content"], "ok");
+    let local_requests = local_rx.try_iter().collect::<Vec<_>>();
+    assert_eq!(local_requests.len(), 1, "local account request count");
+    assert_eq!(local_requests[0].path, "/backend-api/codex/responses");
+    assert_eq!(
+        aggregate_rx.try_iter().count(),
+        0,
+        "unbound aggregate API must remain idle"
+    );
+}


### PR DESCRIPTION
## 变更摘要

- 修复混合轮转下，模型仅配置 `aggregate_api` 路由仍请求本地账号池的问题。
- Hybrid 分流阶段使用已校验的模型路由；仅配置聚合 API 的模型直接走聚合 API。
- 仅绑定 `aggregate_api` 的模型直接请求其已绑定的聚合 API，即使系统存在活跃本地账号。
- 同时绑定 `account_pool/default` 与 `aggregate_api` 的模型保持账号池优先；账号池为空或账号候选耗尽时回退聚合 API。
- 仅绑定 `account_pool/default` 的模型只使用账号池，不会请求未绑定的聚合 API。

## 问题描述

本 PR 修复混合轮转下，模型仅配置聚合 API 路由时仍会请求账号池的问题。

PR #311 已修复旧模型映射链路中“仅绑定聚合 API 的模型被账号映射抢占”的问题。Model Catalog V2 切换后，Hybrid 的最终分流重新只看 API Key 的全局策略，相同配置语义再次失效。

当模型仅配置聚合 API 路由、平台 Key 选择混合轮转、且本地存在活跃账号时，请求会先发送到本地账号。某些模型在本地账号侧无法使用时，客户端直接收到账号侧错误，聚合 API 没有机会处理请求。

### 问题链路

```text
请求模型 M（M 仅绑定 aggregate_api，Key 使用 hybrid_rotation）
  → validate_model_route 读取 M 的 V2 路由并确认“账号池或聚合 API 任一可用”
  → 校验函数只返回“通过”，路由配置未传给后续分流
  → HybridAccountFirst 固定进入全局本地账号候选池
  → 活跃本地账号收到请求
  → 聚合 API 仅在账号池为空或候选耗尽后才有机会执行
```

## 根因分析

提交 `a6e44682 feat(gateway): route requests exclusively from model catalog v2` 已让 `proxy.rs` 通过 `storage.get_enabled_model_v2()` 读取 V2 模型配置。

旧的 `model_route_error` 仅使用 `managed_model.routes` 做准入校验，并返回 `Result<()>`。`proxy_validated_request` 因而只知道请求已经通过校验，无法区分模型是“仅聚合 API”“双路由”还是“仅账号池”。随后 Hybrid 固定走账号优先分支，覆盖了模型路由配置表达的上游选择范围。

## 修复内容

1. `proxy.rs`
   - 将模型路由校验改为返回已解析的 V2 模型配置。
   - 在 `proxy_validated_request` 中根据模型路由决定 Hybrid 的实际执行路径。
   - Hybrid + 仅聚合 API 路由直接使用聚合 API 的 passthrough 请求路径和请求体。
   - 聚合兜底仅对配置了聚合 API 路由的 Hybrid 模型生效。

2. `proxy_tests.rs`
   - 覆盖 aggregate-only、双路由、account-only、禁用路由、缺省模型和非默认账号池路由的分流判定。

3. `gateway_logs/hybrid_routing.rs`
   - 使用真实 HTTP mock 上游验证请求实际发往本地账号或聚合 API，并验证请求日志来源。

### 修复后预期

| Key 策略 | 模型绑定 | 预期行为 |
|---|---|---|
| 混合轮转 | 仅聚合 API | 直接请求已绑定聚合 API |
| 混合轮转 | 本地账号池 + 聚合 API | 本地账号优先；账号池为空或候选耗尽后回退聚合 API |
| 混合轮转 | 仅本地账号池 | 仅请求本地账号池 |
| 账号轮转 | 仅聚合 API | 返回模型不可用 |
| 聚合 API 轮转 | 聚合 API | 保持聚合 API 直连 |

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [x] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/gateway/upstream/proxy.rs`
- `crates/service/src/gateway/upstream/proxy_tests.rs`
- `crates/service/tests/gateway_logs.rs`
- `crates/service/tests/gateway_logs/hybrid_routing.rs`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
cargo test -p codexmanager-service 'gateway::upstream::proxy::tests::' -- --nocapture
23 passed; 0 failed

cargo test -p codexmanager-service --test gateway_logs hybrid_routing:: -- --nocapture
5 passed; 0 failed

git diff --check
passed
```

集成测试覆盖：

- `/v1/responses` 非流式：仅聚合 API 路由跳过活跃本地账号，并记录 `aggregate_api` 实际来源。
- `/v1/chat/completions` 流式：仅聚合 API 路由保留 tools / `tool_calls` 协议内容。
- 双路由：流式 Responses 保持本地账号优先。
- 双路由 + 空账号池：回退聚合 API。
- 仅本地账号池：忽略未绑定聚合 API。

未执行或待完成的验证与原因：

```text
cargo test --workspace
本次改动限定在 Gateway 路由，已执行相关单元测试和 HTTP 集成测试；完整工作区测试待提交前执行。

cargo fmt --all -- --check
当前 proxy.rs 存在一处格式差异，提交前执行 cargo fmt 后重新检查。
```

## 风险与影响面

- 影响 `hybrid_rotation` 对 Model Catalog V2 路由的选择。
- `/v1/responses`、`/v1/chat/completions`、流式、非流式和 tools/tool_calls 沿用既有协议适配链路。
- 双路由模型的账号优先语义保持不变；本地账号池与聚合 API 内部候选排序和轮转逻辑保持原路径。