### PR TITLE
fix: expose Fast service tier in Codex model menu

### DIFF
--- a/apps/src/lib/api/managed-models-v2.ts
+++ b/apps/src/lib/api/managed-models-v2.ts
@@ -94,6 +94,10 @@ function stringList(value: unknown): string[] {
     .filter(Boolean);
 }
 
+function serviceTierName(id: string): string {
+  return id.toLowerCase() === "priority" ? "Fast" : id;
+}
+
 function booleanCapability(
   model: ManagedModelV2,
   fallback: boolean,
@@ -147,7 +151,11 @@ export function managedModelV2ToModelInfo(model: ManagedModelV2): ModelInfo {
     additionalSpeedTiers: stringList(
       capability(model, "additionalSpeedTiers", "additional_speed_tiers"),
     ),
-    serviceTiers: serviceTiers.map((id) => ({ id, name: id, description: "" })),
+    serviceTiers: serviceTiers.map((id) => ({
+      id,
+      name: serviceTierName(id),
+      description: "",
+    })),
     defaultServiceTier: nullableString(
       capability(model, "defaultServiceTier", "default_service_tier"),
     ),

--- a/apps/tests/managed-models-v2.test.mjs
+++ b/apps/tests/managed-models-v2.test.mjs
@@ -119,6 +119,9 @@ test("managed model adapter carries non-prompt Codex runtime metadata", () => {
   assert.equal(info.useResponsesLite, true);
   assert.equal(info.compHash, "3000");
   assert.deepEqual(info.additionalSpeedTiers, ["fast"]);
+  assert.deepEqual(info.serviceTiers, [
+    { id: "priority", name: "Fast", description: "" },
+  ]);
   assert.deepEqual(info.outputModalities, ["text"]);
   assert.deepEqual(info.supportedEndpoints, [
     "/v1/responses",

--- a/crates/service/src/gateway/request/tests/local_models_tests.rs
+++ b/crates/service/src/gateway/request/tests/local_models_tests.rs
@@ -149,13 +149,22 @@ fn serialize_models_response_preserves_service_tier_capabilities_for_codex_clien
             slug: "gpt-5.5-codex".to_string(),
             display_name: "GPT-5.5 Codex".to_string(),
             supported_in_api: true,
-            service_tiers: vec![ModelServiceTier {
-                id: "flex".to_string(),
-                name: "Flex".to_string(),
-                description: "Lower priority capacity.".to_string(),
-                ..Default::default()
-            }],
-            default_service_tier: Some("flex".to_string()),
+            additional_speed_tiers: vec!["fast".to_string()],
+            service_tiers: vec![
+                ModelServiceTier {
+                    id: "priority".to_string(),
+                    name: "Fast".to_string(),
+                    description: "Faster responses with increased usage.".to_string(),
+                    ..Default::default()
+                },
+                ModelServiceTier {
+                    id: "flex".to_string(),
+                    name: "Flex".to_string(),
+                    description: "Lower priority capacity.".to_string(),
+                    ..Default::default()
+                },
+            ],
+            default_service_tier: Some("priority".to_string()),
             upgrade_info: Some(serde_json::json!({
                 "model": "gpt-5.5-codex",
                 "upgrade_copy": "Use the newer coding model"
@@ -176,13 +185,23 @@ fn serialize_models_response_preserves_service_tier_capabilities_for_codex_clien
         models[0]["service_tiers"][0]
             .get("id")
             .and_then(Value::as_str),
-        Some("flex")
+        Some("priority")
+    );
+    assert_eq!(
+        models[0]["service_tiers"][0]
+            .get("name")
+            .and_then(Value::as_str),
+        Some("Fast")
+    );
+    assert_eq!(
+        models[0]["additional_speed_tiers"],
+        serde_json::json!(["fast"])
     );
     assert_eq!(
         models[0]
             .get("default_service_tier")
             .and_then(Value::as_str),
-        Some("flex")
+        Some("priority")
     );
     assert_eq!(
         models[0]["upgrade_info"]

--- a/crates/service/src/models_v2/mod.rs
+++ b/crates/service/src/models_v2/mod.rs
@@ -138,6 +138,14 @@ pub(crate) fn ensure_text_generation_model(
     ))
 }
 
+fn service_tier_display_name(id: &str) -> &str {
+    if id.eq_ignore_ascii_case("priority") {
+        "Fast"
+    } else {
+        id
+    }
+}
+
 pub(crate) fn model_info(model: &ManagedModelV2) -> ModelInfo {
     let string_list = |keys: &[&str]| {
         capability(model, keys)
@@ -159,14 +167,20 @@ pub(crate) fn model_info(model: &ManagedModelV2) -> ModelInfo {
             ..Default::default()
         })
         .collect();
+    let additional_speed_tiers = string_list(&["additional_speed_tiers", "additionalSpeedTiers"]);
     let service_tiers = string_list(&["service_tiers", "serviceTiers"])
         .into_iter()
         .map(|id| ModelServiceTier {
-            name: id.clone(),
+            name: service_tier_display_name(&id).to_string(),
             id,
             ..Default::default()
         })
         .collect();
+    let default_service_tier = capability(model, &["default_service_tier", "defaultServiceTier"])
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
     let truncation_policy = capability(model, &["truncation_mode", "truncationMode"])
         .and_then(Value::as_str)
         .zip(capability(model, &["truncation_limit", "truncationLimit"]).and_then(Value::as_i64))
@@ -251,7 +265,9 @@ pub(crate) fn model_info(model: &ManagedModelV2) -> ModelInfo {
         visibility: Some(model.visibility.clone()),
         supported_in_api: model.supported_in_api,
         priority: model.sort_order,
+        additional_speed_tiers,
         service_tiers,
+        default_service_tier,
         availability_nux: Some(
             capability(model, &["availability_nux", "availabilityNux"])
                 .cloned()
@@ -398,6 +414,29 @@ mod tests {
             .expect("text generation models response");
         assert!(!text.models.iter().any(|model| model.slug == "gpt-image-2"));
         assert_eq!(text.models.len() + 1, all.models.len());
+    }
+
+    #[test]
+    fn model_info_exposes_fast_service_tier_for_codex_clients() {
+        let model = ManagedModelV2 {
+            slug: "fast-model".to_string(),
+            display_name: "Fast Model".to_string(),
+            capabilities: serde_json::json!({
+                "service_tiers": ["priority", "flex"],
+                "additional_speed_tiers": ["fast"],
+                "default_service_tier": "priority"
+            }),
+            ..Default::default()
+        };
+
+        let info = model_info(&model);
+        assert_eq!(info.additional_speed_tiers, ["fast"]);
+        assert_eq!(info.default_service_tier.as_deref(), Some("priority"));
+        assert_eq!(info.service_tiers.len(), 2);
+        assert_eq!(info.service_tiers[0].id, "priority");
+        assert_eq!(info.service_tiers[0].name, "Fast");
+        assert_eq!(info.service_tiers[1].id, "flex");
+        assert_eq!(info.service_tiers[1].name, "flex");
     }
 
     #[test]


### PR DESCRIPTION
## 变更摘要

- 修复 CodexManager 接管 Codex 后，模型菜单不显示 `Fast` 开关的问题。
- 保留服务层级的传输值 `priority`，仅将面向 Codex 的显示名称输出为 `Fast`。
- 补全托管模型目录中的 `additional_speed_tiers` 与 `default_service_tier` 透传。
- 增加后端序列化和前端适配回归测试，防止后续重构再次丢失 Fast 元数据。

## 改动范围

- [x] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [x] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/models_v2/mod.rs`
- `crates/service/src/gateway/request/tests/local_models_tests.rs`
- `apps/src/lib/api/managed-models-v2.ts`
- `apps/tests/managed-models-v2.test.mjs`

## 验证

- [ ] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
cargo +stable-x86_64-pc-windows-gnu test -p codexmanager-service models_v2::tests --lib
  4 passed

cargo +stable-x86_64-pc-windows-gnu test -p codexmanager-service serialize_models_response_preserves_service_tier_capabilities_for_codex_clients --lib
  1 passed

node --test apps/tests/managed-models-v2.test.mjs
  2 passed

cargo +stable-x86_64-pc-windows-gnu fmt --all -- --check
pnpm -C apps exec tsc --noEmit --incremental false
pnpm -C apps run build
  passed

Local end-to-end verification with codex-cli 0.146.0-alpha.3.1:
  - Codex loaded the generated managed model catalog from an isolated CODEX_HOME.
  - 5 models exposed additional_speed_tiers=[fast] and service_tiers=[{id:priority,name:Fast}].
  - The Fast toggle was visible and switchable in the Codex model menu.
```

未执行的验证与原因：

```text
cargo test --workspace
  Not run because the change is isolated to managed model catalog conversion and /v1/models serialization; targeted service tests were run instead.

pnpm -C apps run test:ui
  Not run because this change does not alter a CodexManager UI flow.

pnpm -C apps run test
  The broader runtime suite was run during development: 189 tests passed and 1 pre-existing unrelated sidebar test failed. The targeted adapter test passes.
```

## 风险与影响面

- `priority` 仍然是发送给 API 的 service tier 值，因此不会改变请求协议。
- 仅 `priority` 的展示名称映射为 `Fast`；其他 service tier 保持原样。
- 变更仅影响托管模型目录生成、序列化及对应前端适配。

## 备注

- 未包含任何本地测试数据库、token、cookie、API key、构建产物或依赖目录。