### PR TITLE
feat(cm-imagegen): support image_generation API with data.image_urls handling

### DIFF
--- a/cm-skills/cm-imagegen/SKILL.md
+++ b/cm-skills/cm-imagegen/SKILL.md
@@ -31,7 +31,8 @@ CodexManager config policy:
 - Otherwise, read the active `model_provider` from `$CODEX_HOME/config.toml`.
 - Read that provider's `base_url` from `[model_providers.<provider>]`.
 - Read `OPENAI_API_KEY` from `$CODEX_HOME/auth.json`.
-- Use `CODEXMANAGER_IMAGE_MODEL` only for the image model override; otherwise use `gpt-image-2`.
+- Use `CODEXMANAGER_IMAGE_MODEL` only for the image model override; otherwise use `gpt-image-2` for OpenAI-compatible Images providers, or `image-01` when the provider base URL targets the image_generation API (`minimax.io` / `minimaxi.com` hosts).
+- When the provider base URL targets the image_generation API, the CLI calls `POST /v1/image_generation` with `aspect_ratio`/`width`/`height`/`seed`/`n`/`prompt_optimizer`/`response_format` request fields, passes `--image` inputs as `subject_reference`, and parses `data.image_urls` / `data.image_base64` + `base_resp.status_code`; otherwise it calls the OpenAI Images `/images/generations` and `/images/edits` endpoints and parses `data[].b64_json`.
 - Use `CODEXMANAGER_IMAGE_OUTPUT_DIR` only for the output directory override; otherwise save under the current working directory's `generated-images/` folder.
 
 Save-path policy:

--- a/cm-skills/cm-imagegen/references/image-api.md
+++ b/cm-skills/cm-imagegen/references/image-api.md
@@ -44,6 +44,35 @@ Model-specific note for `input_fidelity`:
 - High `input_fidelity` can materially increase input token usage.
 - If a request fails because a specific option is unsupported by the selected GPT Image model, retry manually without that option.
 
+## Image generation API (provider-configured)
+
+When the active `model_provider.base_url` points at the image_generation API (hostnames `minimax.io` or `minimaxi.com`), the CLI routes `generate` and `edit` to `POST /v1/image_generation` instead of the OpenAI Images endpoints.
+
+### Endpoint
+- Generate / edit: `POST /v1/image_generation`
+
+### Core request fields
+- `model`: image model (default `image-01`)
+- `prompt`: text prompt (max 1500 characters)
+- `aspect_ratio`: `1:1` (default), `16:9`, `4:3`, `3:2`, `2:3`, `3:4`, `9:16`, `21:9`. Takes priority over `width`/`height`.
+- `width` / `height`: pixels, range [512, 2048], must be divisible by 8, and must be set together.
+- `response_format`: `url` (default, link expires in 24 hours) or `base64`
+- `seed`: random seed for reproducibility
+- `n`: number of images, range [1, 9], default 1
+- `prompt_optimizer`: boolean, default `false`
+
+### Image-to-image (edit)
+- `subject_reference`: array of `{ "type": "character", "image_file": "<public URL or data:image/...;base64,...>" }`. For local files the CLI embeds each `--image` as a base64 data URL.
+
+### Response
+- `data.image_urls`: array of image URL strings (returned when `response_format=url`)
+- `data.image_base64`: array of base64 image strings (returned when `response_format=base64`)
+- `metadata.success_count` / `metadata.failed_count`
+- `base_resp.status_code`: `0` on success; non-zero indicates failure (for example `1004` auth failed, `1008` insufficient balance, `1026` sensitive content).
+
+The CLI downloads `url` responses and decodes `base64` responses, then writes PNG/JPG/WEBP files to the output directory.
+
 ## Important boundary
-- `quality`, `input_fidelity`, explicit masks, `background`, `output_format`, and related parameters are fallback-only execution controls.
+- `quality`, `input_fidelity`, explicit masks, `background`, `output_format`, and related parameters are OpenAI-Images fallback-only execution controls.
+- They are not accepted by the image_generation API and are ignored when the provider targets that API.
 - Do not assume they are built-in `image_gen` tool arguments.

