### PR TITLE
fix(usage): 失败请求不计入总用量 / exclude failed requests from token aggregates

### DIFF
--- a/crates/core/migrations/125_request_token_stats_successful_usage.sql
+++ b/crates/core/migrations/125_request_token_stats_successful_usage.sql
@@ -1,0 +1,29 @@
+ALTER TABLE request_token_stats
+  ADD COLUMN usage_included INTEGER NOT NULL DEFAULT 1
+  CHECK (usage_included IN (0, 1));
+
+UPDATE request_token_stats
+SET usage_included = CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM request_logs
+    WHERE request_logs.id = request_token_stats.request_log_id
+      AND request_logs.status_code >= 200
+      AND request_logs.status_code <= 299
+  ) THEN 1
+  ELSE 0
+END;
+
+UPDATE request_token_stat_hourly_rollups
+SET
+  input_tokens = 0,
+  cached_input_tokens = 0,
+  output_tokens = 0,
+  total_tokens = 0,
+  reasoning_output_tokens = 0,
+  estimated_cost_usd = 0.0
+WHERE success_count = 0;
+
+CREATE INDEX IF NOT EXISTS idx_request_token_stats_success_key_model_created_at
+  ON request_token_stats(key_id, model, created_at DESC)
+  WHERE usage_included = 1;

--- a/crates/core/src/storage/api_key_quota_limits.rs
+++ b/crates/core/src/storage/api_key_quota_limits.rs
@@ -151,6 +151,7 @@ fn api_key_total_token_usage_sql() -> &'static str {
         FROM request_token_stats
         WHERE key_id = ?1
           AND TRIM(key_id) <> ''
+          AND usage_included = 1
         UNION ALL
         SELECT
             input_tokens,
@@ -261,7 +262,10 @@ fn api_key_usage_cte_sql(include_cost: bool, scope: ApiKeyUsageScope) -> String 
     let raw_from = api_key_usage_from_sql("request_token_stats", "s", scope);
     let hourly_from = api_key_usage_from_sql("request_token_stat_hourly_rollups", "h", scope);
     let legacy_from = api_key_usage_from_sql("request_token_stat_rollups", "r", scope);
-    let raw_where = api_key_usage_where_sql("s", scope);
+    let raw_where = format!(
+        "{} AND s.usage_included = 1",
+        api_key_usage_where_sql("s", scope)
+    );
     let hourly_where = api_key_usage_where_sql("h", scope);
     let legacy_where = api_key_usage_where_sql("r", scope);
     let hourly_cost_select = rollup_cost_select.replace("{rollup_alias}", "h");

