### PR TITLE
fix: 让 Responses WebSocket 遵循环境代理配置

### DIFF
--- a/crates/service/src/gateway/core/runtime_config.rs
+++ b/crates/service/src/gateway/core/runtime_config.rs
@@ -383,6 +383,91 @@ pub(crate) fn upstream_proxy_url_for_account(account_id: &str) -> Option<String>
     current_upstream_proxy_url()
 }
 
+pub(crate) fn websocket_proxy_url_for_account(
+    account_id: &str,
+    target_url: &str,
+) -> Result<Option<String>, String> {
+    if let Some(proxy_url) = upstream_proxy_url_for_account(account_id) {
+        return Ok(Some(proxy_url));
+    }
+    environment_proxy_url_for_target(target_url)
+}
+
+fn environment_proxy_url_for_target(target_url: &str) -> Result<Option<String>, String> {
+    let target = reqwest::Url::parse(target_url.trim())
+        .map_err(|err| format!("invalid websocket target url {target_url}: {err}"))?;
+    if environment_no_proxy_matches(&target) {
+        return Ok(None);
+    }
+
+    let proxy_url = match target.scheme() {
+        "wss" | "https" => {
+            first_environment_proxy(&["https_proxy", "HTTPS_PROXY", "all_proxy", "ALL_PROXY"])
+        }
+        "ws" | "http" => {
+            first_environment_proxy(&["http_proxy", "HTTP_PROXY", "all_proxy", "ALL_PROXY"])
+        }
+        _ => None,
+    };
+    normalize_upstream_proxy_url(proxy_url.as_deref())
+        .map_err(|err| format!("invalid websocket environment proxy: {err}"))
+}
+
+fn first_environment_proxy(keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| env_non_empty(key))
+}
+
+fn environment_no_proxy_matches(target: &reqwest::Url) -> bool {
+    let Some(host) = target.host_str().map(|value| value.to_ascii_lowercase()) else {
+        return false;
+    };
+    let target_port = target.port_or_known_default();
+    let Some(raw) = env_non_empty("no_proxy").or_else(|| env_non_empty("NO_PROXY")) else {
+        return false;
+    };
+
+    raw.split(',').any(|entry| {
+        let entry = entry.trim();
+        if entry == "*" {
+            return true;
+        }
+        if entry.is_empty() {
+            return false;
+        }
+
+        let (pattern, port) = split_no_proxy_host_port(entry);
+        if port.is_some() && port != target_port {
+            return false;
+        }
+        let pattern = pattern
+            .trim()
+            .trim_start_matches("*.")
+            .trim_start_matches('.')
+            .trim_end_matches('.')
+            .to_ascii_lowercase();
+        !pattern.is_empty() && (host == pattern || host.ends_with(format!(".{pattern}").as_str()))
+    })
+}
+
+fn split_no_proxy_host_port(entry: &str) -> (&str, Option<u16>) {
+    if let Some(rest) = entry.strip_prefix('[') {
+        if let Some((host, suffix)) = rest.split_once(']') {
+            let port = suffix
+                .strip_prefix(':')
+                .and_then(|value| value.parse().ok());
+            return (host, port);
+        }
+    }
+    if entry.matches(':').count() == 1 {
+        if let Some((host, port)) = entry.rsplit_once(':') {
+            if let Ok(port) = port.parse::<u16>() {
+                return (host, Some(port));
+            }
+        }
+    }
+    (entry, None)
+}
+
 pub(crate) fn upstream_client_for_aggregate_api_candidate(
     aggregate_api_id: &str,
     url: &str,

--- a/crates/service/src/gateway/core/tests/runtime_config_tests.rs
+++ b/crates/service/src/gateway/core/tests/runtime_config_tests.rs
@@ -717,6 +717,127 @@ fn upstream_proxy_url_for_account_prefers_explicit_account_proxy() {
 }
 
 #[test]
+fn websocket_proxy_url_for_account_falls_back_to_lowercase_https_proxy() {
+    let _guard = crate::test_env_guard();
+    let db = TestDbGuard::new("runtime-websocket-env-proxy");
+    seed_account(db.path(), "acc-env");
+    let _managed_proxy = EnvGuard::clear(ENV_UPSTREAM_PROXY_URL);
+    let _pool_proxy = EnvGuard::clear(ENV_PROXY_LIST);
+    let _upper_https_proxy = EnvGuard::clear("HTTPS_PROXY");
+    let _https_proxy = EnvGuard::set("https_proxy", "http://127.0.0.1:58438");
+    let _all_proxy = EnvGuard::clear("all_proxy");
+    let _upper_all_proxy = EnvGuard::clear("ALL_PROXY");
+    let _no_proxy = EnvGuard::clear("no_proxy");
+    let _upper_no_proxy = EnvGuard::clear("NO_PROXY");
+
+    reload_from_env();
+
+    assert_eq!(
+        websocket_proxy_url_for_account(
+            "acc-env",
+            "wss://chatgpt.com/backend-api/codex/responses",
+        )
+        .expect("resolve websocket proxy")
+        .as_deref(),
+        Some("http://127.0.0.1:58438")
+    );
+}
+
+#[test]
+fn websocket_proxy_url_for_account_prefers_managed_proxy_over_environment() {
+    let _guard = crate::test_env_guard();
+    let db = TestDbGuard::new("runtime-websocket-managed-proxy");
+    seed_account(db.path(), "acc-managed");
+    let _managed_proxy = EnvGuard::set(ENV_UPSTREAM_PROXY_URL, "http://127.0.0.1:7001");
+    let _pool_proxy = EnvGuard::clear(ENV_PROXY_LIST);
+    let _upper_https_proxy = EnvGuard::clear("HTTPS_PROXY");
+    let _https_proxy = EnvGuard::set("https_proxy", "http://127.0.0.1:7002");
+    let _all_proxy = EnvGuard::clear("all_proxy");
+    let _upper_all_proxy = EnvGuard::clear("ALL_PROXY");
+    let _no_proxy = EnvGuard::clear("no_proxy");
+    let _upper_no_proxy = EnvGuard::clear("NO_PROXY");
+
+    reload_from_env();
+
+    assert_eq!(
+        websocket_proxy_url_for_account(
+            "acc-managed",
+            "wss://chatgpt.com/backend-api/codex/responses",
+        )
+        .expect("resolve websocket proxy")
+        .as_deref(),
+        Some("http://127.0.0.1:7001")
+    );
+}
+
+#[test]
+fn websocket_environment_proxy_honors_no_proxy_host_and_port() {
+    let _guard = crate::test_env_guard();
+    let db = TestDbGuard::new("runtime-websocket-no-proxy");
+    seed_account(db.path(), "acc-bypass");
+    let _managed_proxy = EnvGuard::clear(ENV_UPSTREAM_PROXY_URL);
+    let _pool_proxy = EnvGuard::clear(ENV_PROXY_LIST);
+    let _upper_https_proxy = EnvGuard::clear("HTTPS_PROXY");
+    let _https_proxy = EnvGuard::set("https_proxy", "http://127.0.0.1:58438");
+    let _all_proxy = EnvGuard::clear("all_proxy");
+    let _upper_all_proxy = EnvGuard::clear("ALL_PROXY");
+    let _upper_no_proxy = EnvGuard::clear("NO_PROXY");
+    let _no_proxy = EnvGuard::set("no_proxy", ".example.test, chatgpt.com:443");
+
+    reload_from_env();
+
+    assert_eq!(
+        websocket_proxy_url_for_account(
+            "acc-bypass",
+            "wss://chatgpt.com/backend-api/codex/responses",
+        )
+        .expect("resolve bypassed websocket proxy"),
+        None
+    );
+    assert_eq!(
+        websocket_proxy_url_for_account(
+            "acc-bypass",
+            "wss://api.example.test/backend-api/codex/responses",
+        )
+        .expect("resolve suffix-bypassed websocket proxy"),
+        None
+    );
+    assert_eq!(
+        websocket_proxy_url_for_account(
+            "acc-bypass",
+            "wss://chatgpt.com:444/backend-api/codex/responses",
+        )
+        .expect("resolve non-bypassed websocket proxy")
+        .as_deref(),
+        Some("http://127.0.0.1:58438")
+    );
+}
+
+#[test]
+fn websocket_environment_proxy_is_fail_closed_when_invalid() {
+    let _guard = crate::test_env_guard();
+    let db = TestDbGuard::new("runtime-websocket-invalid-env-proxy");
+    seed_account(db.path(), "acc-invalid");
+    let _managed_proxy = EnvGuard::clear(ENV_UPSTREAM_PROXY_URL);
+    let _pool_proxy = EnvGuard::clear(ENV_PROXY_LIST);
+    let _upper_https_proxy = EnvGuard::clear("HTTPS_PROXY");
+    let _https_proxy = EnvGuard::set("https_proxy", "://invalid");
+    let _all_proxy = EnvGuard::clear("all_proxy");
+    let _upper_all_proxy = EnvGuard::clear("ALL_PROXY");
+    let _no_proxy = EnvGuard::clear("no_proxy");
+    let _upper_no_proxy = EnvGuard::clear("NO_PROXY");
+
+    reload_from_env();
+
+    let error = websocket_proxy_url_for_account(
+        "acc-invalid",
+        "wss://chatgpt.com/backend-api/codex/responses",
+    )
+    .expect_err("invalid environment proxy must fail closed");
+    assert!(error.contains("invalid websocket environment proxy"));
+}
+
+#[test]
 fn upstream_client_for_account_uses_explicit_proxy_before_global_and_pool() {
     let _guard = crate::test_env_guard();
     let db = TestDbGuard::new("runtime-account-proxy-explicit");

--- a/crates/service/src/gateway/mod.rs
+++ b/crates/service/src/gateway/mod.rs
@@ -817,8 +817,11 @@ pub(crate) fn apply_async_upstream_proxy(
     runtime_config::apply_async_upstream_proxy(builder, proxy_url, invalid_event)
 }
 
-pub(crate) fn current_upstream_proxy_url_for_account(account_id: &str) -> Option<String> {
-    runtime_config::upstream_proxy_url_for_account(account_id)
+pub(crate) fn current_websocket_proxy_url_for_account(
+    account_id: &str,
+    target_url: &str,
+) -> Result<Option<String>, String> {
+    runtime_config::websocket_proxy_url_for_account(account_id, target_url)
 }
 
 /// 函数 `set_upstream_proxy_url`

--- a/crates/service/src/gateway/upstream/attempt_flow/transport.rs
+++ b/crates/service/src/gateway/upstream/attempt_flow/transport.rs
@@ -1350,7 +1350,8 @@ fn send_websocket_upstream_request(
         target_url.to_string()
     };
     let request_headers = request_headers.to_vec();
-    let proxy_url = super::super::super::current_upstream_proxy_url_for_account(account_id);
+    let proxy_url =
+        super::super::super::current_websocket_proxy_url_for_account(account_id, ws_url.as_str())?;
     let handshake_timeout = websocket_handshake_timeout(request_deadline);
 
     let (meta_tx, meta_rx) = mpsc::sync_channel::<Result<(), String>>(1);

--- a/crates/service/src/http/responses_websocket.rs
+++ b/crates/service/src/http/responses_websocket.rs
@@ -1008,7 +1008,8 @@ async fn connect_account_upstream_websocket(
         resolve_upstream_authorization_for_websocket(account.clone(), token).await?;
     let request = build_upstream_websocket_request(ws_url, account, &authorization, context)
         .map_err(|err| err.message)?;
-    let proxy_url = crate::gateway::current_upstream_proxy_url_for_account(account.id.as_str());
+    let proxy_url =
+        crate::gateway::current_websocket_proxy_url_for_account(account.id.as_str(), ws_url)?;
     let first_error =
         match connect_upstream_websocket_request_detailed(request, ws_url, proxy_url.as_deref())
             .await


### PR DESCRIPTION
## 概述

为 OpenAI 账号请求的 Responses WebSocket 连接补充标准环境代理回退。

当账号、代理池或 CodexManager 全局配置均未提供代理时，WebSocket 连接会根据目标地址读取 `http_proxy`、`https_proxy` 或 `all_proxy`，并遵循 `NO_PROXY`。

## 问题

Responses 的普通 HTTP 请求和 WebSocket 请求使用不同的连接实现。

在依赖环境变量配置代理的运行环境中，HTTP 请求可以正常使用代理，但 Responses WebSocket 连接此前只读取 CodexManager 内部的账号和代理配置，不会回退到标准代理环境变量。

这可能造成以下现象：

- HTTP / SSE 请求可以正常工作；
- WebSocket 握手仍尝试直接连接上游；
- 请求长时间等待或连接失败；
- 同一运行环境下，不同 transport 的代理行为不一致。

## 修改内容

- 为账号 Responses WebSocket 增加环境代理回退；
- 根据目标 URL 协议选择代理变量：
  - `wss` / `https`：`https_proxy`、`HTTPS_PROXY`；
  - `ws` / `http`：`http_proxy`、`HTTP_PROXY`；
  - 在对应变量为空时回退到 `all_proxy`、`ALL_PROXY`；
- 支持小写和大写代理环境变量；
- 支持 `no_proxy` 和 `NO_PROXY`；
- 支持 `NO_PROXY` 中的：
  - 全局通配符 `*`；
  - 精确主机；
  - 子域名后缀；
  - 主机与端口组合；
- 环境代理格式无效时拒绝继续直连，避免静默绕过代理；
- 将目标 WebSocket URL 传入代理解析逻辑；
- 在两条账号 WebSocket 连接路径中统一使用新的解析结果；
- 增加环境代理、优先级、`NO_PROXY` 和无效配置测试。

## 代理优先级

现有 CodexManager 代理配置仍然具有更高优先级。

环境代理只在账号显式代理、代理池和 Manager 全局代理均未提供可用代理时作为回退，不会覆盖用户在 CodexManager 中明确选择的代理。

## 行为边界

本 PR 仅修改 OpenAI 账号 Responses WebSocket 的代理解析，不修改：

- 普通 HTTP / SSE 请求的代理逻辑；
- 聚合 API 的现有请求和代理行为；
- Codex profile 或 provider 配置；
- 模型目录和模型缓存逻辑；
- 账号池轮换和调度策略；
- WebSocket 是否启用的配置。

本 PR 不会自动设置 `supports_websockets = true`。

如果 provider 配置为：

supports_websockets = false
Codex 仍会继续使用 HTTP / SSE，本次修改不会改变该行为。
关于 Responses Lite 工具错误
本 PR 解决的是 WebSocket 连接未遵循环境代理的问题，不处理上游 Responses Lite 对工具类型返回的 unsupported_value 错误。
如果上游当前无法接受某些工具类型，仍可以通过：
supports_websockets = false
临时回退到 HTTP / SSE。

## 验证

cargo fmt --all -- --check

cargo test -p codexmanager-service websocket_proxy_url_for_account -- --test-threads=1

cargo test -p codexmanager-service websocket_environment_proxy -- --test-threads=1

cargo check -p codexmanager-service

git diff --check upstream/main...HEAD