### PR TITLE
fix: 让 OpenAI 账号池跟随官方 Codex 模型目录

### DIFF
--- a/apps/src/components/modals/model-catalog-modal.tsx
+++ b/apps/src/components/modals/model-catalog-modal.tsx
@@ -96,7 +96,13 @@ const DEFAULT_CAPABILITIES = {
   reasoningEfforts: [],
   serviceTiers: [],
   inputModalities: ["text", "image"],
-  supportsParallelToolCalls: true,
+  supportsParallelToolCalls: false,
+  supportsReasoningSummaries: false,
+  defaultReasoningSummary: "auto",
+  supportsVerbosity: false,
+  truncationMode: "tokens",
+  truncationLimit: 10000,
+  experimentalSupportedTools: [],
 };
 
 function aggregateApiDisplayName(

--- a/apps/src/lib/api/managed-models-v2.ts
+++ b/apps/src/lib/api/managed-models-v2.ts
@@ -160,6 +160,7 @@ export function managedModelV2ToModelInfo(model: ManagedModelV2): ModelInfo {
     supportsReasoningSummaries: booleanCapability(
       model,
       false,
+      "supports_reasoning_summary_parameter",
       "supportsReasoningSummaries",
       "supports_reasoning_summaries",
     ),
@@ -317,6 +318,7 @@ export function serializeManagedModelV2ForCodexCache(
     supports_reasoning_summary_parameter: booleanCapability(
       model,
       false,
+      "supports_reasoning_summary_parameter",
       "supportsReasoningSummaries",
       "supports_reasoning_summaries",
     ),

--- a/crates/service/src/apikey/apikey_update_model.rs
+++ b/crates/service/src/apikey/apikey_update_model.rs
@@ -155,12 +155,13 @@ pub(crate) fn update_api_key_model(
             .map_err(|e| e.to_string())?;
     }
 
+    let has_protocol_type = protocol_type.is_some();
     let has_upstream_base_url = upstream_base_url.is_some();
     let has_static_headers_json = static_headers_json.is_some();
     let normalized_upstream_base_url = normalize_upstream_base_url(upstream_base_url)?;
     let normalized_static_headers_json = normalize_static_headers_json(static_headers_json)?;
 
-    if protocol_type.is_some() || has_upstream_base_url || has_static_headers_json {
+    if has_protocol_type || has_upstream_base_url || has_static_headers_json {
         let current = storage
             .find_api_key_profile_config_by_id(key_id)
             .map_err(|e| e.to_string())?
@@ -191,6 +192,9 @@ pub(crate) fn update_api_key_model(
                     .or(current.service_tier.as_deref()),
             )
             .map_err(|e| e.to_string())?;
+    }
+    if update_routing_config || has_protocol_type || has_upstream_base_url {
+        crate::codex_profile::sync_active_gateway_profile_for_api_key(&storage, key_id)?;
     }
     Ok(())
 }

--- a/crates/service/src/codex_model_catalog.rs
+++ b/crates/service/src/codex_model_catalog.rs
@@ -20,7 +20,52 @@ fn serialize_gateway_model_catalog(catalog: &ModelsResponse) -> Result<String, S
             "managed model catalog is empty; refusing to replace the Codex catalog".to_string(),
         );
     }
-    let mut content = serde_json::to_string_pretty(catalog)
+    let mut catalog = catalog.clone();
+    for model in &mut catalog.models {
+        if model
+            .shell_type
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none()
+        {
+            model.shell_type = Some("shell_command".to_string());
+        }
+        model.base_instructions.get_or_insert_with(String::new);
+        model
+            .availability_nux
+            .get_or_insert(serde_json::Value::Null);
+        model.upgrade.get_or_insert(serde_json::Value::Null);
+        model.model_messages.get_or_insert_with(|| {
+            serde_json::json!({
+                "instructions_template": "",
+                "instructions_variables": null,
+                "approvals": null,
+            })
+        });
+        model.effective_context_window_percent.get_or_insert(95);
+
+        let max_context_window = model.context_window.unwrap_or(200_000);
+        model
+            .extra
+            .entry("max_context_window".to_string())
+            .or_insert_with(|| serde_json::json!(max_context_window));
+        for key in ["comp_hash", "tool_mode", "multi_agent_version"] {
+            model
+                .extra
+                .entry(key.to_string())
+                .or_insert(serde_json::Value::Null);
+        }
+        model
+            .extra
+            .entry("use_responses_lite".to_string())
+            .or_insert(serde_json::Value::Bool(false));
+        model
+            .extra
+            .entry("include_skills_usage_instructions".to_string())
+            .or_insert(serde_json::Value::Bool(false));
+    }
+    let mut content = serde_json::to_string_pretty(&catalog)
         .map_err(|err| format!("serialize managed model catalog failed: {err}"))?;
     content.push('\n');
     Ok(content)
@@ -104,7 +149,58 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&content).expect("parse catalog");
 
         assert_eq!(value["models"][0]["slug"].as_str(), Some("gpt-test"));