--- a/crates/core/src/storage/api_key_quota_limits_tests.rs
+++ b/crates/core/src/storage/api_key_quota_limits_tests.rs
@@ -58,7 +58,7 @@ fn api_key_remaining_quota_usage_scopes_stats_to_limited_keys() {
     assert!(
         details.iter().any(|detail| {
             detail.contains("search s")
-                && detail.contains("idx_request_token_stats_key")
+                && detail.contains("idx_request_token_stats_success_key_model_created_at")
                 && detail.contains("key_id=?")
         }),
         "expected limited-key raw usage lookup by key index, got {details:?}"
@@ -98,10 +98,16 @@ fn api_key_quota_overview_stats_reads_key_and_usage_tables_directly() {
             .any(|detail| detail.contains("sqlite_autoindex_api_key_quota_limits_1")),
         "expected quota overview to join quota limits by primary key, got {details:?}"
     );
-    for alias in ["scan s", "scan h", "scan r"] {
+    for aliases in [
+        ["scan s", "search s"],
+        ["scan h", "search h"],
+        ["scan r", "search r"],
+    ] {
         assert!(
-            details.iter().any(|detail| detail.contains(alias)),
-            "expected quota overview to aggregate token usage source {alias}, got {details:?}"
+            details
+                .iter()
+                .any(|detail| aliases.iter().any(|alias| detail.contains(alias))),
+            "expected quota overview to aggregate token usage source {aliases:?}, got {details:?}"
         );
     }
 }

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -2252,6 +2252,11 @@ impl Storage {
             "124_codex_skill_repositories",
             include_str!("../../migrations/124_codex_skill_repositories.sql"),
         )?;
+        self.apply_sql_or_compat_migration(
+            "125_request_token_stats_successful_usage",
+            include_str!("../../migrations/125_request_token_stats_successful_usage.sql"),
+            |s| s.ensure_request_token_stats_usage_included_column(),
+        )?;
         self.ensure_api_key_rotation_columns()?;
         self.ensure_api_key_account_group_filter_column()?;
         self.ensure_aggregate_apis_table()?;

--- a/crates/core/src/storage/request_logs.rs
+++ b/crates/core/src/storage/request_logs.rs
@@ -284,8 +284,8 @@ impl Storage {
                 "INSERT INTO request_token_stats (
                     request_log_id, key_id, account_id, model, actual_source_kind, actual_source_id,
                     input_tokens, cached_input_tokens, output_tokens, total_tokens, reasoning_output_tokens,
-                    estimated_cost_usd, created_at
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                    estimated_cost_usd, usage_included, created_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 (
                     request_log_id,
                     &stat.key_id,
@@ -299,6 +299,10 @@ impl Storage {
                     stat.total_tokens,
                     stat.reasoning_output_tokens,
                     stat.estimated_cost_usd,
+                    i64::from(
+                        log.status_code
+                            .is_some_and(|status| (200..=299).contains(&status)),
+                    ),
                     stat.created_at,
                 ),
             )
@@ -1083,6 +1087,7 @@ fn request_log_summary_sql(filters: &RequestLogSqlFilters) -> String {
             IFNULL(SUM(CASE WHEN IFNULL(r.status_code, 0) >= 400 OR TRIM(IFNULL(r.error, '')) <> '' THEN 1 ELSE 0 END), 0),
             IFNULL(SUM(
                 CASE
+                    WHEN t.usage_included <> 1 THEN 0
                     WHEN t.total_tokens IS NOT NULL THEN
                         CASE WHEN t.total_tokens > 0 THEN t.total_tokens ELSE 0 END
                     ELSE
@@ -1093,7 +1098,13 @@ fn request_log_summary_sql(filters: &RequestLogSqlFilters) -> String {
                         END
                 END
             ), 0),
-            IFNULL(SUM(IFNULL(t.estimated_cost_usd, 0.0)), 0.0)
+            IFNULL(SUM(
+                CASE
+                    WHEN t.usage_included = 1
+                        THEN IFNULL(t.estimated_cost_usd, 0.0)
+                    ELSE 0.0
+                END
+            ), 0.0)
          FROM request_logs r
          {account_join}
          LEFT JOIN request_token_stats t ON t.request_log_id = r.id

--- a/crates/core/src/storage/request_token_stats.rs
+++ b/crates/core/src/storage/request_token_stats.rs
@@ -50,13 +50,14 @@ fn token_total_sql_expr() -> &'static str {
 }
 
 const TOKEN_ROLLUP_COLUMNS: &str = "
-    IFNULL(SUM(IFNULL(t.input_tokens, 0)), 0) AS input_tokens,
-    IFNULL(SUM(IFNULL(t.cached_input_tokens, 0)), 0) AS cached_input_tokens,
-    IFNULL(SUM(IFNULL(t.output_tokens, 0)), 0) AS output_tokens,
-    IFNULL(SUM(IFNULL(t.reasoning_output_tokens, 0)), 0) AS reasoning_output_tokens,
+    IFNULL(SUM(CASE WHEN t.usage_included = 1 THEN IFNULL(t.input_tokens, 0) ELSE 0 END), 0) AS input_tokens,
+    IFNULL(SUM(CASE WHEN t.usage_included = 1 THEN IFNULL(t.cached_input_tokens, 0) ELSE 0 END), 0) AS cached_input_tokens,
+    IFNULL(SUM(CASE WHEN t.usage_included = 1 THEN IFNULL(t.output_tokens, 0) ELSE 0 END), 0) AS output_tokens,
+    IFNULL(SUM(CASE WHEN t.usage_included = 1 THEN IFNULL(t.reasoning_output_tokens, 0) ELSE 0 END), 0) AS reasoning_output_tokens,
     IFNULL(
         SUM(
             CASE
+                WHEN t.usage_included <> 1 THEN 0
                 WHEN t.total_tokens IS NOT NULL THEN
                     CASE WHEN t.total_tokens > 0 THEN t.total_tokens ELSE 0 END
                 ELSE
@@ -69,7 +70,7 @@ const TOKEN_ROLLUP_COLUMNS: &str = "
         ),
         0
     ) AS total_tokens,
-    IFNULL(SUM(IFNULL(t.estimated_cost_usd, 0.0)), 0.0) AS estimated_cost_usd,
+    IFNULL(SUM(CASE WHEN t.usage_included = 1 THEN IFNULL(t.estimated_cost_usd, 0.0) ELSE 0.0 END), 0.0) AS estimated_cost_usd,
     COUNT(DISTINCT t.request_log_id) AS request_count,
     COUNT(DISTINCT CASE WHEN r.status_code >= 200 AND r.status_code <= 299 THEN t.request_log_id END) AS success_count,
     COUNT(DISTINCT CASE WHEN IFNULL(r.status_code, 0) >= 400 OR TRIM(IFNULL(r.error, '')) <> '' THEN t.request_log_id END) AS error_count";
@@ -189,7 +190,8 @@ fn request_log_today_summary_sql(
                 IFNULL(SUM(IFNULL(s.reasoning_output_tokens, 0)), 0) AS reasoning_output_tokens,
                 IFNULL(SUM(IFNULL(s.estimated_cost_usd, 0.0)), 0.0) AS estimated_cost_usd
             FROM request_token_stats s
-            WHERE s.created_at >= ? AND s.created_at < ?{raw_key_clause}
+            WHERE s.created_at >= ? AND s.created_at < ?
+              AND s.usage_included = 1{raw_key_clause}
             UNION ALL
             SELECT
                 IFNULL(SUM(IFNULL(h.input_tokens, 0)), 0) AS input_tokens,
@@ -546,7 +548,7 @@ fn raw_key_usage_select(select_prefix: &str, where_clause: &str, group_by: &str)
             IFNULL(SUM({token_total}), 0) AS total_tokens,
             IFNULL(SUM(IFNULL(t.estimated_cost_usd, 0.0)), 0.0) AS estimated_cost_usd
          FROM request_token_stats t
-         WHERE {where_clause}
+         WHERE ({where_clause}) AND t.usage_included = 1
          {group_by}",
         token_total = token_total_sql_expr(),
     )
@@ -668,8 +670,22 @@ impl Storage {
             "INSERT INTO request_token_stats (
                 request_log_id, key_id, account_id, model, actual_source_kind, actual_source_id,
                 input_tokens, cached_input_tokens, output_tokens, total_tokens, reasoning_output_tokens,
-                estimated_cost_usd, created_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                estimated_cost_usd, usage_included, created_at
+             ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                COALESCE(
+                    (
+                        SELECT CASE
+                            WHEN status_code >= 200 AND status_code <= 299 THEN 1
+                            ELSE 0
+                        END
+                        FROM request_logs
+                        WHERE id = ?1
+                    ),
+                    1
+                ),
+                ?13
+             )",
             (
                 stat.request_log_id,
                 &stat.key_id,
@@ -757,12 +773,12 @@ impl Storage {
                     COALESCE(NULLIF(TRIM(t.actual_source_kind), ''), ''),
                     COALESCE(NULLIF(TRIM(t.actual_source_id), ''), ''),
                     COALESCE({USER_OWNER_EXPR}, ''),
-                    IFNULL(SUM(CASE WHEN t.input_tokens > 0 THEN t.input_tokens ELSE 0 END), 0),
-                    IFNULL(SUM(CASE WHEN t.cached_input_tokens > 0 THEN t.cached_input_tokens ELSE 0 END), 0),
-                    IFNULL(SUM(CASE WHEN t.output_tokens > 0 THEN t.output_tokens ELSE 0 END), 0),
-                    IFNULL(SUM({token_total}), 0),
-                    IFNULL(SUM(CASE WHEN t.reasoning_output_tokens > 0 THEN t.reasoning_output_tokens ELSE 0 END), 0),
-                    IFNULL(SUM(CASE WHEN t.estimated_cost_usd > 0 THEN t.estimated_cost_usd ELSE 0 END), 0.0),
+                    IFNULL(SUM(CASE WHEN t.usage_included = 1 AND t.input_tokens > 0 THEN t.input_tokens ELSE 0 END), 0),
+                    IFNULL(SUM(CASE WHEN t.usage_included = 1 AND t.cached_input_tokens > 0 THEN t.cached_input_tokens ELSE 0 END), 0),
+                    IFNULL(SUM(CASE WHEN t.usage_included = 1 AND t.output_tokens > 0 THEN t.output_tokens ELSE 0 END), 0),
+                    IFNULL(SUM(CASE WHEN t.usage_included = 1 THEN {token_total} ELSE 0 END), 0),
+                    IFNULL(SUM(CASE WHEN t.usage_included = 1 AND t.reasoning_output_tokens > 0 THEN t.reasoning_output_tokens ELSE 0 END), 0),
+                    IFNULL(SUM(CASE WHEN t.usage_included = 1 AND t.estimated_cost_usd > 0 THEN t.estimated_cost_usd ELSE 0.0 END), 0.0),
                     COUNT(DISTINCT t.request_log_id),
                     COUNT(DISTINCT CASE WHEN r.status_code >= 200 AND r.status_code <= 299 THEN t.request_log_id END),
                     COUNT(DISTINCT CASE WHEN IFNULL(r.status_code, 0) >= 400 OR TRIM(IFNULL(r.error, '')) <> '' THEN t.request_log_id END),
@@ -1552,6 +1568,8 @@ impl Storage {
                 total_tokens INTEGER,
                 reasoning_output_tokens INTEGER,
                 estimated_cost_usd REAL,
+                usage_included INTEGER NOT NULL DEFAULT 1
+                    CHECK (usage_included IN (0, 1)),
                 created_at INTEGER NOT NULL
             )",
             [],
@@ -1594,6 +1612,17 @@ impl Storage {
         self.ensure_column("request_token_stats", "total_tokens", "INTEGER")?;
         self.ensure_column("request_token_stats", "actual_source_kind", "TEXT")?;
         self.ensure_column("request_token_stats", "actual_source_id", "TEXT")?;
+        self.ensure_column(
+            "request_token_stats",
+            "usage_included",
+            "INTEGER NOT NULL DEFAULT 1 CHECK (usage_included IN (0, 1))",
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_request_token_stats_success_key_model_created_at
+             ON request_token_stats(key_id, model, created_at DESC)
+             WHERE usage_included = 1",
+            [],
+        )?;
         if self.has_column("request_logs", "actual_source_kind")?
             && self.has_column("request_logs", "actual_source_id")?
         {
@@ -1724,12 +1753,14 @@ impl Storage {
                 "INSERT OR IGNORE INTO request_token_stats (
                     request_log_id, key_id, account_id, model, actual_source_kind, actual_source_id,
                     input_tokens, cached_input_tokens, output_tokens, total_tokens, reasoning_output_tokens,
-                    estimated_cost_usd, created_at
+                    estimated_cost_usd, usage_included, created_at
                  )
                  SELECT
                     id, key_id, account_id, model, {actual_source_kind_expr}, {actual_source_id_expr},
                     input_tokens, cached_input_tokens, output_tokens, NULL, reasoning_output_tokens,
-                    estimated_cost_usd, created_at
+                    estimated_cost_usd,
+                    CASE WHEN status_code >= 200 AND status_code <= 299 THEN 1 ELSE 0 END,
+                    created_at
                  FROM request_logs
                  WHERE input_tokens IS NOT NULL
                     OR cached_input_tokens IS NOT NULL
@@ -1739,6 +1770,41 @@ impl Storage {
             );
             self.conn.execute(&backfill_sql, [])?;
         }
+        Ok(())
+    }
+
+    pub(super) fn ensure_request_token_stats_usage_included_column(&self) -> Result<()> {
+        self.ensure_column(
+            "request_token_stats",
+            "usage_included",
+            "INTEGER NOT NULL DEFAULT 1 CHECK (usage_included IN (0, 1))",
+        )?;
+        self.conn.execute(
+            "UPDATE request_token_stats
+             SET usage_included = CASE
+                WHEN EXISTS (
+                    SELECT 1
+                    FROM request_logs
+                    WHERE request_logs.id = request_token_stats.request_log_id
+                      AND request_logs.status_code >= 200
+                      AND request_logs.status_code <= 299
+                ) THEN 1
+                ELSE 0
+             END",
+            [],
+        )?;
+        self.conn.execute(
+            "UPDATE request_token_stat_hourly_rollups
+             SET
+                input_tokens = 0,
+                cached_input_tokens = 0,
+                output_tokens = 0,
+                total_tokens = 0,
+                reasoning_output_tokens = 0,
+                estimated_cost_usd = 0.0
+             WHERE success_count = 0",
+            [],
+        )?;
         Ok(())
     }
 }

--- a/crates/core/src/storage/tests/request_logs_tests.rs
+++ b/crates/core/src/storage/tests/request_logs_tests.rs
@@ -679,8 +679,8 @@ fn request_logs_filtered_summary_aggregates_counts_and_tokens() {
     assert_eq!(summary.count, 3);
     assert_eq!(summary.success_count, 2);
     assert_eq!(summary.error_count, 1);
-    assert_eq!(summary.total_tokens, 150);
-    assert_eq!(summary.estimated_cost_usd, 0.03);
+    assert_eq!(summary.total_tokens, 80);
+    assert_eq!(summary.estimated_cost_usd, 0.02);
 }
 
 #[test]

--- a/crates/core/src/storage/tests/request_token_stats_tests.rs
+++ b/crates/core/src/storage/tests/request_token_stats_tests.rs
@@ -988,7 +988,7 @@ fn by_key_usage_summary_query_includes_raw_hourly_and_legacy_sources() {
 
     assert_uses_index(
         &details,
-        "idx_request_token_stats_key_model_created_at",
+        "idx_request_token_stats_success_key_model_created_at",
         "by-key raw usage summary",
     );
     assert_uses_index(
@@ -1033,7 +1033,7 @@ fn by_key_for_user_usage_summary_query_joins_owner_index() {
 
     assert_uses_index(
         &details,
-        "idx_request_token_stats_key_model_created_at",
+        "idx_request_token_stats_success_key_model_created_at",
         "by-key-for-user raw usage summary",
     );
     assert_uses_index(
@@ -1070,7 +1070,7 @@ fn by_model_usage_summary_query_includes_key_scoped_sources() {
 
     assert_uses_index(
         &details,
-        "idx_request_token_stats_key_model_created_at",
+        "idx_request_token_stats_success_key_model_created_at",
         "by-model raw usage summary",
     );
     assert_uses_index(
@@ -1115,7 +1115,7 @@ fn by_key_model_usage_summary_query_includes_key_scoped_sources() {
 
     assert_uses_index(
         &details,
-        "idx_request_token_stats_key_model_created_at",
+        "idx_request_token_stats_success_key_model_created_at",
         "by-key-model raw usage summary",
     );
     assert_uses_index(
@@ -1143,6 +1143,116 @@ fn summarize_request_token_stats_between_short_circuits_empty_range() {
     assert_eq!(summary.output_tokens, 0);
     assert_eq!(summary.reasoning_output_tokens, 0);
     assert_eq!(summary.estimated_cost_usd, 0.0);
+}
+
+#[test]
+fn usage_rollups_exclude_499_and_502_tokens_before_and_after_compaction() {
+    let storage = Storage::open_in_memory().expect("open");
+    storage.init().expect("init");
+
+    for (status_code, input_tokens, output_tokens, total_tokens, estimated_cost_usd) in [
+        (200, 20, 10, 30, 0.30),
+        (499, 30, 10, 40, 0.40),
+        (502, 40, 10, 50, 0.50),
+    ] {
+        storage
+            .insert_request_log_with_token_stat(
+                &RequestLog {
+                    key_id: Some("key-success-only".to_string()),
+                    account_id: Some("account-success-only".to_string()),
+                    request_path: "/v1/responses".to_string(),
+                    method: "POST".to_string(),
+                    model: Some("gpt-5".to_string()),
+                    actual_source_kind: Some("openai_account".to_string()),
+                    actual_source_id: Some("account-success-only".to_string()),
+                    status_code: Some(status_code),
+                    error: (status_code != 200).then(|| format!("http {status_code}")),
+                    created_at: 1_000 + status_code,
+                    ..Default::default()
+                },
+                &RequestTokenStat {
+                    key_id: Some("key-success-only".to_string()),
+                    account_id: Some("account-success-only".to_string()),
+                    model: Some("gpt-5".to_string()),
+                    actual_source_kind: Some("openai_account".to_string()),
+                    actual_source_id: Some("account-success-only".to_string()),
+                    input_tokens: Some(input_tokens),
+                    cached_input_tokens: Some(5),
+                    output_tokens: Some(output_tokens),
+                    total_tokens: Some(total_tokens),
+                    reasoning_output_tokens: Some(2),
+                    estimated_cost_usd: Some(estimated_cost_usd),
+                    created_at: 1_000 + status_code,
+                    ..Default::default()
+                },
+            )
+            .expect("insert request usage");
+    }
+
+    let inclusion_flags = storage
+        .conn
+        .prepare(
+            "SELECT r.status_code, t.usage_included
+             FROM request_logs r
+             JOIN request_token_stats t ON t.request_log_id = r.id
+             ORDER BY r.status_code",
+        )
+        .expect("prepare inclusion flags")
+        .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))
+        .expect("query inclusion flags")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("collect inclusion flags");
+    assert_eq!(inclusion_flags, vec![(200, 1), (499, 0), (502, 0)]);
+
+    let query_summary = storage
+        .summarize_request_token_stats_query_between(Some(0), Some(3_600))
+        .expect("summarize request token stats");
+    assert_eq!(query_summary.count, 3);
+    assert_eq!(query_summary.success_count, 1);
+    assert_eq!(query_summary.error_count, 2);
+    assert_eq!(query_summary.total_tokens, 30);
+    assert_float_close(query_summary.estimated_cost_usd, 0.30);
+
+    let today = storage
+        .summarize_request_token_stats_between(0, 3_600)
+        .expect("summarize today usage");
+    assert_eq!(today.input_tokens, 20);
+    assert_eq!(today.cached_input_tokens, 5);
+    assert_eq!(today.output_tokens, 10);
+    assert_eq!(today.reasoning_output_tokens, 2);
+    assert_float_close(today.estimated_cost_usd, 0.30);
+
+    let by_key = storage
+        .summarize_request_token_stats_by_key_for_keys(&["key-success-only".to_string()])
+        .expect("summarize key usage");
+    assert_eq!(by_key.len(), 1);
+    assert_eq!(by_key[0].total_tokens, 30);
+    assert_float_close(by_key[0].estimated_cost_usd, 0.30);
+    assert_eq!(
+        storage
+            .api_key_total_token_usage("key-success-only")
+            .expect("summarize quota usage"),
+        30
+    );
+
+    storage
+        .rollup_request_token_stats_before(3_600)
+        .expect("compact request usage");
+
+    let compacted = storage
+        .summarize_request_token_stats_query_between(Some(0), Some(3_600))
+        .expect("summarize compacted request token stats");
+    assert_eq!(compacted.count, 3);
+    assert_eq!(compacted.success_count, 1);
+    assert_eq!(compacted.error_count, 2);
+    assert_eq!(compacted.total_tokens, 30);
+    assert_float_close(compacted.estimated_cost_usd, 0.30);
+    assert_eq!(
+        storage
+            .api_key_total_token_usage("key-success-only")
+            .expect("summarize compacted quota usage"),
+        30
+    );
 }
 
 #[test]
@@ -1638,7 +1748,7 @@ fn model_usage_timeline_groups_raw_and_hourly_usage_by_bucket() {
     assert_eq!(timeline[0].usage.success_count, 1);
     assert_eq!(timeline[1].bucket_start_ts, 3_600);
     assert_eq!(timeline[1].model, "gpt-4.1");
-    assert_eq!(timeline[1].usage.total_tokens, 20);
+    assert_eq!(timeline[1].usage.total_tokens, 0);
     assert_eq!(timeline[1].usage.request_count, 1);
     assert_eq!(timeline[1].usage.error_count, 1);
 }
@@ -1667,7 +1777,7 @@ fn key_model_range_query_matches_composite_index() {
     );
     assert!(details
         .iter()
-        .any(|detail| detail.contains("idx_request_token_stats_key_model_created_at")));
+        .any(|detail| detail.contains("idx_request_token_stats_success_key_model_created_at")));
 }
 
 #[test]

--- a/crates/core/tests/storage.rs
+++ b/crates/core/tests/storage.rs
@@ -2174,10 +2174,10 @@ fn request_token_stats_rollups_use_owner_and_actual_source_precedence() {
         .summarize_request_token_stats_daily(base, base + 2 * 86_400, 86_400)
         .expect("daily rollup");
     assert_eq!(daily.len(), 2);
-    assert_eq!(daily[0].usage.total_tokens, 170);
-    assert_eq!(daily[0].usage.input_tokens, 180);
-    assert_eq!(daily[0].usage.cached_input_tokens, 50);
-    assert_eq!(daily[0].usage.output_tokens, 70);
+    assert_eq!(daily[0].usage.total_tokens, 100);
+    assert_eq!(daily[0].usage.input_tokens, 100);
+    assert_eq!(daily[0].usage.cached_input_tokens, 20);
+    assert_eq!(daily[0].usage.output_tokens, 50);
     assert_eq!(daily[0].usage.request_count, 2);
     assert_eq!(daily[0].usage.success_count, 1);
     assert_eq!(daily[0].usage.error_count, 1);
@@ -2195,7 +2195,7 @@ fn request_token_stats_rollups_use_owner_and_actual_source_precedence() {
         .find(|item| item.user_id == "current-user")
         .expect("current owner fallback rollup");
     assert_eq!(ledger_user.usage.total_tokens, 100);
-    assert_eq!(current_user.usage.total_tokens, 70);
+    assert_eq!(current_user.usage.total_tokens, 0);
 
     let ledger_direct = storage
         .summarize_request_token_stats_for_user_between("ledger-user", base, base + 86_400)
@@ -2221,7 +2221,7 @@ fn request_token_stats_rollups_use_owner_and_actual_source_precedence() {
             .expect("legacy account")
             .usage
             .total_tokens,
-        70
+        0
     );
 
     let aggregate_sources = storage

--- a/crates/service/tests/rpc.rs
+++ b/crates/service/tests/rpc.rs
@@ -3936,7 +3936,7 @@ fn rpc_requestlog_list_and_summary_support_pagination() {
         summary_result
             .get("totalTokens")
             .and_then(|value| value.as_i64()),
-        Some(45)
+        Some(0)
     );
 }
 


### PR DESCRIPTION
## 变更概述

本次修改调整了 Token 使用量、费用及配额消耗的统计口径：

- 新增 `usage_included` 字段，用于标记请求是否计入使用量。
- **只有 HTTP 2xx 成功请求计入 Token、费用和配额统计。**
- **499、502 等失败请求仍保留在请求日志中（但不计入使用量），并计入请求数和错误数。**
- 失败请求的 Token 明细仍会保留，但不会进入汇总统计。
- 原始数据查询和小时聚合采用统一的成功请求统计口径。
- 根据关联请求的 HTTP 状态码回填已有 Token 记录。
- 增加 499、502 请求在小时聚合前后的回归测试。

## 统计口径说明

虽然 OpenAI 官方文档没有明确承诺所有本地观察到的 499 或 502 请求都一定不会产生费用，但实际使用中大多数失败请求都不会产生计费。

例如，499 可能表示客户端超时或主动断开，但上游服务可能已经开始甚至完成处理。因此，仅凭本地 HTTP 状态码无法准确完成账单对账。

本项目的本地使用量统计统一采用以下口径：

- HTTP 2xx：计入 Token、费用及配额消耗。
- 非 HTTP 2xx：不计入 Token、费用及配额消耗。
- 实际账单对账仍以 OpenAI Costs API 或官方账单页面为准。

## 数据库迁移

新增迁移：

`crates/core/migrations/125_request_token_stats_successful_usage.sql`

迁移行为包括：

- 为 Token 统计表增加 `usage_included` 字段。
- 根据关联请求日志的 HTTP 状态码回填已有原始记录。
- 将仅包含失败请求的历史小时聚合 Token 和费用清零。
- 保留失败请求的请求数量和错误数量。
- 添加成功请求统计使用的部分索引。

## 兼容性说明

迁移前已经压缩、且同时包含成功和失败请求的混合小时数据，无法精确拆分。

这是因为旧版小时聚合结构没有分别保存成功请求和失败请求的 Token 数量。迁移后产生的新数据以及仍保留原始记录的数据，均会按照新口径准确统计。

## 测试情况

已通过：

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codexmanager-core`
- `cargo test -p codexmanager-service --test rpc rpc_requestlog_list_and_summary_support_pagination -- --nocapture`

同时尝试执行了完整的 `cargo test --workspace`，过程中遇到：

- 一个与本次修改无关、在现有代码中即可复现的临时路径/FIFO 测试失败。
- 跳过该测试后，并行 RPC 测试出现长时间挂起。

因此，本次修改涉及的核心存储包及请求日志 RPC 路径已分别完成针对性验证。