### PR TITLE
fix: fix layout for language switch / 修复语言选择器的布局

### DIFF
--- a/apps/src/components/layout/header.tsx
+++ b/apps/src/components/layout/header.tsx
@@ -246,7 +246,7 @@ export function Header() {
           <DisclaimerTicker compact />
           <LanguageSwitcher
             compact
-            triggerClassName="w-9 min-w-9 px-0 sm:w-[106px] sm:min-w-[106px] sm:px-3"
+            triggerClassName="w-10 min-w-10 gap-1 px-0 sm:w-[124px] sm:min-w-[124px] sm:gap-2 sm:px-2.5"
           />
 
           {canLogoutWebSession ? (

--- a/apps/src/components/layout/language-switcher.tsx
+++ b/apps/src/components/layout/language-switcher.tsx
@@ -42,22 +42,28 @@ export function LanguageSwitcher({
           className={cn("h-9 min-w-[116px] gap-2 text-xs", triggerClassName)}
           aria-label={t("选择语言")}
         >
-          <div className="flex min-w-0 items-center justify-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center justify-center gap-2 overflow-hidden">
             <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className={compact ? "hidden min-w-0 sm:inline" : "min-w-0"}>
-              <SelectValue>
+            <span
+              className={
+                compact
+                  ? "hidden min-w-0 flex-1 overflow-hidden sm:flex"
+                  : "flex min-w-0 flex-1 overflow-hidden"
+              }
+            >
+              <SelectValue className="min-w-0 truncate">
                 {(value) => getLocaleLabel(normalizeLocale(value))}
               </SelectValue>
             </span>
           </div>
         </SelectTrigger>
         <SelectContent>
-                    <SelectGroup>
-          {localeOptions.map((item) => (
-            <SelectItem key={item} value={item}>
-              {getLocaleLabel(item)}
-            </SelectItem>
-          ))}
+          <SelectGroup>
+            {localeOptions.map((item) => (
+              <SelectItem key={item} value={item}>
+                {getLocaleLabel(item)}
+              </SelectItem>
+            ))}
           </SelectGroup>
         </SelectContent>
       </Select>

--- a/apps/tests/header-controls.test.mjs
+++ b/apps/tests/header-controls.test.mjs
@@ -20,7 +20,7 @@ test("管理员仪表盘保留服务开关和语言选择", async () => {
   assert.match(source, /<Switch[\s\S]*?onCheckedChange=\{handleToggleService\}/);
   assert.match(
     source,
-    /<LanguageSwitcher[\s\S]*?compact[\s\S]*?triggerClassName="w-9 min-w-9[\s\S]*?sm:w-\[106px\]/,
+    /<LanguageSwitcher[\s\S]*?compact[\s\S]*?triggerClassName="w-10 min-w-10 gap-1 px-0[\s\S]*?sm:w-\[124px\][\s\S]*?sm:gap-2/,
   );
   assert.match(source, /<DisclaimerTicker compact \/>/);
   assert.match(source, /v\{serviceStatus\.version\}/);

--- a/apps/tests/ui-responsive-regressions.test.mjs
+++ b/apps/tests/ui-responsive-regressions.test.mjs
@@ -23,8 +23,15 @@ test("mobile shell preserves page titles and compact controls", async () => {
   );
   assert.match(headerSource, /flex min-w-0 flex-1[\s\S]*overflow-hidden/);
   assert.match(headerSource, /truncate text-lg[\s\S]*sm:text-\[21px\]/);
-  assert.match(headerSource, /triggerClassName="w-9 min-w-9/);
-  assert.match(languageSource, /compact \? "hidden min-w-0 sm:inline"/);
+  assert.match(
+    headerSource,
+    /triggerClassName="w-10 min-w-10 gap-1 px-0[\s\S]*?sm:w-\[124px\][\s\S]*?sm:gap-2/,
+  );
+  assert.match(
+    languageSource,
+    /flex min-w-0 flex-1 items-center justify-center gap-2 overflow-hidden/,
+  );
+  assert.match(languageSource, /<SelectValue className="min-w-0 truncate">/);
   assert.match(workspaceSource, /line-clamp-2[\s\S]*sm:line-clamp-1/);
 });
 


### PR DESCRIPTION
## 变更摘要

之前：

<img width="92" height="60" alt="屏幕截图 2026-07-27 124428" src="https://github.com/user-attachments/assets/5d8a9078-1433-48e1-9c3c-b6b7144ca9aa" />

修复后：

<img width="114" height="50" alt="屏幕截图 2026-07-27 124718" src="https://github.com/user-attachments/assets/5fa4ee7d-8bc5-406a-8a1d-335487ffda7f" />


## 改动范围

- [x] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- 

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [ ] 其他本地验证已说明

已执行的实际验证：

```text

```

未执行的验证与原因：

```text

```

## 风险与影响面

- 

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