--- a/cm-skills/cm-imagegen/scripts/cm_image_gen.py
+++ b/cm-skills/cm-imagegen/scripts/cm_image_gen.py
@@ -13,6 +13,8 @@ from pathlib import Path
 DEFAULT_MODEL = "gpt-image-2"
 DEFAULT_SIZE = "1024x1024"
 DEFAULT_RESPONSE_FORMAT = "b64_json"
+DEFAULT_MINIMAX_MODEL = "image-01"
+MINIMAX_HOST_FRAGMENTS = ("minimax.io", "minimaxi.com")
 
 
 def home() -> Path:
@@ -70,6 +72,12 @@ def provider_base_url() -> str:
     return base_url.rstrip("/")
 
 
+def is_minimax_base_url(base_url: str) -> bool:
+    """Return True when the configured provider base URL targets the image_generation API."""
+    lowered = base_url.lower()
+    return any(fragment in lowered for fragment in MINIMAX_HOST_FRAGMENTS)
+
+
 def load_api_key() -> str:
     auth_path = codex_home() / "auth.json"
     if auth_path.exists():
@@ -118,6 +126,17 @@ def request_json(url: str, api_key: str, payload: dict, timeout: int) -> dict:
         raise SystemExit(f"Failed to reach CodexManager Images API: {exc}")
 
 
