### PR TITLE
fix(codex-profile): 修改config.toml时保留自定义cm配置 / preserve custom cm provider fields

### DIFF
--- a/crates/service/src/codex_profile.rs
+++ b/crates/service/src/codex_profile.rs
@@ -2041,8 +2041,9 @@ fn patch_config_for_gateway(
         .get_mut(PROVIDER_ID)
         .and_then(Item::as_table_mut)
         .ok_or_else(|| "config.toml model_providers.cm is not a table".to_string())?;
-    provider.clear();
-    provider.insert("name", toml_value("CodexManager"));
+    if provider.get("name").is_none() {
+        provider.insert("name", toml_value("CodexManager"));
+    }
     provider.insert("base_url", toml_value(base_url));
     provider.insert("wire_api", toml_value("responses"));
     provider.insert("supports_websockets", toml_value(supports_websockets));

--- a/crates/service/src/codex_profile_tests.rs
+++ b/crates/service/src/codex_profile_tests.rs
@@ -164,6 +164,7 @@ name = "Other"
 
     assert!(output.contains("model_provider = \"cm\""));
     assert!(output.contains("[model_providers.cm]"));
+    assert!(output.contains("name = \"CodexManager\""));
     assert!(output.contains("base_url = \"http://127.0.0.1:48770/v1\""));
     assert!(output.contains("wire_api = \"responses\""));
     assert!(output.contains("supports_websockets = true"));
@@ -178,6 +179,64 @@ name = "Other"
     )
     .expect("disable gateway websocket");
     assert!(without_websocket.contains("supports_websockets = false"));
+}
+
+#[test]
+fn gateway_config_preserves_custom_managed_provider_values() {
+    let input = r#"
+model_provider = "cm"
+
+[model_providers.cm]
+name = "Custom Gateway"
+base_url = "https://stale.example.test/v1"
+wire_api = "chat"
+supports_websockets = false
+experimental_bearer_token = "custom-key"
+custom_header = "custom-value"
+"#;
+
+    let managed_catalog = PathBuf::from("/tmp/codexmanager/gateway-models.json");
+    let output = patch_config_for_gateway(
+        Some(input.to_string()),
+        "http://127.0.0.1:48770/v1",
+        &managed_catalog,
+        true,
+    )
+    .expect("patch gateway");
+    let doc = parse_config(&output).expect("parse patched gateway config");
+    let provider = doc
+        .get("model_providers")
+        .and_then(Item::as_table)
+        .and_then(|providers| providers.get(PROVIDER_ID))
+        .and_then(Item::as_table)
+        .expect("managed provider");
+
+    assert_eq!(
+        provider.get("name").and_then(Item::as_str),
+        Some("Custom Gateway")
+    );
+    assert_eq!(
+        provider
+            .get("experimental_bearer_token")
+            .and_then(Item::as_str),
+        Some("custom-key")
+    );
+    assert_eq!(
+        provider.get("custom_header").and_then(Item::as_str),
+        Some("custom-value")
+    );
+    assert_eq!(
+        provider.get("base_url").and_then(Item::as_str),
+        Some("http://127.0.0.1:48770/v1")
+    );
+    assert_eq!(
+        provider.get("wire_api").and_then(Item::as_str),
+        Some("responses")
+    );
+    assert_eq!(
+        provider.get("supports_websockets").and_then(Item::as_bool),
+        Some(true)
+    );
 }
 
 #[test]


### PR DESCRIPTION

## 变更摘要

- **修复 Codex 网关 profile 同步时清空 `[model_providers.cm]` 的问题。**
- 保留用户已有的 provider `name`、`experimental_bearer_token` 及其他自定义字段。
- 继续由 CodexManager 更新运行所需的 `base_url`、`wire_api` 和 `supports_websockets`。
- 当 `name` 缺失时仍补充默认值 `CodexManager`。
- 新增回归测试，覆盖自定义字段保留及托管字段更新行为。

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/codex_profile.rs`
- `crates/service/src/codex_profile_tests.rs`

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
cargo fmt --all -- --check
# PASS

git diff --check
# PASS

cargo test -p codexmanager-service codex_profile::tests:: -- --nocapture
# PASS: 28 passed, 0 failed

# 新回归测试在 main 基线上：
# FAIL: name 从 Custom Gateway 被重置为 CodexManager（exit 101）

# 同一回归测试在修复分支上：
cargo test -p codexmanager-service codex_profile::tests::gateway_config_preserves_custom_managed_provider_values -- --exact --nocapture
# PASS: 1 passed, 0 failed
```

未执行或未完全通过的验证与原因：

```text
cargo test --workspace
# 未继续执行；更窄的 service 完整测试已暴露仓库现有/时序型失败。

cargo test -p codexmanager-service
# 1368 passed, 2 failed, 3 ignored
# 1. codex_skills FIFO/目录校验用例在 main 基线同样失败。
# 2. SSE keep-alive 时序用例在完整套件中失败，但单独复跑通过。
```

## 风险与影响面

- 改动仅影响 CodexManager 接管的 `[model_providers.cm]` 合并行为。
- `base_url`、`wire_api`、`supports_websockets` 仍以 CodexManager 状态为准。
- 其他 provider 小节、`auth.json` 写入逻辑和模型目录同步逻辑未改变。

## 备注

- 已确认变更与测试数据不包含真实 token、cookie 或 API key。