+        assert_eq!(
+            value["models"][0]["shell_type"].as_str(),
+            Some("shell_command")
+        );
+        assert_eq!(value["models"][0]["base_instructions"].as_str(), Some(""));
+        assert!(value["models"][0]["availability_nux"].is_null());
+        assert!(value["models"][0]["upgrade"].is_null());
+        assert_eq!(
+            value["models"][0]["model_messages"]["instructions_template"].as_str(),
+            Some("")
+        );
+        assert_eq!(
+            value["models"][0]["effective_context_window_percent"].as_i64(),
+            Some(95)
+        );
+        assert_eq!(
+            value["models"][0]["max_context_window"].as_i64(),
+            Some(200_000)
+        );
+        assert!(value["models"][0]["comp_hash"].is_null());
+        assert!(value["models"][0]["tool_mode"].is_null());
+        assert!(value["models"][0]["multi_agent_version"].is_null());
+        assert_eq!(
+            value["models"][0]["use_responses_lite"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(
+            value["models"][0]["include_skills_usage_instructions"].as_bool(),
+            Some(false)
+        );
         assert!(content.ends_with('\n'));
+    }
+
+    #[test]
+    fn gateway_catalog_preserves_explicit_shell_type() {
+        let catalog = ModelsResponse {
+            models: vec![ModelInfo {
+                slug: "gpt-test".to_string(),
+                display_name: "GPT Test".to_string(),
+                shell_type: Some("custom_shell".to_string()),
+                ..ModelInfo::default()
+            }],
+            ..ModelsResponse::default()
+        };
+
+        let content = serialize_gateway_model_catalog(&catalog).expect("serialize catalog");
+        let value: serde_json::Value = serde_json::from_str(&content).expect("parse catalog");
+
+        assert_eq!(
+            value["models"][0]["shell_type"].as_str(),
+            Some("custom_shell")
+        );
     }
 
     #[test]

--- a/crates/service/src/codex_model_catalog.rs
+++ b/crates/service/src/codex_model_catalog.rs
@@ -1,44 +1,48 @@
 use codexmanager_core::rpc::types::ModelsResponse;
 use codexmanager_core::storage::Storage;
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GatewayCatalogPolicy {
+    OfficialAccountPool,
+    Managed,
+}
+
 pub(crate) fn write_gateway_model_catalog(
     storage: &Storage,
     catalog_path: &Path,
-    use_official_account_catalog: bool,
+    policy: GatewayCatalogPolicy,
 ) -> Result<usize, String> {
-    let catalog = crate::models_v2::text_generation_models_response_with_storage(storage)?;
-    let official_metadata = load_official_model_metadata()?;
-    let content = if use_official_account_catalog {
-        let custom_model_slugs = storage
-            .list_api_models_v2()
-            .map_err(|err| format!("list custom account-pool models failed: {err}"))?
-            .into_iter()
-            .filter(|model| model.origin == "custom")
-            .map(|model| model.slug)
-            .collect();
-        serialize_account_pool_model_catalog(&catalog, &official_metadata, &custom_model_slugs)?
-    } else {
-        serialize_gateway_model_catalog_with_official(&catalog, &official_metadata)?
+    let (content, models_count) = match policy {
+        GatewayCatalogPolicy::OfficialAccountPool => {
+            let official_models = load_official_model_catalog()?;
+            let models_count = official_models.len();
+            (
+                serialize_account_pool_model_catalog(&official_models)?,
+                models_count,
+            )
+        }
+        GatewayCatalogPolicy::Managed => {
+            let catalog = crate::models_v2::text_generation_models_response_with_storage(storage)?;
+            let models_count = catalog.models.len();
+            (serialize_gateway_model_catalog(&catalog)?, models_count)
+        }
     };
     write_atomic(catalog_path, &content)?;
-    Ok(catalog.models.len())
+    Ok(models_count)
 }
 
-#[derive(Debug, Default)]
-struct OfficialModelMetadata {
-    by_slug: HashMap<String, Value>,
-}
-
-fn load_official_model_metadata() -> Result<OfficialModelMetadata, String> {
+fn load_official_model_catalog() -> Result<Vec<Value>, String> {
     let codex_home = crate::codex_profile::resolve_profile_dir(None)?;
     let cache_path = codex_home.join("models_cache.json");
     if !cache_path.is_file() {
-        return Ok(OfficialModelMetadata::default());
+        return Err(format!(
+            "official Codex model cache not found: {}",
+            cache_path.display()
+        ));
     }
 
     let content = fs::read_to_string(&cache_path).map_err(|err| {
@@ -53,101 +57,31 @@ fn load_official_model_metadata() -> Result<OfficialModelMetadata, String> {
             cache_path.display()
         )
     })?;
-    official_model_metadata_from_value(&value)
+    official_model_catalog_from_value(&value)
 }
 
-fn official_model_metadata_from_value(value: &Value) -> Result<OfficialModelMetadata, String> {
+fn official_model_catalog_from_value(value: &Value) -> Result<Vec<Value>, String> {
     let models = value
         .get("models")
         .and_then(Value::as_array)
         .ok_or_else(|| "official Codex model cache is missing models array".to_string())?;
-    let mut metadata = OfficialModelMetadata::default();
+    if models.is_empty() {
+        return Err("official Codex model cache is empty".to_string());
+    }
     for model in models {
-        let Some(slug) = model.get("slug").and_then(Value::as_str) else {
-            continue;
-        };
-        metadata.by_slug.insert(slug.to_string(), model.clone());
-    }
-    Ok(metadata)
-}
-
-fn model_has_instruction_template(model_messages: Option<&Value>) -> bool {
-    model_messages
-        .and_then(Value::as_object)
-        .and_then(|messages| messages.get("instructions_template"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .is_some_and(|value| !value.is_empty())
-}
-
-fn merge_model_messages(target: &mut Option<Value>, source: Option<&Value>) {
-    let Some(source) = source.and_then(Value::as_object) else {
-        return;
-    };
-    if target.is_none() {
-        *target = Some(Value::Object(source.clone()));
-        return;
-    }
-    let Some(target) = target.as_mut().and_then(Value::as_object_mut) else {
-        return;
-    };
-    for (key, value) in source {
-        let should_fill = match target.get(key) {
-            None | Some(Value::Null) => true,
-            Some(Value::String(value)) => value.trim().is_empty(),
-            Some(_) => false,
-        };
-        if should_fill {
-            target.insert(key.clone(), value.clone());
-        }
-    }
-}
-
-fn fill_missing_official_metadata(
-    model: &mut codexmanager_core::rpc::types::ModelInfo,
-    official_metadata: &OfficialModelMetadata,
-) {
-    let exact = official_metadata.by_slug.get(&model.slug);
-
-    if model
-        .base_instructions
-        .as_deref()
-        .map(str::trim)
-        .is_none_or(|value| value.is_empty())
-    {
-        model.base_instructions = exact
-            .and_then(|source| source.get("base_instructions"))
+        let slug = model
+            .get("slug")
             .and_then(Value::as_str)
-            .map(str::to_string);
-    }
-    if !model_has_instruction_template(model.model_messages.as_ref()) {
-        merge_model_messages(
-            &mut model.model_messages,
-            exact.and_then(|source| source.get("model_messages")),
-        );
-    }
-
-    if let Some(exact) = exact {
-        for (target, key) in [
-            (&mut model.availability_nux, "availability_nux"),
-            (&mut model.upgrade, "upgrade"),
-        ] {
-            if target.as_ref().is_none_or(Value::is_null) {
-                *target = exact.get(key).cloned();
-            }
+            .map(str::trim)
+            .unwrap_or_default();
+        if slug.is_empty() {
+            return Err("official Codex model cache contains a model without slug".to_string());
         }
     }
+    Ok(models.clone())
 }
 
-#[cfg(test)]
 fn serialize_gateway_model_catalog(catalog: &ModelsResponse) -> Result<String, String> {
-    serialize_gateway_model_catalog_with_official(catalog, &OfficialModelMetadata::default())
-}
-
-fn serialize_gateway_model_catalog_with_official(
-    catalog: &ModelsResponse,
-    official_metadata: &OfficialModelMetadata,
-) -> Result<String, String> {
     if catalog.models.is_empty() {
         return Err(
             "managed model catalog is empty; refusing to replace the Codex catalog".to_string(),
@@ -155,7 +89,7 @@ fn serialize_gateway_model_catalog_with_official(
     }
     let mut catalog = catalog.clone();
     for model in &mut catalog.models {
-        prepare_managed_model(model, official_metadata)?;
+        prepare_managed_model(model);
     }
     let mut content = serde_json::to_string_pretty(&catalog)
         .map_err(|err| format!("serialize managed model catalog failed: {err}"))?;
@@ -163,58 +97,24 @@ fn serialize_gateway_model_catalog_with_official(
     Ok(content)
 }
 
-fn serialize_account_pool_model_catalog(
-    catalog: &ModelsResponse,
-    official_metadata: &OfficialModelMetadata,
-    custom_model_slugs: &HashSet<String>,
-) -> Result<String, String> {
-    if catalog.models.is_empty() {
+fn serialize_account_pool_model_catalog(official_models: &[Value]) -> Result<String, String> {
+    if official_models.is_empty() {
         return Err(
-            "managed model catalog is empty; refusing to replace the Codex catalog".to_string(),
-        );
-    }
-
-    let mut models = Vec::with_capacity(catalog.models.len());
-    for model in &catalog.models {
-        if let Some(official) = official_metadata.by_slug.get(&model.slug) {
-            // Account-pool mode intentionally preserves the complete official object. New Codex
-            // fields therefore flow through without requiring a matching Manager release.
-            models.push(official.clone());
-            continue;
-        }
-
-        // Official entries missing from the current Codex catalog are intentionally omitted so
-        // account-pool mode follows removals as well as additions. Only explicit Manager custom
-        // aliases retain the compatibility fallback.
-        if !custom_model_slugs.contains(&model.slug) {
-            continue;
-        }
-        let mut fallback = model.clone();
-        prepare_managed_model(&mut fallback, official_metadata)?;
-        models.push(
-            serde_json::to_value(fallback)
-                .map_err(|err| format!("serialize account-pool fallback model failed: {err}"))?,
-        );
-    }
-
-    if models.is_empty() {
-        return Err(
-            "official Codex model cache has no enabled account-pool models; refusing to replace the Codex catalog"
+            "official Codex model cache is empty; refusing to replace the Codex catalog"
                 .to_string(),
         );
     }
 
-    let mut content = serde_json::to_string_pretty(&serde_json::json!({ "models": models }))
-        .map_err(|err| format!("serialize account-pool model catalog failed: {err}"))?;
+    // Preserve every official object verbatim. Account-pool mode must not depend on Manager's
+    // built-in model list, enabled flags, or schema knowledge.
+    let mut content =
+        serde_json::to_string_pretty(&serde_json::json!({ "models": official_models }))
+            .map_err(|err| format!("serialize account-pool model catalog failed: {err}"))?;
     content.push('\n');
     Ok(content)
 }
 
-fn prepare_managed_model(
-    model: &mut codexmanager_core::rpc::types::ModelInfo,
-    official_metadata: &OfficialModelMetadata,
-) -> Result<(), String> {
-    fill_missing_official_metadata(model, official_metadata);
+fn prepare_managed_model(model: &mut codexmanager_core::rpc::types::ModelInfo) {
     if model
         .shell_type
         .as_deref()
@@ -249,32 +149,17 @@ fn prepare_managed_model(
             .entry(key.to_string())
             .or_insert(serde_json::Value::Null);
     }
-    model
-        .extra
-        .entry("use_responses_lite".to_string())
-        .or_insert(serde_json::Value::Bool(false));
+    // Managed aggregate and hybrid catalogs keep the established full Responses transport.
+    // Responses Lite requires official prompt metadata and must remain exclusive to the raw
+    // official account-pool catalog.
+    model.extra.insert(
+        "use_responses_lite".to_string(),
+        serde_json::Value::Bool(false),
+    );
     model
         .extra
         .entry("include_skills_usage_instructions".to_string())
         .or_insert(serde_json::Value::Bool(false));
-
-    let uses_responses_lite = model
-        .extra
-        .get("use_responses_lite")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let has_base_instructions = model
-        .base_instructions
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|value| !value.is_empty());
-    if uses_responses_lite && !has_base_instructions {
-        return Err(format!(
-            "model {} enables Responses Lite but official base instructions are unavailable; refusing to replace the Codex catalog",
-            model.slug
-        ));
-    }
-    Ok(())
 }
 
 fn write_atomic(path: &Path, content: &str) -> Result<(), String> {
@@ -410,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn gateway_catalog_fills_official_instruction_metadata() {
+    fn managed_catalog_disables_responses_lite_without_official_metadata() {
         let mut model = ModelInfo {
             slug: "gpt-test".to_string(),
             display_name: "GPT Test".to_string(),
@@ -423,152 +308,55 @@ mod tests {
             models: vec![model],
             ..ModelsResponse::default()
         };
-        let official = official_model_metadata_from_value(&serde_json::json!({
-            "models": [{
-                "slug": "gpt-test",
-                "base_instructions": "official instructions",
-                "model_messages": {
-                    "instructions_template": "official template",
-                    "instructions_variables": {"personality_default": ""}
-                },
-                "availability_nux": {"message": "new"},
-                "upgrade": null
-            }]
-        }))
-        .expect("parse official metadata");
 
-        let content = serialize_gateway_model_catalog_with_official(&catalog, &official)
-            .expect("serialize catalog");
+        let content = serialize_gateway_model_catalog(&catalog).expect("serialize catalog");
         let value: Value = serde_json::from_str(&content).expect("parse catalog");
         let model = &value["models"][0];
 
-        assert_eq!(
-            model["base_instructions"].as_str(),
-            Some("official instructions")
-        );
-        assert_eq!(
-            model["model_messages"]["instructions_template"].as_str(),
-            Some("official template")
-        );
-        assert_eq!(model["availability_nux"]["message"].as_str(), Some("new"));
-        assert!(model["upgrade"].is_null());
-        assert_eq!(model["use_responses_lite"].as_bool(), Some(true));
+        assert_eq!(model["base_instructions"].as_str(), Some(""));
+        assert_eq!(model["use_responses_lite"].as_bool(), Some(false));
     }
 
     #[test]
-    fn account_pool_catalog_preserves_complete_official_model_object() {
-        let catalog = ModelsResponse {
-            models: vec![ModelInfo {
-                slug: "gpt-test".to_string(),
-                display_name: "Manager Name".to_string(),
-                shell_type: Some("manager_shell".to_string()),
-                ..ModelInfo::default()
-            }],
-            ..ModelsResponse::default()
-        };
-        let official = official_model_metadata_from_value(&serde_json::json!({
+    fn account_pool_catalog_preserves_complete_official_catalog() {
+        let official = official_model_catalog_from_value(&serde_json::json!({
             "models": [{
                 "slug": "gpt-test",
                 "display_name": "Official Name",
                 "shell_type": "official_shell",
                 "base_instructions": "official instructions",
                 "future_codex_field": {"revision": 7}
+            }, {
+                "slug": "future-model-manager-does-not-know",
+                "display_name": "Future Model",
+                "future_codex_field": true
             }]
         }))
-        .expect("parse official metadata");
+        .expect("parse official catalog");
 
-        let content = serialize_account_pool_model_catalog(&catalog, &official, &HashSet::new())
+        let content = serialize_account_pool_model_catalog(&official)
             .expect("serialize account-pool catalog");
         let value: Value = serde_json::from_str(&content).expect("parse catalog");
         let model = &value["models"][0];
 
+        assert_eq!(value["models"].as_array().map(Vec::len), Some(2));
         assert_eq!(model["display_name"].as_str(), Some("Official Name"));
         assert_eq!(model["shell_type"].as_str(), Some("official_shell"));
         assert_eq!(model["future_codex_field"]["revision"].as_i64(), Some(7));
         assert!(model.get("max_context_window").is_none());
-    }
-
-    #[test]
-    fn account_pool_catalog_keeps_custom_model_fallback() {
-        let catalog = ModelsResponse {
-            models: vec![ModelInfo {
-                slug: "custom-alias".to_string(),
-                display_name: "Custom Alias".to_string(),
-                ..ModelInfo::default()
-            }],
-            ..ModelsResponse::default()
-        };
-
-        let content = serialize_account_pool_model_catalog(
-            &catalog,
-            &OfficialModelMetadata::default(),
-            &HashSet::from(["custom-alias".to_string()]),
-        )
-        .expect("serialize custom fallback");
-        let value: Value = serde_json::from_str(&content).expect("parse catalog");
-
-        assert_eq!(value["models"][0]["slug"].as_str(), Some("custom-alias"));
         assert_eq!(
-            value["models"][0]["shell_type"].as_str(),
-            Some("shell_command")
+            value["models"][1]["slug"].as_str(),
+            Some("future-model-manager-does-not-know")
         );
     }
 
     #[test]
-    fn account_pool_catalog_omits_stale_builtin_model() {
-        let catalog = ModelsResponse {
-            models: vec![
-                ModelInfo {
-                    slug: "retired-official-model".to_string(),
-                    display_name: "Retired".to_string(),
-                    ..ModelInfo::default()
-                },
-                ModelInfo {
-                    slug: "current-official-model".to_string(),
-                    display_name: "Generated Current".to_string(),
-                    ..ModelInfo::default()
-                },
-            ],
-            ..ModelsResponse::default()
-        };
-        let official = official_model_metadata_from_value(&serde_json::json!({
-            "models": [{
-                "slug": "current-official-model",
-                "display_name": "Official Current"
-            }]
+    fn official_catalog_rejects_missing_slug() {
+        let err = official_model_catalog_from_value(&serde_json::json!({
+            "models": [{"display_name": "Broken"}]
         }))
-        .expect("parse official metadata");
-
-        let content = serialize_account_pool_model_catalog(&catalog, &official, &HashSet::new())
-            .expect("serialize account-pool catalog");
-        let value: Value = serde_json::from_str(&content).expect("parse catalog");
-
-        assert_eq!(value["models"].as_array().map(Vec::len), Some(1));
-        assert_eq!(
-            value["models"][0]["slug"].as_str(),
-            Some("current-official-model")
-        );
-    }
-
-    #[test]
-    fn gateway_catalog_rejects_responses_lite_without_instructions() {
-        let mut model = ModelInfo {
-            slug: "gpt-lite".to_string(),
-            display_name: "GPT Lite".to_string(),
-            ..ModelInfo::default()
-        };
-        model
-            .extra
-            .insert("use_responses_lite".to_string(), Value::Bool(true));
-        let catalog = ModelsResponse {
-            models: vec![model],
-            ..ModelsResponse::default()
-        };
-
-        let err = serialize_gateway_model_catalog(&catalog)
-            .expect_err("Responses Lite without instructions must fail");
-        assert!(err.contains("gpt-lite"));
-        assert!(err.contains("Responses Lite"));
+        .expect_err("missing slug must fail");
+        assert!(err.contains("without slug"));
     }
 
     #[test]

--- a/crates/service/src/codex_model_catalog.rs
+++ b/crates/service/src/codex_model_catalog.rs
@@ -1,9 +1,16 @@
 use codexmanager_core::rpc::types::ModelsResponse;
-use codexmanager_core::storage::Storage;
+use codexmanager_core::storage::{Account, Storage};
+use reqwest::header::{ACCEPT, ACCEPT_ENCODING, AUTHORIZATION, ETAG, USER_AGENT};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const OFFICIAL_CATALOG_CACHE_DIR: &str = "official-model-catalogs";
+const OFFICIAL_CATALOG_CACHE_TTL_SECS: i64 = 300;
+static OFFICIAL_CATALOG_SYNC_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GatewayCatalogPolicy {
@@ -41,7 +48,7 @@ pub(crate) fn models_response_for_gateway_key(
     let policy = gateway_catalog_policy_for_api_key(storage, api_key_id)?;
     let response = match policy {
         GatewayCatalogPolicy::OfficialAccountPool => {
-            let value = load_official_model_cache()?;
+            let value = load_or_sync_official_model_catalog(storage, api_key_id)?;
             official_models_response_from_value(value)?
         }
         GatewayCatalogPolicy::Managed => crate::models_v2::models_response_with_storage(storage)?,
@@ -57,12 +64,13 @@ fn official_models_response_from_value(value: Value) -> Result<ModelsResponse, S
 
 pub(crate) fn write_gateway_model_catalog(
     storage: &Storage,
+    api_key_id: &str,
     catalog_path: &Path,
     policy: GatewayCatalogPolicy,
 ) -> Result<usize, String> {
     let (content, models_count) = match policy {
         GatewayCatalogPolicy::OfficialAccountPool => {
-            let official_cache = load_official_model_cache()?;
+            let official_cache = load_or_sync_official_model_catalog(storage, api_key_id)?;
             let official_models = official_model_catalog_from_value(&official_cache)?;
             let models_count = official_models.len();
             (
@@ -80,28 +88,255 @@ pub(crate) fn write_gateway_model_catalog(
     Ok(models_count)
 }
 
-fn load_official_model_cache() -> Result<Value, String> {
-    let codex_home = crate::codex_profile::resolve_profile_dir(None)?;
-    let cache_path = codex_home.join("models_cache.json");
-    if !cache_path.is_file() {
+fn load_or_sync_official_model_catalog(
+    storage: &Storage,
+    api_key_id: &str,
+) -> Result<Value, String> {
+    let client_version = crate::gateway::current_codex_user_agent_version();
+    let cache_path = official_catalog_cache_path(api_key_id);
+    let now = chrono::Utc::now().timestamp();
+    let cached = load_compatible_official_snapshot(&cache_path, &client_version);
+    if cached
+        .as_ref()
+        .is_some_and(|value| official_snapshot_is_fresh(value, now))
+    {
+        return Ok(cached.expect("checked above"));
+    }
+
+    let sync_lock = OFFICIAL_CATALOG_SYNC_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = crate::lock_utils::lock_recover(sync_lock, "official_catalog_sync");
+
+    // Another caller may have completed the refresh while this caller waited for the lock.
+    let cached = load_compatible_official_snapshot(&cache_path, &client_version);
+    if cached
+        .as_ref()
+        .is_some_and(|value| official_snapshot_is_fresh(value, chrono::Utc::now().timestamp()))
+    {
+        return Ok(cached.expect("checked above"));
+    }
+
+    match fetch_official_model_catalog(storage, api_key_id, &client_version) {
+        Ok((response, etag)) => {
+            let snapshot = build_official_snapshot(response, &client_version, etag.as_deref())?;
+            write_official_snapshot(&cache_path, &snapshot)?;
+            Ok(snapshot)
+        }
+        Err(err) => match cached {
+            Some(snapshot) => {
+                log::warn!(
+                    "refresh official Codex model catalog failed; using stale snapshot for client_version {client_version}: {err}"
+                );
+                Ok(snapshot)
+            }
+            None => Err(format!(
+                "refresh official Codex model catalog failed and no snapshot exists for client_version {client_version}: {err}"
+            )),
+        },
+    }
+}
+
+fn fetch_official_model_catalog(
+    storage: &Storage,
+    api_key_id: &str,
+    client_version: &str,
+) -> Result<(Value, Option<String>), String> {
+    let api_key = storage
+        .find_api_key_by_id(api_key_id)
+        .map_err(|err| format!("read api key routing config failed: {err}"))?
+        .ok_or_else(|| "api key not found".to_string())?;
+    let upstream_base = crate::gateway::gateway_resolve_effective_upstream_base(&api_key);
+    if !crate::gateway::gateway_should_send_chatgpt_account_header(&upstream_base) {
         return Err(format!(
-            "official Codex model cache not found: {}",
-            cache_path.display()
+            "account-pool model sync requires the official ChatGPT Codex backend, got {upstream_base}"
         ));
     }
 
-    let content = fs::read_to_string(&cache_path).map_err(|err| {
-        format!(
-            "read official Codex model cache failed ({}): {err}",
+    let (models_url, _) =
+        crate::gateway::gateway_compute_upstream_url(&upstream_base, "/v1/models");
+    let mut models_url = reqwest::Url::parse(&models_url)
+        .map_err(|err| format!("build official Codex model endpoint failed: {err}"))?;
+    models_url
+        .query_pairs_mut()
+        .append_pair("client_version", client_version);
+
+    let routed = crate::gateway::gateway_collect_routed_candidates_with_log_source(
+        storage, api_key_id, None,
+    )?;
+    if routed.candidates.is_empty() {
+        return Err("no available OpenAI account for official model sync".to_string());
+    }
+
+    let mut errors = Vec::new();
+    for (account, mut token) in routed.candidates {
+        let result = (|| {
+            let bearer =
+                crate::gateway::gateway_resolve_openai_bearer_token(storage, &account, &mut token)?;
+            let client = crate::gateway::upstream_client_for_account(account.id.as_str())?;
+            let mut request = client
+                .get(models_url.clone())
+                .header(
+                    AUTHORIZATION,
+                    crate::agent_identity::format_upstream_authorization(&bearer),
+                )
+                .header(ACCEPT, "application/json")
+                .header(ACCEPT_ENCODING, "identity")
+                .header(USER_AGENT, crate::gateway::current_codex_user_agent())
+                .header("originator", crate::gateway::current_wire_originator());
+            if let Some(account_id) = official_chatgpt_account_id(&account, &upstream_base) {
+                request = request.header("ChatGPT-Account-ID", account_id);
+            }
+            let response = request
+                .send()
+                .map_err(|err| format!("request official Codex model endpoint failed: {err}"))?;
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().unwrap_or_default();
+                return Err(format!(
+                    "official Codex model endpoint returned {status}: {}",
+                    truncate_error_body(&body)
+                ));
+            }
+            let response_etag = response
+                .headers()
+                .get(ETAG)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string);
+            let value = response
+                .json::<Value>()
+                .map_err(|err| format!("decode official Codex model response failed: {err}"))?;
+            official_model_catalog_from_value(&value)?;
+            Ok((value, response_etag))
+        })();
+        match result {
+            Ok(value) => return Ok(value),
+            Err(err) => errors.push(format!("account {}: {err}", account.id)),
+        }
+    }
+    Err(errors.join("; "))
+}
+
+fn official_chatgpt_account_id<'a>(account: &'a Account, upstream_base: &str) -> Option<&'a str> {
+    if !crate::gateway::gateway_should_send_chatgpt_account_header(upstream_base) {
+        return None;
+    }
+    account
+        .chatgpt_account_id
+        .as_deref()
+        .or(account.workspace_id.as_deref())
+}
+
+fn official_catalog_cache_path(api_key_id: &str) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(api_key_id.trim().as_bytes());
+    crate::process_env::db_dir()
+        .join(OFFICIAL_CATALOG_CACHE_DIR)
+        .join(format!("{:x}.json", hasher.finalize()))
+}
+
+fn load_compatible_official_snapshot(cache_path: &Path, client_version: &str) -> Option<Value> {
+    if !cache_path.is_file() {
+        return None;
+    }
+    let content = match fs::read_to_string(cache_path) {
+        Ok(content) => content,
+        Err(err) => {
+            log::warn!(
+                "read official Codex model snapshot failed ({}): {err}",
+                cache_path.display()
+            );
+            return None;
+        }
+    };
+    let value: Value = match serde_json::from_str(&content) {
+        Ok(value) => value,
+        Err(err) => {
+            log::warn!(
+                "parse official Codex model snapshot failed ({}): {err}",
+                cache_path.display()
+            );
+            return None;
+        }
+    };
+    if !official_snapshot_matches_client_version(&value, client_version) {
+        return None;
+    }
+    if let Err(err) = official_model_catalog_from_value(&value) {
+        log::warn!(
+            "validate official Codex model snapshot failed ({}): {err}",
             cache_path.display()
-        )
-    })?;
-    serde_json::from_str(&content).map_err(|err| {
-        format!(
-            "parse official Codex model cache failed ({}): {err}",
-            cache_path.display()
-        )
-    })
+        );
+        return None;
+    }
+    Some(value)
+}
+
+fn official_snapshot_matches_client_version(value: &Value, client_version: &str) -> bool {
+    value.get("client_version").and_then(Value::as_str) == Some(client_version)
+}
+
+fn official_snapshot_is_fresh(value: &Value, now: i64) -> bool {
+    let Some(fetched_at) = value.get("fetched_at").and_then(Value::as_str) else {
+        return false;
+    };
+    let Ok(fetched_at) = chrono::DateTime::parse_from_rfc3339(fetched_at) else {
+        return false;
+    };
+    now.saturating_sub(fetched_at.timestamp()) <= OFFICIAL_CATALOG_CACHE_TTL_SECS
+}
+
+fn build_official_snapshot(
+    mut response: Value,
+    client_version: &str,
+    etag: Option<&str>,
+) -> Result<Value, String> {
+    official_model_catalog_from_value(&response)?;
+    set_snapshot_fetch_metadata(&mut response, client_version, etag)?;
+    Ok(response)
+}
+
+fn set_snapshot_fetch_metadata(
+    snapshot: &mut Value,
+    client_version: &str,
+    etag: Option<&str>,
+) -> Result<(), String> {
+    let object = snapshot
+        .as_object_mut()
+        .ok_or_else(|| "official Codex model response is not a JSON object".to_string())?;
+    object.insert(
+        "fetched_at".to_string(),
+        Value::String(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+    );
+    object.insert(
+        "client_version".to_string(),
+        Value::String(client_version.to_string()),
+    );
+    match etag.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(etag) => {
+            object.insert("etag".to_string(), Value::String(etag.to_string()));
+        }
+        None => {
+            object.remove("etag");
+        }
+    }
+    Ok(())
+}
+
+fn write_official_snapshot(cache_path: &Path, snapshot: &Value) -> Result<(), String> {
+    let mut content = serde_json::to_string_pretty(snapshot)
+        .map_err(|err| format!("serialize official Codex model snapshot failed: {err}"))?;
+    content.push('\n');
+    write_atomic(cache_path, &content)
+}
+
+fn truncate_error_body(body: &str) -> String {
+    const MAX_CHARS: usize = 2_048;
+    let mut chars = body.chars();
+    let preview: String = chars.by_ref().take(MAX_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{preview}...")
+    } else {
+        preview
+    }
 }
 
 fn official_model_catalog_from_value(value: &Value) -> Result<Vec<Value>, String> {
@@ -468,6 +703,58 @@ mod tests {
             response.models[0].extra["future_codex_field"]["revision"],
             9
         );
+    }
+
+    #[test]
+    fn official_snapshot_is_scoped_to_exact_client_version() {
+        let snapshot = serde_json::json!({
+            "client_version": "0.145.0",
+            "models": [{"slug": "gpt-test"}]
+        });
+
+        assert!(official_snapshot_matches_client_version(
+            &snapshot, "0.145.0"
+        ));
+        assert!(!official_snapshot_matches_client_version(
+            &snapshot, "0.146.0"
+        ));
+    }
+
+    #[test]
+    fn official_snapshot_uses_five_minute_ttl() {
+        let snapshot = serde_json::json!({
+            "fetched_at": "2026-07-24T00:00:00Z",
+            "models": [{"slug": "gpt-test"}]
+        });
+        let fetched_at = chrono::DateTime::parse_from_rfc3339("2026-07-24T00:00:00Z")
+            .expect("timestamp")
+            .timestamp();
+
+        assert!(official_snapshot_is_fresh(&snapshot, fetched_at + 299));
+        assert!(official_snapshot_is_fresh(&snapshot, fetched_at + 300));
+        assert!(!official_snapshot_is_fresh(&snapshot, fetched_at + 301));
+    }
+
+    #[test]
+    fn official_snapshot_preserves_unknown_response_fields() {
+        let snapshot = build_official_snapshot(
+            serde_json::json!({
+                "models": [{
+                    "slug": "future-model",
+                    "future_codex_field": {"revision": 11}
+                }],
+                "future_top_level_field": true
+            }),
+            "0.145.0",
+            Some("W/\"catalog\""),
+        )
+        .expect("build snapshot");
+
+        assert_eq!(snapshot["client_version"], "0.145.0");
+        assert_eq!(snapshot["etag"], "W/\"catalog\"");
+        assert_eq!(snapshot["future_top_level_field"], true);
+        assert_eq!(snapshot["models"][0]["future_codex_field"]["revision"], 11);
+        assert!(snapshot["fetched_at"].as_str().is_some());
     }
 
     #[test]

--- a/crates/service/src/codex_model_catalog.rs
+++ b/crates/service/src/codex_model_catalog.rs
@@ -1,5 +1,7 @@
 use codexmanager_core::rpc::types::ModelsResponse;
 use codexmanager_core::storage::Storage;
+use serde_json::Value;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -9,12 +11,131 @@ pub(crate) fn write_gateway_model_catalog(
     catalog_path: &Path,
 ) -> Result<usize, String> {
     let catalog = crate::models_v2::text_generation_models_response_with_storage(storage)?;
-    let content = serialize_gateway_model_catalog(&catalog)?;
+    let official_metadata = load_official_model_metadata()?;
+    let content = serialize_gateway_model_catalog_with_official(&catalog, &official_metadata)?;
     write_atomic(catalog_path, &content)?;
     Ok(catalog.models.len())
 }
 
+#[derive(Debug, Default)]
+struct OfficialModelMetadata {
+    by_slug: HashMap<String, Value>,
+}
+
+fn load_official_model_metadata() -> Result<OfficialModelMetadata, String> {
+    let codex_home = crate::codex_profile::resolve_profile_dir(None)?;
+    let cache_path = codex_home.join("models_cache.json");
+    if !cache_path.is_file() {
+        return Ok(OfficialModelMetadata::default());
+    }
+
+    let content = fs::read_to_string(&cache_path).map_err(|err| {
+        format!(
+            "read official Codex model cache failed ({}): {err}",
+            cache_path.display()
+        )
+    })?;
+    let value: Value = serde_json::from_str(&content).map_err(|err| {
+        format!(
+            "parse official Codex model cache failed ({}): {err}",
+            cache_path.display()
+        )
+    })?;
+    official_model_metadata_from_value(&value)
+}
+
+fn official_model_metadata_from_value(value: &Value) -> Result<OfficialModelMetadata, String> {
+    let models = value
+        .get("models")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "official Codex model cache is missing models array".to_string())?;
+    let mut metadata = OfficialModelMetadata::default();
+    for model in models {
+        let Some(slug) = model.get("slug").and_then(Value::as_str) else {
+            continue;
+        };
+        metadata.by_slug.insert(slug.to_string(), model.clone());
+    }
+    Ok(metadata)
+}
+
+fn model_has_instruction_template(model_messages: Option<&Value>) -> bool {
+    model_messages
+        .and_then(Value::as_object)
+        .and_then(|messages| messages.get("instructions_template"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+}
+
+fn merge_model_messages(target: &mut Option<Value>, source: Option<&Value>) {
+    let Some(source) = source.and_then(Value::as_object) else {
+        return;
+    };
+    if target.is_none() {
+        *target = Some(Value::Object(source.clone()));
+        return;
+    }
+    let Some(target) = target.as_mut().and_then(Value::as_object_mut) else {
+        return;
+    };
+    for (key, value) in source {
+        let should_fill = match target.get(key) {
+            None | Some(Value::Null) => true,
+            Some(Value::String(value)) => value.trim().is_empty(),
+            Some(_) => false,
+        };
+        if should_fill {
+            target.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn fill_missing_official_metadata(
+    model: &mut codexmanager_core::rpc::types::ModelInfo,
+    official_metadata: &OfficialModelMetadata,
+) {
+    let exact = official_metadata.by_slug.get(&model.slug);
+
+    if model
+        .base_instructions
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(|value| value.is_empty())
+    {
+        model.base_instructions = exact
+            .and_then(|source| source.get("base_instructions"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+    }
+    if !model_has_instruction_template(model.model_messages.as_ref()) {
+        merge_model_messages(
+            &mut model.model_messages,
+            exact.and_then(|source| source.get("model_messages")),
+        );
+    }
+
+    if let Some(exact) = exact {
+        for (target, key) in [
+            (&mut model.availability_nux, "availability_nux"),
+            (&mut model.upgrade, "upgrade"),
+        ] {
+            if target.as_ref().is_none_or(Value::is_null) {
+                *target = exact.get(key).cloned();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 fn serialize_gateway_model_catalog(catalog: &ModelsResponse) -> Result<String, String> {
+    serialize_gateway_model_catalog_with_official(catalog, &OfficialModelMetadata::default())
+}
+
+fn serialize_gateway_model_catalog_with_official(
+    catalog: &ModelsResponse,
+    official_metadata: &OfficialModelMetadata,
+) -> Result<String, String> {
     if catalog.models.is_empty() {
         return Err(
             "managed model catalog is empty; refusing to replace the Codex catalog".to_string(),
@@ -22,6 +143,7 @@ fn serialize_gateway_model_catalog(catalog: &ModelsResponse) -> Result<String, S
     }
     let mut catalog = catalog.clone();
     for model in &mut catalog.models {
+        fill_missing_official_metadata(model, official_metadata);
         if model
             .shell_type
             .as_deref()
@@ -64,6 +186,23 @@ fn serialize_gateway_model_catalog(catalog: &ModelsResponse) -> Result<String, S
             .extra
             .entry("include_skills_usage_instructions".to_string())
             .or_insert(serde_json::Value::Bool(false));
+
+        let uses_responses_lite = model
+            .extra
+            .get("use_responses_lite")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let has_base_instructions = model
+            .base_instructions
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty());
+        if uses_responses_lite && !has_base_instructions {
+            return Err(format!(
+                "model {} enables Responses Lite but official base instructions are unavailable; refusing to replace the Codex catalog",
+                model.slug
+            ));
+        }
     }
     let mut content = serde_json::to_string_pretty(&catalog)
         .map_err(|err| format!("serialize managed model catalog failed: {err}"))?;
@@ -201,6 +340,73 @@ mod tests {
             value["models"][0]["shell_type"].as_str(),
             Some("custom_shell")
         );
+    }
+
+    #[test]
+    fn gateway_catalog_fills_official_instruction_metadata() {
+        let mut model = ModelInfo {
+            slug: "gpt-test".to_string(),
+            display_name: "GPT Test".to_string(),
+            ..ModelInfo::default()
+        };
+        model
+            .extra
+            .insert("use_responses_lite".to_string(), Value::Bool(true));
+        let catalog = ModelsResponse {
+            models: vec![model],
+            ..ModelsResponse::default()
+        };
+        let official = official_model_metadata_from_value(&serde_json::json!({
+            "models": [{
+                "slug": "gpt-test",
+                "base_instructions": "official instructions",
+                "model_messages": {
+                    "instructions_template": "official template",
+                    "instructions_variables": {"personality_default": ""}
+                },
+                "availability_nux": {"message": "new"},
+                "upgrade": null
+            }]
+        }))
+        .expect("parse official metadata");
+
+        let content = serialize_gateway_model_catalog_with_official(&catalog, &official)
+            .expect("serialize catalog");
+        let value: Value = serde_json::from_str(&content).expect("parse catalog");
+        let model = &value["models"][0];
+
+        assert_eq!(
+            model["base_instructions"].as_str(),
+            Some("official instructions")
+        );
+        assert_eq!(
+            model["model_messages"]["instructions_template"].as_str(),
+            Some("official template")
+        );
+        assert_eq!(model["availability_nux"]["message"].as_str(), Some("new"));
+        assert!(model["upgrade"].is_null());
+        assert_eq!(model["use_responses_lite"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn gateway_catalog_rejects_responses_lite_without_instructions() {
+        let mut model = ModelInfo {
+            slug: "gpt-lite".to_string(),
+            display_name: "GPT Lite".to_string(),
+            ..ModelInfo::default()
+        };
+        model
+            .extra
+            .insert("use_responses_lite".to_string(), Value::Bool(true));
+        let catalog = ModelsResponse {
+            models: vec![model],
+            ..ModelsResponse::default()
+        };
+
+        let err = serialize_gateway_model_catalog(&catalog)
+            .expect_err("Responses Lite without instructions must fail");
+        assert!(err.contains("gpt-lite"));
+        assert!(err.contains("Responses Lite"));
     }
 
     #[test]

--- a/crates/service/src/codex_model_catalog.rs
+++ b/crates/service/src/codex_model_catalog.rs
@@ -124,6 +124,7 @@ fn prepare_managed_model(model: &mut codexmanager_core::rpc::types::ModelInfo) {
     {
         model.shell_type = Some("shell_command".to_string());
     }
+    model.visibility.get_or_insert_with(|| "list".to_string());
     model.base_instructions.get_or_insert_with(String::new);
     model
         .availability_nux
@@ -136,6 +137,21 @@ fn prepare_managed_model(model: &mut codexmanager_core::rpc::types::ModelInfo) {
             "approvals": null,
         })
     });
+    model
+        .default_reasoning_summary
+        .get_or_insert_with(|| "auto".to_string());
+    model.support_verbosity.get_or_insert(false);
+    model
+        .web_search_tool_type
+        .get_or_insert_with(|| "text".to_string());
+    model.truncation_policy.get_or_insert_with(|| {
+        codexmanager_core::rpc::types::ModelTruncationPolicy {
+            mode: "tokens".to_string(),
+            limit: 10_000,
+            ..Default::default()
+        }
+    });
+    model.supports_parallel_tool_calls.get_or_insert(false);
     model.effective_context_window_percent.get_or_insert(95);
 
     let max_context_window = model.context_window.unwrap_or(200_000);
@@ -155,6 +171,10 @@ fn prepare_managed_model(model: &mut codexmanager_core::rpc::types::ModelInfo) {
     model.extra.insert(
         "use_responses_lite".to_string(),
         serde_json::Value::Bool(false),
+    );
+    model.extra.insert(
+        "supports_reasoning_summary_parameter".to_string(),
+        serde_json::Value::Bool(model.supports_reasoning_summaries.unwrap_or(false)),
     );
     model
         .extra
@@ -245,6 +265,31 @@ mod tests {
             Some("shell_command")
         );
         assert_eq!(value["models"][0]["base_instructions"].as_str(), Some(""));
+        assert_eq!(value["models"][0]["visibility"].as_str(), Some("list"));
+        assert_eq!(
+            value["models"][0]["default_reasoning_summary"].as_str(),
+            Some("auto")
+        );
+        assert_eq!(
+            value["models"][0]["support_verbosity"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(
+            value["models"][0]["truncation_policy"]["mode"].as_str(),
+            Some("tokens")
+        );
+        assert_eq!(
+            value["models"][0]["truncation_policy"]["limit"].as_i64(),
+            Some(10_000)
+        );
+        assert_eq!(
+            value["models"][0]["supports_parallel_tool_calls"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(
+            value["models"][0]["supports_reasoning_summary_parameter"].as_bool(),
+            Some(false)
+        );
         assert!(value["models"][0]["availability_nux"].is_null());
         assert!(value["models"][0]["upgrade"].is_null());
         assert_eq!(

--- a/crates/service/src/codex_model_catalog.rs
+++ b/crates/service/src/codex_model_catalog.rs
@@ -1,7 +1,7 @@
 use codexmanager_core::rpc::types::ModelsResponse;
 use codexmanager_core::storage::Storage;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -9,10 +9,22 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub(crate) fn write_gateway_model_catalog(
     storage: &Storage,
     catalog_path: &Path,
+    use_official_account_catalog: bool,
 ) -> Result<usize, String> {
     let catalog = crate::models_v2::text_generation_models_response_with_storage(storage)?;
     let official_metadata = load_official_model_metadata()?;
-    let content = serialize_gateway_model_catalog_with_official(&catalog, &official_metadata)?;
+    let content = if use_official_account_catalog {
+        let custom_model_slugs = storage
+            .list_api_models_v2()
+            .map_err(|err| format!("list custom account-pool models failed: {err}"))?
+            .into_iter()
+            .filter(|model| model.origin == "custom")
+            .map(|model| model.slug)
+            .collect();
+        serialize_account_pool_model_catalog(&catalog, &official_metadata, &custom_model_slugs)?
+    } else {
+        serialize_gateway_model_catalog_with_official(&catalog, &official_metadata)?
+    };
     write_atomic(catalog_path, &content)?;
     Ok(catalog.models.len())
 }
@@ -143,71 +155,126 @@ fn serialize_gateway_model_catalog_with_official(
     }
     let mut catalog = catalog.clone();
     for model in &mut catalog.models {
-        fill_missing_official_metadata(model, official_metadata);
-        if model
-            .shell_type
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .is_none()
-        {
-            model.shell_type = Some("shell_command".to_string());
-        }
-        model.base_instructions.get_or_insert_with(String::new);
-        model
-            .availability_nux
-            .get_or_insert(serde_json::Value::Null);
-        model.upgrade.get_or_insert(serde_json::Value::Null);
-        model.model_messages.get_or_insert_with(|| {
-            serde_json::json!({
-                "instructions_template": "",
-                "instructions_variables": null,
-                "approvals": null,
-            })
-        });
-        model.effective_context_window_percent.get_or_insert(95);
-
-        let max_context_window = model.context_window.unwrap_or(200_000);
-        model
-            .extra
-            .entry("max_context_window".to_string())
-            .or_insert_with(|| serde_json::json!(max_context_window));
-        for key in ["comp_hash", "tool_mode", "multi_agent_version"] {
-            model
-                .extra
-                .entry(key.to_string())
-                .or_insert(serde_json::Value::Null);
-        }
-        model
-            .extra
-            .entry("use_responses_lite".to_string())
-            .or_insert(serde_json::Value::Bool(false));
-        model
-            .extra
-            .entry("include_skills_usage_instructions".to_string())
-            .or_insert(serde_json::Value::Bool(false));
-
-        let uses_responses_lite = model
-            .extra
-            .get("use_responses_lite")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let has_base_instructions = model
-            .base_instructions
-            .as_deref()
-            .map(str::trim)
-            .is_some_and(|value| !value.is_empty());
-        if uses_responses_lite && !has_base_instructions {
-            return Err(format!(
-                "model {} enables Responses Lite but official base instructions are unavailable; refusing to replace the Codex catalog",
-                model.slug
-            ));
-        }
+        prepare_managed_model(model, official_metadata)?;
     }
     let mut content = serde_json::to_string_pretty(&catalog)
         .map_err(|err| format!("serialize managed model catalog failed: {err}"))?;
     content.push('\n');
     Ok(content)
+}
+
+fn serialize_account_pool_model_catalog(
+    catalog: &ModelsResponse,
+    official_metadata: &OfficialModelMetadata,
+    custom_model_slugs: &HashSet<String>,
+) -> Result<String, String> {
+    if catalog.models.is_empty() {
+        return Err(
+            "managed model catalog is empty; refusing to replace the Codex catalog".to_string(),
+        );
+    }
+
+    let mut models = Vec::with_capacity(catalog.models.len());
+    for model in &catalog.models {
+        if let Some(official) = official_metadata.by_slug.get(&model.slug) {
+            // Account-pool mode intentionally preserves the complete official object. New Codex
+            // fields therefore flow through without requiring a matching Manager release.
+            models.push(official.clone());
+            continue;
+        }
+
+        // Official entries missing from the current Codex catalog are intentionally omitted so
+        // account-pool mode follows removals as well as additions. Only explicit Manager custom
+        // aliases retain the compatibility fallback.
+        if !custom_model_slugs.contains(&model.slug) {
+            continue;
+        }
+        let mut fallback = model.clone();
+        prepare_managed_model(&mut fallback, official_metadata)?;
+        models.push(
+            serde_json::to_value(fallback)
+                .map_err(|err| format!("serialize account-pool fallback model failed: {err}"))?,
+        );
+    }
+
+    if models.is_empty() {
+        return Err(
+            "official Codex model cache has no enabled account-pool models; refusing to replace the Codex catalog"
+                .to_string(),
+        );
+    }
+
+    let mut content = serde_json::to_string_pretty(&serde_json::json!({ "models": models }))
+        .map_err(|err| format!("serialize account-pool model catalog failed: {err}"))?;
+    content.push('\n');
+    Ok(content)
+}
+
+fn prepare_managed_model(
+    model: &mut codexmanager_core::rpc::types::ModelInfo,
+    official_metadata: &OfficialModelMetadata,
+) -> Result<(), String> {
+    fill_missing_official_metadata(model, official_metadata);
+    if model
+        .shell_type
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_none()
+    {
+        model.shell_type = Some("shell_command".to_string());
+    }
+    model.base_instructions.get_or_insert_with(String::new);
+    model
+        .availability_nux
+        .get_or_insert(serde_json::Value::Null);
+    model.upgrade.get_or_insert(serde_json::Value::Null);
+    model.model_messages.get_or_insert_with(|| {
+        serde_json::json!({
+            "instructions_template": "",
+            "instructions_variables": null,
+            "approvals": null,
+        })
+    });
+    model.effective_context_window_percent.get_or_insert(95);
+
+    let max_context_window = model.context_window.unwrap_or(200_000);
+    model
+        .extra
+        .entry("max_context_window".to_string())
+        .or_insert_with(|| serde_json::json!(max_context_window));
+    for key in ["comp_hash", "tool_mode", "multi_agent_version"] {
+        model
+            .extra
+            .entry(key.to_string())
+            .or_insert(serde_json::Value::Null);
+    }
+    model
+        .extra
+        .entry("use_responses_lite".to_string())
+        .or_insert(serde_json::Value::Bool(false));
+    model
+        .extra
+        .entry("include_skills_usage_instructions".to_string())
+        .or_insert(serde_json::Value::Bool(false));
+
+    let uses_responses_lite = model
+        .extra
+        .get("use_responses_lite")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let has_base_instructions = model
+        .base_instructions
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+    if uses_responses_lite && !has_base_instructions {
+        return Err(format!(
+            "model {} enables Responses Lite but official base instructions are unavailable; refusing to replace the Codex catalog",
+            model.slug
+        ));
+    }
+    Ok(())
 }
 
 fn write_atomic(path: &Path, content: &str) -> Result<(), String> {
@@ -386,6 +453,101 @@ mod tests {
         assert_eq!(model["availability_nux"]["message"].as_str(), Some("new"));
         assert!(model["upgrade"].is_null());
         assert_eq!(model["use_responses_lite"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn account_pool_catalog_preserves_complete_official_model_object() {
+        let catalog = ModelsResponse {
+            models: vec![ModelInfo {
+                slug: "gpt-test".to_string(),
+                display_name: "Manager Name".to_string(),
+                shell_type: Some("manager_shell".to_string()),
+                ..ModelInfo::default()
+            }],
+            ..ModelsResponse::default()
+        };
+        let official = official_model_metadata_from_value(&serde_json::json!({
+            "models": [{
+                "slug": "gpt-test",
+                "display_name": "Official Name",
+                "shell_type": "official_shell",
+                "base_instructions": "official instructions",
+                "future_codex_field": {"revision": 7}
+            }]
+        }))
+        .expect("parse official metadata");
+
+        let content = serialize_account_pool_model_catalog(&catalog, &official, &HashSet::new())
+            .expect("serialize account-pool catalog");
+        let value: Value = serde_json::from_str(&content).expect("parse catalog");
+        let model = &value["models"][0];
+
+        assert_eq!(model["display_name"].as_str(), Some("Official Name"));
+        assert_eq!(model["shell_type"].as_str(), Some("official_shell"));
+        assert_eq!(model["future_codex_field"]["revision"].as_i64(), Some(7));
+        assert!(model.get("max_context_window").is_none());
+    }
+
+    #[test]
+    fn account_pool_catalog_keeps_custom_model_fallback() {
+        let catalog = ModelsResponse {
+            models: vec![ModelInfo {
+                slug: "custom-alias".to_string(),
+                display_name: "Custom Alias".to_string(),
+                ..ModelInfo::default()
+            }],
+            ..ModelsResponse::default()
+        };
+
+        let content = serialize_account_pool_model_catalog(
+            &catalog,
+            &OfficialModelMetadata::default(),
+            &HashSet::from(["custom-alias".to_string()]),
+        )
+        .expect("serialize custom fallback");
+        let value: Value = serde_json::from_str(&content).expect("parse catalog");
+
+        assert_eq!(value["models"][0]["slug"].as_str(), Some("custom-alias"));
+        assert_eq!(
+            value["models"][0]["shell_type"].as_str(),
+            Some("shell_command")
+        );
+    }
+
+    #[test]
+    fn account_pool_catalog_omits_stale_builtin_model() {
+        let catalog = ModelsResponse {
+            models: vec![
+                ModelInfo {
+                    slug: "retired-official-model".to_string(),
+                    display_name: "Retired".to_string(),
+                    ..ModelInfo::default()
+                },
+                ModelInfo {
+                    slug: "current-official-model".to_string(),
+                    display_name: "Generated Current".to_string(),
+                    ..ModelInfo::default()
+                },
+            ],
+            ..ModelsResponse::default()
+        };
+        let official = official_model_metadata_from_value(&serde_json::json!({
+            "models": [{
+                "slug": "current-official-model",
+                "display_name": "Official Current"
+            }]
+        }))
+        .expect("parse official metadata");
+
+        let content = serialize_account_pool_model_catalog(&catalog, &official, &HashSet::new())
+            .expect("serialize account-pool catalog");
+        let value: Value = serde_json::from_str(&content).expect("parse catalog");
+
+        assert_eq!(value["models"].as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            value["models"][0]["slug"].as_str(),
+            Some("current-official-model")
+        );
     }
 
     #[test]

--- a/crates/service/src/codex_model_catalog.rs
+++ b/crates/service/src/codex_model_catalog.rs
@@ -11,6 +11,50 @@ pub(crate) enum GatewayCatalogPolicy {
     Managed,
 }
 
+pub(crate) fn gateway_catalog_policy_for_api_key(
+    storage: &Storage,
+    api_key_id: &str,
+) -> Result<GatewayCatalogPolicy, String> {
+    let api_key = storage
+        .find_api_key_by_id(api_key_id)
+        .map_err(|err| format!("read api key routing config failed: {err}"))?
+        .ok_or_else(|| "api key not found".to_string())?;
+    Ok(gateway_catalog_policy_for_rotation_strategy(
+        api_key.rotation_strategy.as_str(),
+    ))
+}
+
+pub(crate) fn gateway_catalog_policy_for_rotation_strategy(
+    rotation_strategy: &str,
+) -> GatewayCatalogPolicy {
+    if rotation_strategy == crate::apikey_profile::ROTATION_ACCOUNT {
+        GatewayCatalogPolicy::OfficialAccountPool
+    } else {
+        GatewayCatalogPolicy::Managed
+    }
+}
+
+pub(crate) fn models_response_for_gateway_key(
+    storage: &Storage,
+    api_key_id: &str,
+) -> Result<(ModelsResponse, GatewayCatalogPolicy), String> {
+    let policy = gateway_catalog_policy_for_api_key(storage, api_key_id)?;
+    let response = match policy {
+        GatewayCatalogPolicy::OfficialAccountPool => {
+            let value = load_official_model_cache()?;
+            official_models_response_from_value(value)?
+        }
+        GatewayCatalogPolicy::Managed => crate::models_v2::models_response_with_storage(storage)?,
+    };
+    Ok((response, policy))
+}
+
+fn official_models_response_from_value(value: Value) -> Result<ModelsResponse, String> {
+    official_model_catalog_from_value(&value)?;
+    serde_json::from_value(value)
+        .map_err(|err| format!("decode official Codex model cache failed: {err}"))
+}
+
 pub(crate) fn write_gateway_model_catalog(
     storage: &Storage,
     catalog_path: &Path,
@@ -18,7 +62,8 @@ pub(crate) fn write_gateway_model_catalog(
 ) -> Result<usize, String> {
     let (content, models_count) = match policy {
         GatewayCatalogPolicy::OfficialAccountPool => {
-            let official_models = load_official_model_catalog()?;
+            let official_cache = load_official_model_cache()?;
+            let official_models = official_model_catalog_from_value(&official_cache)?;
             let models_count = official_models.len();
             (
                 serialize_account_pool_model_catalog(&official_models)?,
@@ -35,7 +80,7 @@ pub(crate) fn write_gateway_model_catalog(
     Ok(models_count)
 }
 
-fn load_official_model_catalog() -> Result<Vec<Value>, String> {
+fn load_official_model_cache() -> Result<Value, String> {
     let codex_home = crate::codex_profile::resolve_profile_dir(None)?;
     let cache_path = codex_home.join("models_cache.json");
     if !cache_path.is_file() {
@@ -51,13 +96,12 @@ fn load_official_model_catalog() -> Result<Vec<Value>, String> {
             cache_path.display()
         )
     })?;
-    let value: Value = serde_json::from_str(&content).map_err(|err| {
+    serde_json::from_str(&content).map_err(|err| {
         format!(
             "parse official Codex model cache failed ({}): {err}",
             cache_path.display()
         )
-    })?;
-    official_model_catalog_from_value(&value)
+    })
 }
 
 fn official_model_catalog_from_value(value: &Value) -> Result<Vec<Value>, String> {
@@ -402,6 +446,28 @@ mod tests {
         }))
         .expect_err("missing slug must fail");
         assert!(err.contains("without slug"));
+    }
+
+    #[test]
+    fn official_models_response_preserves_cache_metadata_and_future_fields() {
+        let response = official_models_response_from_value(serde_json::json!({
+            "fetched_at": "2026-07-24T00:00:00Z",
+            "etag": "W/\"future\"",
+            "client_version": "0.145.0",
+            "models": [{
+                "slug": "future-model",
+                "display_name": "Future Model",
+                "future_codex_field": {"revision": 9}
+            }]
+        }))
+        .expect("decode official response");
+
+        assert_eq!(response.models.len(), 1);
+        assert_eq!(response.extra["etag"], "W/\"future\"");
+        assert_eq!(
+            response.models[0].extra["future_codex_field"]["revision"],
+            9
+        );
     }
 
     #[test]

--- a/crates/service/src/codex_profile.rs
+++ b/crates/service/src/codex_profile.rs
@@ -397,6 +397,7 @@ pub(crate) fn apply_gateway(
         previous_model_catalog_for_gateway(&profile_dir, current_config.as_deref())?;
     let paths = managed_profile_paths(&profile_dir)?;
     let catalog_policy = gateway_catalog_policy(&storage, gateway_auth.id.as_str())?;
+    let supports_websockets = gateway_supports_websockets(&storage, gateway_auth.id.as_str())?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         &storage,
         &paths.gateway_model_catalog_path,
@@ -407,6 +408,7 @@ pub(crate) fn apply_gateway(
         current_config,
         &gateway_base_url,
         &paths.gateway_model_catalog_path,
+        supports_websockets,
     )?;
     write_profile_files(
         &profile_dir,
@@ -1994,6 +1996,7 @@ fn patch_config_for_gateway(
     content: Option<String>,
     base_url: &str,
     managed_catalog_path: &Path,
+    supports_websockets: bool,
 ) -> Result<String, String> {
     let mut doc = parse_config(content.as_deref().unwrap_or(""))?;
     doc.as_table_mut()
@@ -2027,13 +2030,11 @@ fn patch_config_for_gateway(
     provider.insert("name", toml_value("CodexManager"));
     provider.insert("base_url", toml_value(base_url));
     provider.insert("wire_api", toml_value("responses"));
-    provider.insert("supports_websockets", toml_value(true));
+    provider.insert("supports_websockets", toml_value(supports_websockets));
     Ok(doc.to_string())
 }
 
-pub(crate) fn sync_active_gateway_model_catalog_from_storage(
-    storage: &Storage,
-) -> Result<bool, String> {
+pub(crate) fn sync_active_gateway_profile_from_storage(storage: &Storage) -> Result<bool, String> {
     let Some(state) = load_state() else {
         return Ok(false);
     };
@@ -2047,12 +2048,37 @@ pub(crate) fn sync_active_gateway_model_catalog_from_storage(
         .as_deref()
         .ok_or_else(|| "active gateway profile is missing api key id".to_string())?;
     let catalog_policy = gateway_catalog_policy(storage, api_key_id)?;
+    let supports_websockets = gateway_supports_websockets(storage, api_key_id)?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         storage,
         &paths.gateway_model_catalog_path,
         catalog_policy,
     )?;
+    let gateway_base_url = normalize_gateway_base_url(state.gateway_base_url.as_deref());
+    let current_config = read_optional(&profile_dir.join(CONFIG_FILE))?;
+    let config_toml = patch_config_for_gateway(
+        current_config,
+        &gateway_base_url,
+        &paths.gateway_model_catalog_path,
+        supports_websockets,
+    )?;
+    write_atomic(&profile_dir.join(CONFIG_FILE), &config_toml)?;
     Ok(true)
+}
+
+pub(crate) fn sync_active_gateway_profile_for_api_key(
+    storage: &Storage,
+    api_key_id: &str,
+) -> Result<bool, String> {
+    let Some(state) = load_state() else {
+        return Ok(false);
+    };
+    if !matches!(state.mode, CodexProfileMode::Gateway)
+        || state.api_key_id.as_deref() != Some(api_key_id)
+    {
+        return Ok(false);
+    }
+    sync_active_gateway_profile_from_storage(storage)
 }
 
 fn gateway_catalog_policy(
@@ -2066,6 +2092,14 @@ fn gateway_catalog_policy(
     Ok(rotation_strategy_catalog_policy(
         api_key.rotation_strategy.as_str(),
     ))
+}
+
+fn gateway_supports_websockets(storage: &Storage, api_key_id: &str) -> Result<bool, String> {
+    let api_key = storage
+        .find_api_key_by_id(api_key_id)
+        .map_err(|err| format!("read api key websocket config failed: {err}"))?
+        .ok_or_else(|| "api key not found".to_string())?;
+    Ok(crate::gateway::gateway_supports_official_responses_websocket(&api_key))
 }
 
 fn rotation_strategy_catalog_policy(

--- a/crates/service/src/codex_profile.rs
+++ b/crates/service/src/codex_profile.rs
@@ -396,12 +396,11 @@ pub(crate) fn apply_gateway(
     let previous_model_catalog_json =
         previous_model_catalog_for_gateway(&profile_dir, current_config.as_deref())?;
     let paths = managed_profile_paths(&profile_dir)?;
-    let use_official_account_catalog =
-        gateway_uses_official_account_catalog(&storage, gateway_auth.id.as_str())?;
+    let catalog_policy = gateway_catalog_policy(&storage, gateway_auth.id.as_str())?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         &storage,
         &paths.gateway_model_catalog_path,
-        use_official_account_catalog,
+        catalog_policy,
     )?;
     let auth_json = build_gateway_auth_json(&secret)?;
     let config_toml = patch_config_for_gateway(
@@ -2047,30 +2046,36 @@ pub(crate) fn sync_active_gateway_model_catalog_from_storage(
         .api_key_id
         .as_deref()
         .ok_or_else(|| "active gateway profile is missing api key id".to_string())?;
-    let use_official_account_catalog = gateway_uses_official_account_catalog(storage, api_key_id)?;
+    let catalog_policy = gateway_catalog_policy(storage, api_key_id)?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         storage,
         &paths.gateway_model_catalog_path,
-        use_official_account_catalog,
+        catalog_policy,
     )?;
     Ok(true)
 }
 
-fn gateway_uses_official_account_catalog(
+fn gateway_catalog_policy(
     storage: &Storage,
     api_key_id: &str,
-) -> Result<bool, String> {
+) -> Result<crate::codex_model_catalog::GatewayCatalogPolicy, String> {
     let api_key = storage
         .find_api_key_by_id(api_key_id)
         .map_err(|err| format!("read api key routing config failed: {err}"))?
         .ok_or_else(|| "api key not found".to_string())?;
-    Ok(rotation_strategy_uses_official_account_catalog(
+    Ok(rotation_strategy_catalog_policy(
         api_key.rotation_strategy.as_str(),
     ))
 }
 
-fn rotation_strategy_uses_official_account_catalog(rotation_strategy: &str) -> bool {
-    rotation_strategy == crate::apikey_profile::ROTATION_ACCOUNT
+fn rotation_strategy_catalog_policy(
+    rotation_strategy: &str,
+) -> crate::codex_model_catalog::GatewayCatalogPolicy {
+    if rotation_strategy == crate::apikey_profile::ROTATION_ACCOUNT {
+        crate::codex_model_catalog::GatewayCatalogPolicy::OfficialAccountPool
+    } else {
+        crate::codex_model_catalog::GatewayCatalogPolicy::Managed
+    }
 }
 
 fn parse_config(content: &str) -> Result<DocumentMut, String> {

--- a/crates/service/src/codex_profile.rs
+++ b/crates/service/src/codex_profile.rs
@@ -403,6 +403,7 @@ pub(crate) fn apply_gateway(
     let supports_websockets = gateway_supports_websockets(&storage, gateway_auth.id.as_str())?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         &storage,
+        gateway_auth.id.as_str(),
         &paths.gateway_model_catalog_path,
         catalog_policy,
     )?;
@@ -2055,6 +2056,7 @@ pub(crate) fn sync_active_gateway_profile_from_storage(storage: &Storage) -> Res
     let supports_websockets = gateway_supports_websockets(storage, api_key_id)?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         storage,
+        api_key_id,
         &paths.gateway_model_catalog_path,
         catalog_policy,
     )?;

--- a/crates/service/src/codex_profile.rs
+++ b/crates/service/src/codex_profile.rs
@@ -396,9 +396,12 @@ pub(crate) fn apply_gateway(
     let previous_model_catalog_json =
         previous_model_catalog_for_gateway(&profile_dir, current_config.as_deref())?;
     let paths = managed_profile_paths(&profile_dir)?;
+    let use_official_account_catalog =
+        gateway_uses_official_account_catalog(&storage, gateway_auth.id.as_str())?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         &storage,
         &paths.gateway_model_catalog_path,
+        use_official_account_catalog,
     )?;
     let auth_json = build_gateway_auth_json(&secret)?;
     let config_toml = patch_config_for_gateway(
@@ -2040,11 +2043,34 @@ pub(crate) fn sync_active_gateway_model_catalog_from_storage(
     }
     let profile_dir = PathBuf::from(state.profile_dir);
     let paths = managed_profile_paths(&profile_dir)?;
+    let api_key_id = state
+        .api_key_id
+        .as_deref()
+        .ok_or_else(|| "active gateway profile is missing api key id".to_string())?;
+    let use_official_account_catalog = gateway_uses_official_account_catalog(storage, api_key_id)?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         storage,
         &paths.gateway_model_catalog_path,
+        use_official_account_catalog,
     )?;
     Ok(true)
+}
+
+fn gateway_uses_official_account_catalog(
+    storage: &Storage,
+    api_key_id: &str,
+) -> Result<bool, String> {
+    let api_key = storage
+        .find_api_key_by_id(api_key_id)
+        .map_err(|err| format!("read api key routing config failed: {err}"))?
+        .ok_or_else(|| "api key not found".to_string())?;
+    Ok(rotation_strategy_uses_official_account_catalog(
+        api_key.rotation_strategy.as_str(),
+    ))
+}
+
+fn rotation_strategy_uses_official_account_catalog(rotation_strategy: &str) -> bool {
+    rotation_strategy == crate::apikey_profile::ROTATION_ACCOUNT
 }
 
 fn parse_config(content: &str) -> Result<DocumentMut, String> {

--- a/crates/service/src/codex_profile.rs
+++ b/crates/service/src/codex_profile.rs
@@ -396,7 +396,10 @@ pub(crate) fn apply_gateway(
     let previous_model_catalog_json =
         previous_model_catalog_for_gateway(&profile_dir, current_config.as_deref())?;
     let paths = managed_profile_paths(&profile_dir)?;
-    let catalog_policy = gateway_catalog_policy(&storage, gateway_auth.id.as_str())?;
+    let catalog_policy = crate::codex_model_catalog::gateway_catalog_policy_for_api_key(
+        &storage,
+        gateway_auth.id.as_str(),
+    )?;
     let supports_websockets = gateway_supports_websockets(&storage, gateway_auth.id.as_str())?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         &storage,
@@ -2047,7 +2050,8 @@ pub(crate) fn sync_active_gateway_profile_from_storage(storage: &Storage) -> Res
         .api_key_id
         .as_deref()
         .ok_or_else(|| "active gateway profile is missing api key id".to_string())?;
-    let catalog_policy = gateway_catalog_policy(storage, api_key_id)?;
+    let catalog_policy =
+        crate::codex_model_catalog::gateway_catalog_policy_for_api_key(storage, api_key_id)?;
     let supports_websockets = gateway_supports_websockets(storage, api_key_id)?;
     crate::codex_model_catalog::write_gateway_model_catalog(
         storage,
@@ -2081,35 +2085,12 @@ pub(crate) fn sync_active_gateway_profile_for_api_key(
     sync_active_gateway_profile_from_storage(storage)
 }
 
-fn gateway_catalog_policy(
-    storage: &Storage,
-    api_key_id: &str,
-) -> Result<crate::codex_model_catalog::GatewayCatalogPolicy, String> {
-    let api_key = storage
-        .find_api_key_by_id(api_key_id)
-        .map_err(|err| format!("read api key routing config failed: {err}"))?
-        .ok_or_else(|| "api key not found".to_string())?;
-    Ok(rotation_strategy_catalog_policy(
-        api_key.rotation_strategy.as_str(),
-    ))
-}
-
 fn gateway_supports_websockets(storage: &Storage, api_key_id: &str) -> Result<bool, String> {
     let api_key = storage
         .find_api_key_by_id(api_key_id)
         .map_err(|err| format!("read api key websocket config failed: {err}"))?
         .ok_or_else(|| "api key not found".to_string())?;
     Ok(crate::gateway::gateway_supports_official_responses_websocket(&api_key))
-}
-
-fn rotation_strategy_catalog_policy(
-    rotation_strategy: &str,
-) -> crate::codex_model_catalog::GatewayCatalogPolicy {
-    if rotation_strategy == crate::apikey_profile::ROTATION_ACCOUNT {
-        crate::codex_model_catalog::GatewayCatalogPolicy::OfficialAccountPool
-    } else {
-        crate::codex_model_catalog::GatewayCatalogPolicy::Managed
-    }
 }
 
 fn parse_config(content: &str) -> Result<DocumentMut, String> {

--- a/crates/service/src/codex_profile_tests.rs
+++ b/crates/service/src/codex_profile_tests.rs
@@ -223,15 +223,21 @@ fn invalid_toml_is_rejected() {
 #[test]
 fn rotation_strategy_selects_catalog_ownership() {
     assert_eq!(
-        rotation_strategy_catalog_policy(crate::apikey_profile::ROTATION_ACCOUNT),
+        crate::codex_model_catalog::gateway_catalog_policy_for_rotation_strategy(
+            crate::apikey_profile::ROTATION_ACCOUNT
+        ),
         crate::codex_model_catalog::GatewayCatalogPolicy::OfficialAccountPool
     );
     assert_eq!(
-        rotation_strategy_catalog_policy(crate::apikey_profile::ROTATION_AGGREGATE_API),
+        crate::codex_model_catalog::gateway_catalog_policy_for_rotation_strategy(
+            crate::apikey_profile::ROTATION_AGGREGATE_API
+        ),
         crate::codex_model_catalog::GatewayCatalogPolicy::Managed
     );
     assert_eq!(
-        rotation_strategy_catalog_policy(crate::apikey_profile::ROTATION_HYBRID),
+        crate::codex_model_catalog::gateway_catalog_policy_for_rotation_strategy(
+            crate::apikey_profile::ROTATION_HYBRID
+        ),
         crate::codex_model_catalog::GatewayCatalogPolicy::Managed
     );
 }

--- a/crates/service/src/codex_profile_tests.rs
+++ b/crates/service/src/codex_profile_tests.rs
@@ -210,6 +210,19 @@ fn invalid_toml_is_rejected() {
 }
 
 #[test]
+fn only_account_rotation_uses_official_account_catalog() {
+    assert!(rotation_strategy_uses_official_account_catalog(
+        crate::apikey_profile::ROTATION_ACCOUNT
+    ));
+    assert!(!rotation_strategy_uses_official_account_catalog(
+        crate::apikey_profile::ROTATION_AGGREGATE_API
+    ));
+    assert!(!rotation_strategy_uses_official_account_catalog(
+        crate::apikey_profile::ROTATION_HYBRID
+    ));
+}
+
+#[test]
 fn usable_account_token_candidates_by_account_indexes_candidates() {
     let candidates = usable_account_token_candidates_by_account(vec![
         AccountTokenCandidate {

--- a/crates/service/src/codex_profile_tests.rs
+++ b/crates/service/src/codex_profile_tests.rs
@@ -158,6 +158,7 @@ name = "Other"
         Some(input.to_string()),
         "http://127.0.0.1:48770/v1",
         &managed_catalog,
+        true,
     )
     .expect("patch gateway");
 
@@ -168,6 +169,15 @@ name = "Other"
     assert!(output.contains("supports_websockets = true"));
     assert!(output.contains("model_catalog_json = \"/tmp/codexmanager/gateway-models.json\""));
     assert!(output.contains("[model_providers.other]"));
+
+    let without_websocket = patch_config_for_gateway(
+        Some(output),
+        "http://127.0.0.1:48770/v1",
+        &managed_catalog,
+        false,
+    )
+    .expect("disable gateway websocket");
+    assert!(without_websocket.contains("supports_websockets = false"));
 }
 
 #[test]
@@ -205,6 +215,7 @@ fn invalid_toml_is_rejected() {
         Some("bad = [".to_string()),
         "http://x/v1",
         Path::new("/tmp/gateway-models.json"),
+        false,
     )
     .is_err());
 }

--- a/crates/service/src/codex_profile_tests.rs
+++ b/crates/service/src/codex_profile_tests.rs
@@ -210,16 +210,19 @@ fn invalid_toml_is_rejected() {
 }
 
 #[test]
-fn only_account_rotation_uses_official_account_catalog() {
-    assert!(rotation_strategy_uses_official_account_catalog(
-        crate::apikey_profile::ROTATION_ACCOUNT
-    ));
-    assert!(!rotation_strategy_uses_official_account_catalog(
-        crate::apikey_profile::ROTATION_AGGREGATE_API
-    ));
-    assert!(!rotation_strategy_uses_official_account_catalog(
-        crate::apikey_profile::ROTATION_HYBRID
-    ));
+fn rotation_strategy_selects_catalog_ownership() {
+    assert_eq!(
+        rotation_strategy_catalog_policy(crate::apikey_profile::ROTATION_ACCOUNT),
+        crate::codex_model_catalog::GatewayCatalogPolicy::OfficialAccountPool
+    );
+    assert_eq!(
+        rotation_strategy_catalog_policy(crate::apikey_profile::ROTATION_AGGREGATE_API),
+        crate::codex_model_catalog::GatewayCatalogPolicy::Managed
+    );
+    assert_eq!(
+        rotation_strategy_catalog_policy(crate::apikey_profile::ROTATION_HYBRID),
+        crate::codex_model_catalog::GatewayCatalogPolicy::Managed
+    );
 }
 
 #[test]

--- a/crates/service/src/gateway/mod.rs
+++ b/crates/service/src/gateway/mod.rs
@@ -1002,6 +1002,10 @@ pub(crate) fn gateway_resolve_effective_upstream_base(
         .unwrap_or_else(resolve_upstream_base_url)
 }
 
+pub(crate) fn gateway_should_send_chatgpt_account_header(base: &str) -> bool {
+    upstream::config::should_send_chatgpt_account_header(base)
+}
+
 /// 函数 `gateway_supports_official_responses_websocket`
 ///
 /// 作者: gaohongshun

--- a/crates/service/src/gateway/request/local_models.rs
+++ b/crates/service/src/gateway/request/local_models.rs
@@ -67,6 +67,20 @@ fn filter_models_for_key(
     ))
 }
 
+fn filter_models_for_catalog_policy(
+    storage: &codexmanager_core::storage::Storage,
+    key_id: &str,
+    models: ModelsResponse,
+    policy: crate::codex_model_catalog::GatewayCatalogPolicy,
+) -> Result<(ModelsResponse, bool), String> {
+    match policy {
+        crate::codex_model_catalog::GatewayCatalogPolicy::OfficialAccountPool => Ok((models, true)),
+        crate::codex_model_catalog::GatewayCatalogPolicy::Managed => {
+            filter_models_for_key(storage, key_id, models)
+        }
+    }
+}
+
 fn models_etag_header(models: &ModelsResponse) -> Result<Option<tiny_http::Header>, String> {
     let Some(etag) = models.extra.get("etag").and_then(serde_json::Value::as_str) else {
         return Ok(None);
@@ -89,8 +103,15 @@ fn models_etag_header(models: &ModelsResponse) -> Result<Option<tiny_http::Heade
 /// 返回函数执行结果
 fn read_cached_models_response(
     storage: &codexmanager_core::storage::Storage,
-) -> Result<ModelsResponse, String> {
-    crate::models_v2::models_response_with_storage(storage)
+    key_id: &str,
+) -> Result<
+    (
+        ModelsResponse,
+        crate::codex_model_catalog::GatewayCatalogPolicy,
+    ),
+    String,
+> {
+    crate::codex_model_catalog::models_response_for_gateway_key(storage, key_id)
 }
 
 /// 函数 `maybe_respond_local_models`
@@ -134,8 +155,8 @@ pub(super) fn maybe_respond_local_models(
         reasoning_for_log,
         storage,
     };
-    let cached = match read_cached_models_response(storage) {
-        Ok(models) => models,
+    let (cached, catalog_policy) = match read_cached_models_response(storage, key_id) {
+        Ok(result) => result,
         Err(err) => {
             let message = crate::gateway::bilingual_error(
                 "读取模型缓存失败",
@@ -146,9 +167,8 @@ pub(super) fn maybe_respond_local_models(
         }
     };
 
-    let models = cached;
-
-    let (output_models, include_implicit_models) = filter_models_for_key(storage, key_id, models)?;
+    let (output_models, include_implicit_models) =
+        filter_models_for_catalog_policy(storage, key_id, cached, catalog_policy)?;
     let output = if include_implicit_models {
         serialize_models_response(&output_models)
     } else {

--- a/crates/service/src/gateway/request/tests/local_models_tests.rs
+++ b/crates/service/src/gateway/request/tests/local_models_tests.rs
@@ -2,6 +2,32 @@ use super::*;
 use codexmanager_core::rpc::types::{ModelInfo, ModelServiceTier, ModelsResponse};
 use serde_json::Value;
 
+#[test]
+fn official_account_catalog_bypasses_manager_key_filters() {
+    let storage = codexmanager_core::storage::Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+    let models = ModelsResponse {
+        models: vec![ModelInfo {
+            slug: "future-official-model".to_string(),
+            display_name: "Future Official Model".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let (filtered, include_implicit) = filter_models_for_catalog_policy(
+        &storage,
+        "missing-key-would-fail-managed-filtering",
+        models,
+        crate::codex_model_catalog::GatewayCatalogPolicy::OfficialAccountPool,
+    )
+    .expect("official catalog bypasses key filter");
+
+    assert!(include_implicit);
+    assert_eq!(filtered.models.len(), 1);
+    assert_eq!(filtered.models[0].slug, "future-official-model");
+}
+
 /// 函数 `serialize_models_response_outputs_codex_and_api_shapes`
 ///
 /// 作者: gaohongshun
@@ -253,7 +279,8 @@ fn local_models_lists_image_model_once_with_image_only_capabilities() {
     let storage = codexmanager_core::storage::Storage::open_in_memory().expect("open storage");
     storage.init().expect("init storage");
 
-    let response = read_cached_models_response(&storage).expect("read local models");
+    let response = crate::models_v2::models_response_with_storage(&storage)
+        .expect("read managed local models");
     assert_eq!(response.models.len(), 8);
     let image_models = response
         .models

--- a/crates/service/src/models_v2/import.rs
+++ b/crates/service/src/models_v2/import.rs
@@ -155,7 +155,7 @@ fn parse_codex_model(
         "serviceTiers": service_tiers,
         "inputModalities": input_modalities,
         "supportsParallelToolCalls": bool_field(object,&["supports_parallel_tool_calls","supportsParallelToolCalls"],false),
-        "supportsReasoningSummaries": bool_field(object,&["supports_reasoning_summaries","supportsReasoningSummaries"],false),
+        "supportsReasoningSummaries": bool_field(object,&["supports_reasoning_summary_parameter","supports_reasoning_summaries","supportsReasoningSummaries"],false),
         "supportsVerbosity": bool_field(object,&["support_verbosity","supportsVerbosity"],false),
         "supportsImageDetailOriginal": bool_field(object,&["supports_image_detail_original","supportsImageDetailOriginal"],false),
         "supportsSearchTool": bool_field(object,&["supports_search_tool","supportsSearchTool"],false),

--- a/crates/service/src/models_v2/mod.rs
+++ b/crates/service/src/models_v2/mod.rs
@@ -191,6 +191,51 @@ pub(crate) fn model_info(model: &ManagedModelV2) -> ModelInfo {
             "supports_text_generation".to_string(),
             serde_json::json!(supports_text_generation(model)),
         ),
+        (
+            "max_context_window".to_string(),
+            serde_json::json!(model
+                .max_context_window
+                .or(model.context_window)
+                .unwrap_or(200_000)),
+        ),
+        (
+            "comp_hash".to_string(),
+            capability(model, &["comp_hash", "compHash"])
+                .cloned()
+                .unwrap_or(Value::Null),
+        ),
+        (
+            "tool_mode".to_string(),
+            capability(model, &["tool_mode", "toolMode"])
+                .cloned()
+                .unwrap_or(Value::Null),
+        ),
+        (
+            "multi_agent_version".to_string(),
+            capability(model, &["multi_agent_version", "multiAgentVersion"])
+                .cloned()
+                .unwrap_or(Value::Null),
+        ),
+        (
+            "use_responses_lite".to_string(),
+            capability(model, &["use_responses_lite", "useResponsesLite"])
+                .and_then(Value::as_bool)
+                .map(Value::Bool)
+                .unwrap_or(Value::Bool(false)),
+        ),
+        (
+            "include_skills_usage_instructions".to_string(),
+            capability(
+                model,
+                &[
+                    "include_skills_usage_instructions",
+                    "includeSkillsUsageInstructions",
+                ],
+            )
+            .and_then(Value::as_bool)
+            .map(Value::Bool)
+            .unwrap_or(Value::Bool(false)),
+        ),
     ]);
     ModelInfo {
         slug: model.slug.clone(),
@@ -198,12 +243,32 @@ pub(crate) fn model_info(model: &ManagedModelV2) -> ModelInfo {
         description: model.description.clone(),
         default_reasoning_level: model.default_reasoning_effort.clone(),
         supported_reasoning_levels,
+        shell_type: capability(model, &["shell_type", "shellType"])
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .or_else(|| supports_text_generation(model).then(|| "shell_command".to_string())),
         visibility: Some(model.visibility.clone()),
         supported_in_api: model.supported_in_api,
         priority: model.sort_order,
         service_tiers,
-        base_instructions: None,
-        model_messages: None,
+        availability_nux: Some(
+            capability(model, &["availability_nux", "availabilityNux"])
+                .cloned()
+                .unwrap_or(Value::Null),
+        ),
+        upgrade: Some(
+            capability(model, &["upgrade"])
+                .cloned()
+                .unwrap_or(Value::Null),
+        ),
+        base_instructions: Some(String::new()),
+        model_messages: Some(serde_json::json!({
+            "instructions_template": "",
+            "instructions_variables": null,
+            "approvals": null,
+        })),
         supports_reasoning_summaries: capability(
             model,
             &["supports_reasoning_summaries", "supportsReasoningSummaries"],
@@ -239,6 +304,15 @@ pub(crate) fn model_info(model: &ManagedModelV2) -> ModelInfo {
         )
         .and_then(Value::as_bool),
         context_window: model.context_window,
+        effective_context_window_percent: capability(
+            model,
+            &[
+                "effective_context_window_percent",
+                "effectiveContextWindowPercent",
+            ],
+        )
+        .and_then(Value::as_i64)
+        .or(Some(95)),
         input_modalities: string_list(&["input_modalities", "inputModalities"]),
         supports_search_tool: capability(model, &["supports_search_tool", "supportsSearchTool"])
             .and_then(Value::as_bool),
@@ -287,6 +361,20 @@ mod tests {
         storage.init().expect("init storage");
 
         let all = models_response_with_storage(&storage).expect("full models response");
+        let text_model = all
+            .models
+            .iter()
+            .find(|model| model.slug == "gpt-5.6-sol")
+            .expect("text model");
+        assert_eq!(text_model.shell_type.as_deref(), Some("shell_command"));
+        assert_eq!(text_model.base_instructions.as_deref(), Some(""));
+        assert_eq!(text_model.effective_context_window_percent, Some(95));
+        assert_eq!(text_model.extra["max_context_window"], 372_000);
+        assert_eq!(text_model.extra["comp_hash"], "3000");
+        assert_eq!(text_model.extra["tool_mode"], "code_mode_only");
+        assert_eq!(text_model.extra["multi_agent_version"], "v2");
+        assert_eq!(text_model.extra["use_responses_lite"], true);
+        assert_eq!(text_model.extra["include_skills_usage_instructions"], false);
         let image = all
             .models
             .iter()
@@ -307,6 +395,27 @@ mod tests {
             .expect("text generation models response");
         assert!(!text.models.iter().any(|model| model.slug == "gpt-image-2"));
         assert_eq!(text.models.len() + 1, all.models.len());
+    }
+
+    #[test]
+    fn text_model_without_shell_capability_uses_codex_compatible_default() {
+        let model = ManagedModelV2 {
+            slug: "custom-text-model".to_string(),
+            display_name: "Custom Text Model".to_string(),
+            capabilities: serde_json::json!({}),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            model_info(&model).shell_type.as_deref(),
+            Some("shell_command")
+        );
+        let info = model_info(&model);
+        assert_eq!(info.base_instructions.as_deref(), Some(""));
+        assert_eq!(info.effective_context_window_percent, Some(95));
+        assert_eq!(info.extra["max_context_window"], 200_000);
+        assert_eq!(info.extra["comp_hash"], Value::Null);
+        assert_eq!(info.extra["use_responses_lite"], false);
     }
 
     #[test]

--- a/crates/service/src/models_v2/mod.rs
+++ b/crates/service/src/models_v2/mod.rs
@@ -97,9 +97,8 @@ pub(crate) fn delete(slug: &str) -> Result<(), String> {
 pub(super) fn sync_active_gateway_catalog_best_effort(
     storage: &codexmanager_core::storage::Storage,
 ) {
-    if let Err(err) = crate::codex_profile::sync_active_gateway_model_catalog_from_storage(storage)
-    {
-        log::warn!("event=sync_active_gateway_model_catalog_failed error={err}");
+    if let Err(err) = crate::codex_profile::sync_active_gateway_profile_from_storage(storage) {
+        log::warn!("event=sync_active_gateway_profile_failed error={err}");
     }
 }
 

--- a/crates/service/src/models_v2/mod.rs
+++ b/crates/service/src/models_v2/mod.rs
@@ -270,7 +270,11 @@ pub(crate) fn model_info(model: &ManagedModelV2) -> ModelInfo {
         })),
         supports_reasoning_summaries: capability(
             model,
-            &["supports_reasoning_summaries", "supportsReasoningSummaries"],
+            &[
+                "supports_reasoning_summary_parameter",
+                "supports_reasoning_summaries",
+                "supportsReasoningSummaries",
+            ],
         )
         .and_then(Value::as_bool),
         default_reasoning_summary: capability(

--- a/crates/start/src/main.rs
+++ b/crates/start/src/main.rs
@@ -704,6 +704,14 @@ fn main() {
         }
     }
 
+    println!("Waiting for web gateway readiness...");
+    if !wait_for_service_ready(&web_open_addr, 120) {
+        eprintln!("web gateway failed health check: http://{web_open_addr}/health");
+        let _ = web_child.kill();
+        let _ = service_child.kill();
+        std::process::exit(1);
+    }
+
     let should_exit = Arc::new(AtomicBool::new(false));
     {
         let flag = Arc::clone(&should_exit);


### PR DESCRIPTION
## 概述

本 PR 调整 OpenAI 账号池在网关模式下的 Codex 模型目录处理逻辑，使其尽可能跟随 Codex 官方模型目录，避免模型列表和运行时元数据与直接登录 OpenAI 账号时不一致。

## 问题

此前，CodexManager 生成的网关模型目录可能存在以下问题：

- 模型列表没有及时跟随 Codex 官方目录更新
- 部分新模型元数据缺失或不完整
- `shell_type`、`base_instructions`、模型消息及能力字段可能与当前 Codex 客户端不兼容
- OpenAI 账号池与聚合 API 共用部分模型目录处理逻辑，导致模型归属边界不够清晰
- 切换账号或更新目录后，已生成的网关 profile 可能继续使用旧目录

这些问题可能导致模型列表与直接登录 OpenAI 账号时不一致，或在加载 `model_catalog_json` 时出现字段缺失错误。

## 修改内容

- OpenAI 账号池的网关模型目录改为跟随官方 Codex 模型目录
- 补全新版 Codex 客户端需要的模型元数据，包括：
  - `shell_type`
  - `base_instructions`
  - model messages
  - reasoning 配置
  - verbosity 配置
  - tool 类型及模型能力字段
- 区分官方账号池目录与 Manager 管理的聚合 API 模型目录
- 对已有网关 profile 进行必要的目录重新同步
- 调整本地模型接口，使其遵循新的模型目录归属规则
- 在生成网关目录前等待官方目录准备完成，减少启动阶段生成不完整目录的情况
- 增加模型目录、Codex profile 和本地模型接口相关的回归测试

## 行为边界

本 PR 仅处理 OpenAI 账号池的模型目录同步和元数据兼容问题。

以下修改不会包含在本 PR 中，后续将分别提交：

- Codex CLI onboarding 的 platform mode 路由调整
- 旧版 `models_cache.json` 导出逻辑清理
- Responses WebSocket 对环境代理的继承支持

聚合 API 原有的自定义模型和映射逻辑不会改为强制跟随官方目录。

## 兼容性

- OpenAI 账号池继续使用 Codex 官方模型及能力定义
- 聚合 API 继续保留 Manager 原有的模型管理逻辑
- 不写死具体模型列表，以便后续 Codex 官方模型更新能够继续同步
- 保留旧 profile 的兼容与重新生成路径
- 不要求用户手动维护 `gateway-models.json`

## 验证

执行了以下检查：

- `cargo fmt --all -- --check`
- `cargo test -p codexmanager-service codex_model_catalog -- --test-threads=1`
- `cargo test -p codexmanager-service codex_profile -- --test-threads=1`
- `cargo test -p codexmanager-service local_models -- --test-threads=1`
- `cargo check -p codexmanager-service`
- `pnpm run build:desktop`
- `git diff --check upstream/main...HEAD`