+def download_bytes(url: str, timeout: int) -> bytes:
+    req = urllib.request.Request(url, headers={"Accept": "image/*"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"HTTP {exc.code} downloading image {url}")
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Failed to download image {url}: {exc}")
+
+
 def data_url_from_file(path: Path) -> str:
     if not path.exists() or not path.is_file():
         raise SystemExit(f"Input image not found: {path}")
@@ -126,12 +145,7 @@ def data_url_from_file(path: Path) -> str:
     return f"data:{mime_type};base64,{b64}"
 
 
-def save_image_from_item(item: dict, out_dir: Path, filename: str | None, index: int) -> Path:
-    b64 = item.get("b64_json")
-    if not isinstance(b64, str) or not b64.strip():
-        url = item.get("url")
-        raise SystemExit(f"Response item has no b64_json. URL responses are not saved by this script: {url}")
-    raw = base64.b64decode(b64)
+def save_image_bytes(raw: bytes, out_dir: Path, filename: str | None, index: int) -> Path:
     ext = ".png"
     if raw.startswith(b"\xff\xd8"):
         ext = ".jpg"
@@ -154,10 +168,106 @@ def save_image_from_item(item: dict, out_dir: Path, filename: str | None, index:
     return path
 
 
+def save_image_from_item(item: dict, out_dir: Path, filename: str | None, index: int) -> Path:
+    b64 = item.get("b64_json")
+    if not isinstance(b64, str) or not b64.strip():
+        url = item.get("url")
+        raise SystemExit(f"Response item has no b64_json. URL responses are not saved by this script: {url}")
+    return save_image_bytes(base64.b64decode(b64), out_dir, filename, index)
+
+
+def normalize_response_format(value: str, minimax: bool) -> str:
+    if minimax:
+        if value == "b64_json":
+            return "base64"
+        if value in ("url", "base64"):
+            return value
+    return value
+
+
+def minimax_payload(args: argparse.Namespace, model: str, prompt: str, subject_reference=None) -> dict:
+    payload: dict = {"model": model, "prompt": prompt}
+    response_format = normalize_response_format(args.response_format, True)
+    if response_format:
+        payload["response_format"] = response_format
+    if getattr(args, "aspect_ratio", None):
+        payload["aspect_ratio"] = args.aspect_ratio
+    if getattr(args, "width", None):
+        payload["width"] = args.width
+    if getattr(args, "height", None):
+        payload["height"] = args.height
+    if getattr(args, "seed", None) is not None:
+        payload["seed"] = args.seed
+    if args.n is not None:
+        payload["n"] = args.n
+    if getattr(args, "prompt_optimizer", None) is not None:
+        payload["prompt_optimizer"] = args.prompt_optimizer
+    if subject_reference is not None:
+        payload["subject_reference"] = subject_reference
+    return payload
+
+
+def parse_minimax_response(data: dict, out_dir: Path, filename: str | None, timeout: int) -> list[Path]:
+    base_resp = data.get("base_resp") or {}
+    status_code = base_resp.get("status_code")
+    if status_code not in (None, 0):
+        raise SystemExit(
+            f"image_generation failed (base_resp.status_code={status_code}): "
+            f"{base_resp.get('status_msg')}"
+        )
+    data_obj = data.get("data") or {}
+    sources: list[tuple[str, str]] = []
+    image_urls = data_obj.get("image_urls")
+    if isinstance(image_urls, list):
+        for value in image_urls:
+            if isinstance(value, str) and value.strip():
+                sources.append(("url", value.strip()))
+    image_base64 = data_obj.get("image_base64")
+    if isinstance(image_base64, list):
+        for value in image_base64:
+            if isinstance(value, str) and value.strip():
+                sources.append(("base64", value.strip()))
+    if not sources:
+        metadata = data.get("metadata") or {}
+        raise SystemExit(
+            "image_generation returned no images "
+            f"(success_count={metadata.get('success_count')}, "
+            f"failed_count={metadata.get('failed_count')}): "
+            f"{json.dumps(data, ensure_ascii=False)[:1000]}"
+        )
+    paths: list[Path] = []
+    for index, (kind, value) in enumerate(sources):
+        if kind == "url":
+            raw = download_bytes(value, timeout)
+        else:
+            raw = base64.b64decode(value)
+        paths.append(save_image_bytes(raw, out_dir, filename, index))
+    return paths
+
+
 def generate(args: argparse.Namespace) -> int:
     base_url = provider_base_url()
     api_key = load_api_key()
-    model = args.model or os.environ.get("CODEXMANAGER_IMAGE_MODEL") or DEFAULT_MODEL
+    minimax = is_minimax_base_url(base_url)
+    model = args.model or os.environ.get("CODEXMANAGER_IMAGE_MODEL") or (
+        DEFAULT_MINIMAX_MODEL if minimax else DEFAULT_MODEL
+    )
+    if minimax:
+        url = f"{base_url.rstrip('/')}/image_generation"
+        payload = minimax_payload(args, model, args.prompt)
+        data = request_json(url, api_key, payload, args.timeout)
+        out_dir = Path(args.out_dir) if args.out_dir else output_dir()
+        paths = parse_minimax_response(data, out_dir, args.filename, args.timeout)
+        result = {
+            "ok": True,
+            "base_url": base_url,
+            "model": model,
+            "paths": [str(path.resolve()) for path in paths],
+            "metadata": data.get("metadata"),
+            "created": data.get("created"),
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
     url = f"{base_url.rstrip('/')}/images/generations"
     payload = {
         "model": model,
@@ -194,9 +304,34 @@ def generate(args: argparse.Namespace) -> int:
 def edit(args: argparse.Namespace) -> int:
     base_url = provider_base_url()
     api_key = load_api_key()
-    model = args.model or os.environ.get("CODEXMANAGER_IMAGE_MODEL") or DEFAULT_MODEL
-    url = f"{base_url.rstrip('/')}/images/edits"
+    minimax = is_minimax_base_url(base_url)
+    model = args.model or os.environ.get("CODEXMANAGER_IMAGE_MODEL") or (
+        DEFAULT_MINIMAX_MODEL if minimax else DEFAULT_MODEL
+    )
     image_paths = [Path(value).expanduser() for value in args.image]
+    if minimax:
+        url = f"{base_url.rstrip('/')}/image_generation"
+        subject_reference = [
+            {"type": "character", "image_file": data_url_from_file(path)}
+            for path in image_paths
+        ]
+        payload = minimax_payload(args, model, args.prompt, subject_reference=subject_reference)
+        data = request_json(url, api_key, payload, args.timeout)
+        out_dir = Path(args.out_dir) if args.out_dir else output_dir()
+        paths = parse_minimax_response(data, out_dir, args.filename, args.timeout)
+        result = {
+            "ok": True,
+            "operation": "edit",
+            "base_url": base_url,
+            "model": model,
+            "source_images": [str(path.resolve()) for path in image_paths],
+            "paths": [str(path.resolve()) for path in paths],
+            "metadata": data.get("metadata"),
+            "created": data.get("created"),
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+    url = f"{base_url.rstrip('/')}/images/edits"
     payload = {
         "model": model,
         "prompt": args.prompt,
@@ -234,6 +369,25 @@ def edit(args: argparse.Namespace) -> int:
     return 0
 
 
+def add_minimax_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--aspect-ratio")
+    parser.add_argument("--width", type=int)
+    parser.add_argument("--height", type=int)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument(
+        "--prompt-optimizer",
+        choices=["true", "false"],
+        help="enable automatic prompt optimization for the image_generation API",
+    )
+
+
+def coerce_prompt_optimizer(args: argparse.Namespace) -> None:
+    value = getattr(args, "prompt_optimizer", None)
+    if value is None:
+        return
+    setattr(args, "prompt_optimizer", value == "true")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Generate images through CodexManager Images API.")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -241,7 +395,7 @@ def main() -> int:
     gen.add_argument("--prompt", required=True)
     gen.add_argument("--model")
     gen.add_argument("--size", default=DEFAULT_SIZE)
-    gen.add_argument("--response-format", default=DEFAULT_RESPONSE_FORMAT, choices=["b64_json", "url"])
+    gen.add_argument("--response-format", default=DEFAULT_RESPONSE_FORMAT, choices=["b64_json", "url", "base64"])
     gen.add_argument("--out-dir")
     gen.add_argument("--filename")
     gen.add_argument("--n", type=int)
@@ -249,6 +403,7 @@ def main() -> int:
     gen.add_argument("--background")
     gen.add_argument("--output-format", choices=["png", "jpeg", "webp"])
     gen.add_argument("--timeout", type=int, default=600)
+    add_minimax_arguments(gen)
     gen.set_defaults(func=generate)
     edit_parser = sub.add_parser("edit")
     edit_parser.add_argument("--prompt", required=True)
@@ -256,7 +411,7 @@ def main() -> int:
     edit_parser.add_argument("--mask")
     edit_parser.add_argument("--model")
     edit_parser.add_argument("--size", default=DEFAULT_SIZE)
-    edit_parser.add_argument("--response-format", default=DEFAULT_RESPONSE_FORMAT, choices=["b64_json", "url"])
+    edit_parser.add_argument("--response-format", default=DEFAULT_RESPONSE_FORMAT, choices=["b64_json", "url", "base64"])
     edit_parser.add_argument("--out-dir")
     edit_parser.add_argument("--filename")
     edit_parser.add_argument("--n", type=int)
@@ -264,8 +419,10 @@ def main() -> int:
     edit_parser.add_argument("--background")
     edit_parser.add_argument("--output-format", choices=["png", "jpeg", "webp"])
     edit_parser.add_argument("--timeout", type=int, default=600)
+    add_minimax_arguments(edit_parser)
     edit_parser.set_defaults(func=edit)
     args = parser.parse_args()
+    coerce_prompt_optimizer(args)
     return args.func(args)
 
 


### PR DESCRIPTION
Reason: Support the image_generation API (data.image_urls / data.image_base64) in the cm-imagegen skill when the provider base URL targets it.

## Changes
- `cm-skills/cm-imagegen/scripts/cm_image_gen.py`: when the configured provider `base_url` targets the image_generation API (`minimax.io` / `minimaxi.com` hosts), route `generate` and `edit` to `POST /v1/image_generation` instead of the OpenAI Images `/images/generations` and `/images/edits` endpoints.
  - Added request fields: `model`, `prompt`, `subject_reference`, `aspect_ratio`, `width`, `height`, `response_format`, `seed`, `n`, `prompt_optimizer`.
  - `edit` now passes each `--image` as a `subject_reference` character entry with a base64 data URL.
  - Added response handling for `data.image_urls` (URL responses are downloaded and saved) and `data.image_base64` (base64 responses are decoded and saved), plus `base_resp.status_code` error checking and `metadata.success_count` / `failed_count` reporting.
  - New CLI flags: `--aspect-ratio`, `--width`, `--height`, `--seed`, `--prompt-optimizer`; `--response-format` now also accepts `base64`.
  - Existing OpenAI Images path is unchanged.
- `cm-skills/cm-imagegen/references/image-api.md`: documented the image_generation endpoint, request fields, image-to-image `subject_reference`, and response fields.
- `cm-skills/cm-imagegen/SKILL.md`: documented the config policy that routes to the image_generation API based on the provider base URL.

## Checks
- `python3 -m py_compile cm-skills/cm-imagegen/scripts/cm_image_gen.py`
- Smoke tests covering provider detection, payload construction, and `parse_minimax_response` for `url`/`base64`/error/empty cases.
- `generate --help` and `edit --help` render the new flags.
