### PR TITLE
fix(accounts): 修复账号页面ui控件遮挡问题 | isolate action rail from horizontal scroll

### DIFF
--- a/apps/src/app/accounts/accounts-page-helpers.tsx
+++ b/apps/src/app/accounts/accounts-page-helpers.tsx
@@ -451,8 +451,11 @@ export function AccountStatusCell({ account }: { account: Account }) {
 
   return (
     <Tooltip>
-      <TooltipTrigger render={<div />} className="block min-w-0 cursor-help">
-        <div className="flex min-w-0 flex-col gap-1">
+      <TooltipTrigger
+        render={<div />}
+        className="block min-w-0 max-w-full cursor-help overflow-hidden"
+      >
+        <div className="flex min-w-0 max-w-full flex-col gap-1">
           <div className="flex min-w-0 items-center gap-1.5">
             <div
               className={cn(
@@ -462,7 +465,7 @@ export function AccountStatusCell({ account }: { account: Account }) {
             />
             <span
               className={cn(
-                "text-xs font-semibold leading-4",
+                "min-w-0 max-w-full break-words whitespace-normal text-xs font-semibold leading-4",
                 account.isAvailable
                   ? "text-green-600 dark:text-green-400"
                   : "text-red-600 dark:text-red-400",
@@ -475,7 +478,7 @@ export function AccountStatusCell({ account }: { account: Account }) {
             <span
               className={fitLongTextClassName(
                 statusReasonLabel,
-                "block max-w-[180px] whitespace-normal break-words text-muted-foreground [overflow-wrap:anywhere]",
+                "block min-w-0 max-w-full whitespace-normal break-words text-muted-foreground [overflow-wrap:anywhere]",
                 "text-[11px] leading-4",
               )}
               title={statusReasonLabel}

--- a/apps/src/app/accounts/accounts-page-view.tsx
+++ b/apps/src/app/accounts/accounts-page-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLayoutEffect, useRef } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import {
   ArrowDown,
@@ -392,6 +393,195 @@ export function AccountsPageView(props: AccountsPageViewProps) {
   );
   const statusMutationBusy =
     isUpdatingManyStatuses || Boolean(isUpdatingStatusAccountId);
+  const accountPoolLayoutRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const layout = accountPoolLayoutRef.current;
+    if (!layout) return;
+
+    const mainRows = Array.from(
+      layout.querySelectorAll<HTMLElement>("[data-account-pool-main-row]"),
+    );
+    const actionRows = Array.from(
+      layout.querySelectorAll<HTMLElement>("[data-account-pool-action-row]"),
+    );
+    const syncRowHeights = () => {
+      actionRows.forEach((actionRow, index) => {
+        const mainRow = mainRows[index];
+        actionRow.style.height = mainRow
+          ? `${mainRow.getBoundingClientRect().height}px`
+          : "";
+      });
+    };
+
+    syncRowHeights();
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        actionRows.forEach((row) => row.style.removeProperty("height"));
+      };
+    }
+
+    const observer = new ResizeObserver(syncRowHeights);
+    mainRows.forEach((row) => observer.observe(row));
+    return () => {
+      observer.disconnect();
+      actionRows.forEach((row) => row.style.removeProperty("height"));
+    };
+  }, [isLoading, visibleAccounts]);
+
+  const renderAccountActions = (account: Account) => {
+    const statusAction = getAccountStatusAction(account, t);
+    const StatusActionIcon = statusAction.icon;
+    const isRefreshingCurrentAccount =
+      isRefreshingAccountId === account.id;
+    const isRefreshingCurrentRt = isRefreshingRtAccountId === account.id;
+    const isAtListTop = accounts[0]?.id === account.id;
+    const isAtListBottom =
+      accounts[accounts.length - 1]?.id === account.id;
+
+    return (
+      <div className="table-action-cell gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground transition-colors hover:text-primary"
+          disabled={!isServiceReady}
+          onClick={() => openUsage(account)}
+          title={t("用量详情")}
+          aria-label={t("用量详情")}
+        >
+          <BarChart3 className="h-4 w-4" />
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              render={<span />}
+              nativeButton={false}
+              disabled={!isServiceReady}
+              title={t("更多账号操作")}
+              aria-label={t("更多账号操作")}
+            >
+              <MoreVertical className="h-4 w-4" />
+              <span className="sr-only">{t("更多账号操作")}</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="px-2 py-1 text-[11px] uppercase tracking-[0.16em] text-muted-foreground/80">
+                {t("排序")}
+              </DropdownMenuLabel>
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={
+                  !isServiceReady || isReorderingAccounts || isAtListTop
+                }
+                onClick={() => void handleMoveAccount(account, "top")}
+              >
+                <ArrowUpToLine className="h-4 w-4" />
+                {t("移到顶部")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={
+                  !isServiceReady || isReorderingAccounts || isAtListBottom
+                }
+                onClick={() => void handleMoveAccount(account, "bottom")}
+              >
+                <ArrowDownToLine className="h-4 w-4" />
+                {t("移到底部")}
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={
+                  !isServiceReady ||
+                  isRefreshingAllAccounts ||
+                  isRefreshingCurrentAccount
+                }
+                onClick={() => refreshAccount(account.id)}
+              >
+                <RefreshCw
+                  className={cn(
+                    "h-4 w-4",
+                    isRefreshingCurrentAccount && "animate-spin",
+                  )}
+                />
+                {t("刷新用量")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={!isServiceReady || isRefreshingCurrentRt}
+                onClick={() => refreshAccountRt(account.id)}
+              >
+                <KeyRound
+                  className={cn(
+                    "h-4 w-4",
+                    isRefreshingCurrentRt && "animate-pulse",
+                  )}
+                />
+                {t("刷新 AT/RT")}
+                <DropdownMenuShortcut>RT</DropdownMenuShortcut>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={!isServiceReady || isUpdatingPreferred}
+                onClick={() =>
+                  account.preferred
+                    ? clearPreferredAccount(account.id)
+                    : setPreferredAccount(account.id)
+                }
+              >
+                <Pin className="h-4 w-4" />
+                {account.preferred ? t("取消优先") : t("设为优先")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={!isServiceReady}
+                onClick={() => void openProxyDialog(account)}
+              >
+                <Network className="h-4 w-4" />
+                {t("账号代理")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="gap-2"
+                disabled={
+                  !isServiceReady ||
+                  isUpdatingManyStatuses ||
+                  isUpdatingStatusAccountId === account.id ||
+                  statusAction.action === null
+                }
+                onClick={() =>
+                  statusAction.action &&
+                  toggleAccountStatus(
+                    account.id,
+                    statusAction.action === "enable",
+                    account.status,
+                  )
+                }
+              >
+                <StatusActionIcon className="h-4 w-4" />
+                {statusAction.label}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="gap-2 text-red-500"
+                disabled={!isServiceReady}
+                onClick={() => handleDeleteSingle(account)}
+              >
+                <Trash2 className="h-4 w-4" /> {t("删除")}
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  };
 
   return (
     <div className="space-y-6">
@@ -879,9 +1069,19 @@ export function AccountsPageView(props: AccountsPageViewProps) {
 
       <Card className="glass-card mission-panel overflow-hidden py-0 shadow-sm">
         <CardContent className="p-0">
-          <Table className="min-w-[1164px]">
-            <TableHeader>
-              <TableRow>
+          <div ref={accountPoolLayoutRef} className="account-pool-layout">
+            <div className="account-pool-main-pane">
+              <Table className="account-pool-main-table">
+                <colgroup>
+                  <col className="account-pool-col-select" />
+                  <col className="account-pool-col-info" />
+                  <col />
+                  <col className="account-pool-col-order" />
+                  <col className="account-pool-col-proxy" />
+                  <col className="account-pool-col-status" />
+                </colgroup>
+                <TableHeader>
+                  <TableRow data-account-pool-main-row>
                 <TableHead className="w-12 text-center">
                   <Checkbox
                     checked={
@@ -901,16 +1101,15 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                 </TableHead>
                 <TableHead className="w-[132px]">{t("顺序")}</TableHead>
                 <TableHead className="min-w-[180px]">{t("账号代理")}</TableHead>
-                <TableHead className="w-[112px]">{t("状态")}</TableHead>
-                <TableHead className="table-sticky-action-head w-[112px] text-center">
-                  {t("操作")}
+                <TableHead className="account-pool-status-head whitespace-normal">
+                  {t("状态")}
                 </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
               {isLoading ? (
                 Array.from({ length: 5 }).map((_, index) => (
-                  <TableRow key={index}>
+                  <TableRow key={index} data-account-pool-main-row>
                     <TableCell>
                       <Skeleton className="mx-auto h-4 w-4" />
                     </TableCell>
@@ -930,17 +1129,14 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                     <TableCell>
                       <Skeleton className="h-8 w-28" />
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="account-pool-status-cell align-top">
                       <Skeleton className="h-6 w-16 rounded-full" />
-                    </TableCell>
-                    <TableCell className="table-sticky-action-cell">
-                      <Skeleton className="mx-auto h-8 w-24" />
                     </TableCell>
                   </TableRow>
                 ))
               ) : visibleAccounts.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={7} className="h-48 text-center">
+                <TableRow data-account-pool-main-row>
+                  <TableCell colSpan={6} className="h-48 text-center">
                     <div className="flex w-[calc(100dvw-6rem)] flex-col items-center justify-center gap-2 text-muted-foreground sm:w-auto">
                       <Search className="h-8 w-8 opacity-20" />
                       <p>{t("未找到符合条件的账号")}</p>
@@ -950,23 +1146,18 @@ export function AccountsPageView(props: AccountsPageViewProps) {
               ) : (
                 visibleAccounts.map((account) => {
                   const quotaItems = buildQuotaSummaryItems(account, t);
-                  const statusAction = getAccountStatusAction(account, t);
-                  const StatusActionIcon = statusAction.icon;
-                  const isRefreshingCurrentAccount =
-                    isRefreshingAccountId === account.id;
-                  const isRefreshingCurrentRt =
-                    isRefreshingRtAccountId === account.id;
                   const filteredIndex =
                     filteredAccountIndexMap.get(account.id) ?? -1;
                   const canMoveUp = filteredIndex > 0;
                   const canMoveDown =
                     filteredIndex !== -1 &&
                     filteredIndex < filteredAccounts.length - 1;
-                  const isAtListTop = accounts[0]?.id === account.id;
-                  const isAtListBottom =
-                    accounts[accounts.length - 1]?.id === account.id;
                   return (
-                    <TableRow key={account.id} className="group">
+                    <TableRow
+                      key={account.id}
+                      className="group"
+                      data-account-pool-main-row
+                    >
                       <TableCell className="text-center">
                         <Checkbox
                           checked={effectiveSelectedIds.includes(account.id)}
@@ -1071,167 +1262,59 @@ export function AccountsPageView(props: AccountsPageViewProps) {
                       <TableCell>
                         <AccountProxyCell account={account} />
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="account-pool-status-cell align-top">
                         <AccountStatusCell account={account} />
-                      </TableCell>
-                      <TableCell className="table-sticky-action-cell">
-                        <div className="table-action-cell gap-1">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 text-muted-foreground transition-colors hover:text-primary"
-                            disabled={!isServiceReady}
-                            onClick={() => openUsage(account)}
-                            title={t("用量详情")}
-                            aria-label={t("用量详情")}
-                          >
-                            <BarChart3 className="h-4 w-4" />
-                          </Button>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
-                                render={<span />}
-                                nativeButton={false}
-                                disabled={!isServiceReady}
-                                title={t("更多账号操作")}
-                                aria-label={t("更多账号操作")}
-                              >
-                                <MoreVertical className="h-4 w-4" />
-                                <span className="sr-only">
-                                  {t("更多账号操作")}
-                                </span>
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuGroup>
-                                <DropdownMenuLabel className="px-2 py-1 text-[11px] uppercase tracking-[0.16em] text-muted-foreground/80">
-                                  {t("排序")}
-                                </DropdownMenuLabel>
-                                <DropdownMenuItem
-                                  className="gap-2"
-                                  disabled={
-                                    !isServiceReady ||
-                                    isReorderingAccounts ||
-                                    isAtListTop
-                                  }
-                                  onClick={() =>
-                                    void handleMoveAccount(account, "top")
-                                  }
-                                >
-                                  <ArrowUpToLine className="h-4 w-4" />
-                                  {t("移到顶部")}
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  className="gap-2"
-                                  disabled={
-                                    !isServiceReady ||
-                                    isReorderingAccounts ||
-                                    isAtListBottom
-                                  }
-                                  onClick={() =>
-                                    void handleMoveAccount(account, "bottom")
-                                  }
-                                >
-                                  <ArrowDownToLine className="h-4 w-4" />
-                                  {t("移到底部")}
-                                </DropdownMenuItem>
-                              </DropdownMenuGroup>
-                              <DropdownMenuSeparator />
-                                  <DropdownMenuGroup>
-                              <DropdownMenuItem
-                                className="gap-2"
-                                disabled={
-                                  !isServiceReady ||
-                                  isRefreshingAllAccounts ||
-                                  isRefreshingCurrentAccount
-                                }
-                                onClick={() => refreshAccount(account.id)}
-                              >
-                                <RefreshCw
-                                  className={cn(
-                                    "h-4 w-4",
-                                    isRefreshingCurrentAccount && "animate-spin",
-                                  )}
-                                />
-                                {t("刷新用量")}
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                className="gap-2"
-                                disabled={!isServiceReady || isRefreshingCurrentRt}
-                                onClick={() => refreshAccountRt(account.id)}
-                              >
-                                <KeyRound
-                                  className={cn(
-                                    "h-4 w-4",
-                                    isRefreshingCurrentRt && "animate-pulse",
-                                  )}
-                                />
-                                {t("刷新 AT/RT")}
-                                <DropdownMenuShortcut>RT</DropdownMenuShortcut>
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                className="gap-2"
-                                disabled={!isServiceReady || isUpdatingPreferred}
-                                onClick={() =>
-                                  account.preferred
-                                    ? clearPreferredAccount(account.id)
-                                    : setPreferredAccount(account.id)
-                                }
-                              >
-                                <Pin className="h-4 w-4" />
-                                {account.preferred ? t("取消优先") : t("设为优先")}
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                className="gap-2"
-                                disabled={!isServiceReady}
-                                onClick={() => void openProxyDialog(account)}
-                              >
-                                <Network className="h-4 w-4" />
-                                {t("账号代理")}
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                className="gap-2"
-                                disabled={
-                                  !isServiceReady ||
-                                  isUpdatingManyStatuses ||
-                                  isUpdatingStatusAccountId === account.id ||
-                                  statusAction.action === null
-                                }
-                                onClick={() =>
-                                  statusAction.action &&
-                                  toggleAccountStatus(
-                                    account.id,
-                                    statusAction.action === "enable",
-                                    account.status,
-                                  )
-                                }
-                              >
-                                <StatusActionIcon className="h-4 w-4" />
-                                {statusAction.label}
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                className="gap-2 text-red-500"
-                                disabled={!isServiceReady}
-                                onClick={() => handleDeleteSingle(account)}
-                              >
-                                <Trash2 className="h-4 w-4" /> {t("删除")}
-                              </DropdownMenuItem>
-                              </DropdownMenuGroup>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
                       </TableCell>
                     </TableRow>
                   );
                 })
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+            <div
+              className="account-pool-action-rail"
+              role="table"
+              aria-label={t("账号操作")}
+            >
+              <div
+                className="account-pool-action-rail-head"
+                role="columnheader"
+                data-account-pool-action-row
+              >
+                {t("操作")}
+              </div>
+              {isLoading ? (
+                Array.from({ length: 5 }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="account-pool-action-rail-row"
+                    role="cell"
+                    data-account-pool-action-row
+                  >
+                    <Skeleton className="mx-auto h-8 w-20" />
+                  </div>
+                ))
+              ) : visibleAccounts.length === 0 ? (
+                <div
+                  className="account-pool-action-rail-row"
+                  aria-hidden="true"
+                  data-account-pool-action-row
+                />
+              ) : (
+                visibleAccounts.map((account) => (
+                  <div
+                    key={account.id}
+                    className="account-pool-action-rail-row"
+                    role="cell"
+                    data-account-pool-action-row
+                  >
+                    {renderAccountActions(account)}
+                  </div>
+                ))
               )}
-            </TableBody>
-          </Table>
+            </div>
+          </div>
         </CardContent>
       </Card>
 

--- a/apps/src/app/globals.css
+++ b/apps/src/app/globals.css
@@ -1065,6 +1065,88 @@ tr {
   height: 100%;
 }
 
+.account-pool-layout {
+  --account-pool-action-width: 112px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--account-pool-action-width);
+  width: 100%;
+  isolation: isolate;
+}
+
+.account-pool-main-pane {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.account-pool-main-table {
+  table-layout: fixed;
+  width: 100%;
+  min-width: 1280px;
+}
+
+.account-pool-col-select {
+  width: 48px;
+}
+
+.account-pool-col-info {
+  width: 440px;
+}
+
+.account-pool-col-order {
+  width: 132px;
+}
+
+.account-pool-col-proxy,
+.account-pool-col-status {
+  width: 180px;
+}
+
+.account-pool-status-head,
+.account-pool-status-cell {
+  overflow: hidden;
+  white-space: normal;
+}
+
+.account-pool-action-rail {
+  position: relative;
+  z-index: 5;
+  width: var(--account-pool-action-width);
+  min-width: var(--account-pool-action-width);
+  border-left: 1px solid rgb(var(--primary-rgb) / 0.18);
+  background: var(--card-solid);
+  box-shadow: -16px 0 24px -22px rgb(var(--primary-rgb) / 0.55);
+}
+
+.account-pool-action-rail-head,
+.account-pool-action-rail-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  background: var(--card-solid);
+}
+
+.account-pool-action-rail-head {
+  height: 42px;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  background: var(--table-header-bg);
+  box-shadow: inset 0 -1px 0 rgb(var(--primary-rgb) / 0.14);
+}
+
+.account-pool-action-rail-row {
+  min-height: 48px;
+  padding: 0.5rem;
+  border-bottom: 1px solid rgb(var(--primary-rgb) / 0.12);
+}
+
+.account-pool-action-rail-row:hover {
+  background: color-mix(in srgb, var(--card-solid) 94%, rgb(var(--primary-rgb)) 6%);
+}
+
 .table-sticky-action-head,
 .table-sticky-action-cell {
   position: sticky;

--- a/apps/tests/accounts-reorder.spec.ts
+++ b/apps/tests/accounts-reorder.spec.ts
@@ -161,8 +161,11 @@ test("account row menu moves an account to the top of the pool", async ({
   const openMenuItem = (name: string) =>
     page.getByRole("menuitem", { name }).filter({ visible: true });
 
-  const lastRow = page.locator("tbody tr").last();
-  await lastRow.getByLabel("更多账号操作").click();
+  const actionCells = page
+    .getByRole("table", { name: "账号操作" })
+    .getByRole("cell");
+  await expect(actionCells).toHaveCount(ACCOUNT_ITEMS.length);
+  await actionCells.last().getByLabel("更多账号操作").click();
 
   const moveToTopItem = openMenuItem("移到顶部");
   await expect(moveToTopItem).toBeVisible();
@@ -184,8 +187,7 @@ test("account row menu moves an account to the top of the pool", async ({
   await expect(page.getByText("账号顺序已调整（3 项）")).toBeVisible();
   await expect(openMenuItem("移到顶部")).toHaveCount(0);
 
-  const firstRow = page.locator("tbody tr").first();
-  await firstRow.getByLabel("更多账号操作").click();
+  await actionCells.first().getByLabel("更多账号操作").click();
   await expect(openMenuItem("移到顶部")).toHaveAttribute(
     "aria-disabled",
     "true",

--- a/apps/tests/ui-responsive-regressions.test.mjs
+++ b/apps/tests/ui-responsive-regressions.test.mjs
@@ -79,16 +79,38 @@ test("mobile management toolbars wrap without hidden page overflow", async () =>
 });
 
 test("wide tables retain reachable actions and visible empty states", async () => {
-  const [accountsSource, apiKeysSource, modelsSource] = await Promise.all([
-    readSource("src/app/accounts/accounts-page-view.tsx"),
-    readSource("src/app/apikeys/page.tsx"),
-    readSource("src/app/models/page.tsx"),
-  ]);
+  const [accountsSource, apiKeysSource, modelsSource, stylesSource] =
+    await Promise.all([
+      readSource("src/app/accounts/accounts-page-view.tsx"),
+      readSource("src/app/apikeys/page.tsx"),
+      readSource("src/app/models/page.tsx"),
+      readSource("src/app/globals.css"),
+    ]);
 
   assert.match(accountsSource, /w-\[calc\(100dvw-6rem\)\]/);
   assert.match(apiKeysSource, /w-\[calc\(100dvw-6rem\)\]/);
   assert.match(modelsSource, /table-sticky-action-head/);
   assert.match(modelsSource, /table-sticky-action-cell/);
+  assert.match(
+    accountsSource,
+    /account-pool-layout[\s\S]*account-pool-main-pane[\s\S]*account-pool-main-table[\s\S]*account-pool-col-status[\s\S]*account-pool-action-rail/,
+  );
+  assert.doesNotMatch(accountsSource, /table-sticky-action-(?:head|cell)/);
+  assert.match(accountsSource, /new ResizeObserver\(syncRowHeights\)/);
+  assert.match(accountsSource, /data-account-pool-main-row/);
+  assert.match(accountsSource, /data-account-pool-action-row/);
+  assert.match(
+    stylesSource,
+    /\.account-pool-layout[\s\S]*grid-template-columns: minmax\(0, 1fr\) var\(--account-pool-action-width\);/,
+  );
+  assert.match(
+    stylesSource,
+    /\.account-pool-main-table[\s\S]*table-layout: fixed;[\s\S]*width: 100%;[\s\S]*min-width: 1280px;/,
+  );
+  assert.match(
+    stylesSource,
+    /\.account-pool-action-rail[\s\S]*position: relative;[\s\S]*z-index: 5;[\s\S]*width: var\(--account-pool-action-width\);/,
+  );
 });
 
 test("primary and theme buttons expose clear interaction state", async () => {


### PR DESCRIPTION

```text
fix(accounts): isolate action rail from horizontal scroll
```

修复前：
<img width="874" height="437" alt="截屏2026-07-31 16 29 31" src="https://github.com/user-attachments/assets/903cfabc-eb21-44d4-a864-902f7cbb2238" />

修复后：
<img width="868" height="534" alt="截屏2026-07-31 17 34 20" src="https://github.com/user-attachments/assets/333a20a5-c5c4-4a4b-afd2-3b8ab2305b8d" />


## 变更范围

本 PR 仅描述相对 `main` 分支的账号池页面布局、状态文本边界和前端回归测试变更。后端、数据库、RPC、账号数据与计费逻辑均未涉及。

## 变更摘要

- 将账号池“操作”列从横向滚动表格中拆分为独立操作轨道。
- 操作轨道固定占用 panel 最右侧 `112px`，并通过独立层级覆盖在主表视觉层上方。
- 账号信息、额度详情、顺序、账号代理和状态列统一放入左侧横向滚动视口。
- 左侧滚动视口的右边界与操作轨道左边界完全重合，滚动内容不会进入操作轨道的可见区域。
- 使用 `ResizeObserver` 同步主表表头、加载行、空状态行和账号数据行的高度，保证操作按钮逐行对齐。
- 状态列固定为 `180px`，状态文本和原因文本在单元格内部换行并限制溢出。

## 问题现象

`main` 分支中的账号池表格将状态和操作入口放在同一个横向滚动表格内。窗口变窄或拖动横向滚动条后，操作区域会覆盖账号代理、状态或其他前序列内容；扩大固定列范围又会让更多主表内容进入覆盖区域。

问题的关键在于主表内容与操作区域共享同一个横向滚动视口和坐标空间。

## 根因分析

### 1. sticky 单元格仍属于横向滚动表格

`position: sticky; right: 0` 只改变单元格的视觉位置，单元格仍参与原表格列布局。横向滚动时，其他列会从其下方经过。

### 2. 固定列与主表内容共享覆盖区域

状态列和操作列同时固定后，右侧覆盖区域会扩展，账号代理等前序列可能进入该区域下方，形成新的遮挡。

### 3. 主表与操作区需要不同的滚动边界

操作列应位于 panel 最右侧且保持静止；其余列应只在操作列左侧的独立视口内滚动。因此需要拆分 DOM 区域，而不是继续叠加表格 sticky 规则。

## 实现方案

### 1. 双区域布局

账号池根布局使用两列 CSS Grid：

```css
.account-pool-layout {
  --account-pool-action-width: 112px;
  display: grid;
  grid-template-columns: minmax(0, 1fr) var(--account-pool-action-width);
  width: 100%;
  isolation: isolate;
}
```

- 第一列：`minmax(0, 1fr)`，承载横向滚动主表；
- 第二列：固定 `112px`，承载独立操作轨道；
- 两个区域为相邻 grid track，不共享横向滚动视口。

### 2. 左侧主表滚动区

主表包含六列：

1. 选择框；
2. 账号信息；
3. 额度详情；
4. 顺序；
5. 账号代理；
6. 状态。

```css
.account-pool-main-pane {
  min-width: 0;
  overflow: hidden;
}

.account-pool-main-table {
  table-layout: fixed;
  width: 100%;
  min-width: 1280px;
}
```

`Table` 组件内部的 `overflow-x-auto` 容器只占左侧 grid track，因此横向滚动条及可见内容均终止于操作轨道左侧。

### 3. 右侧独立操作轨道

```css
.account-pool-action-rail {
  position: relative;
  z-index: 5;
  width: 112px;
  min-width: 112px;
  border-left: 1px solid ...;
  background: var(--card-solid);
}
```

操作轨道与主表为同级节点：

- 始终紧贴 panel 最右侧；
- 不参与主表横向滚动；
- 使用实色背景、分隔线和左侧阴影形成独立覆盖层；
- 保留用量详情和更多操作菜单的原有行为。

### 4. 行高同步

主表各行由额度、账号备注、状态原因等内容决定高度。操作轨道通过以下标记建立顺序对应关系：

- `data-account-pool-main-row`
- `data-account-pool-action-row`

`useLayoutEffect` 在首帧读取主表行高，`ResizeObserver` 持续监听主表行尺寸变化，并把精确高度写入对应操作行。加载、空状态、数据更新和窗口缩放均复用同一同步逻辑。

### 5. 状态内容边界

状态文本和原因文本使用：

- `min-w-0`；
- `max-w-full`；
- `whitespace-normal`；
- `break-words`；
- `overflow-hidden`。

完整状态信息继续通过 Tooltip 展示。

## 动态窗口行为

| 场景 | 主表区域 | 操作轨道 | 结果 |
| --- | --- | --- | --- |
| 2620px 视口 | 宽 `2466px`，无需横向滚动 | 宽 `112px`，贴 panel 右侧 | 所有列完整显示 |
| 1780px 视口 | 宽 `1626px`，无需横向滚动 | 宽 `112px`，贴 panel 右侧 | 状态紧邻操作轨道 |
| 1000px 视口起点 | 可见宽 `846px`，内容宽 `1280px` | 宽 `112px`，位置保持 | 前部列在左侧视口显示 |
| 1000px 视口终点 | `scrollLeft=434px` | 宽度与位置保持 | 状态列右边界与操作轨道左边界重合 |
| 动态恢复宽窗口 | 主表重新使用全部剩余空间 | 继续贴 panel 右侧 | 无需重新加载账号数据 |

## 行高同步验证

浏览器探针使用不同主表行高进行验证：

- 表头：`42px`；
- 数据行：`132px`、`88px`、`156px`。

对应操作轨道测量结果完全一致，主表与操作轨道逐行对齐。

## 主要文件

- `apps/src/app/accounts/accounts-page-view.tsx`
  - 拆分主表与操作轨道；
  - 移动账号操作控件到独立轨道；
  - 新增基于 `ResizeObserver` 的行高同步。
- `apps/src/app/accounts/accounts-page-helpers.tsx`
  - 限制状态文本和状态原因在状态单元格内显示。
- `apps/src/app/globals.css`
  - 定义双区域 grid、主表宽度、固定操作轨道和轨道行样式。
- `apps/tests/ui-responsive-regressions.test.mjs`
  - 增加双区域结构、滚动边界、独立轨道和行高同步回归断言。

## 验证

### 静态与运行时

- `git diff --check`：通过；
- ESLint：通过；
- `node --test apps/tests/ui-responsive-regressions.test.mjs`：5/5 通过；
- `pnpm -C apps run test:runtime`：190/190 通过；
- `pnpm -C apps run build:desktop`：通过。

### 浏览器布局探针

- 2620px、1780px、1000px 视口：通过；
- 窄窗口滚动起点和终点：通过；
- 主表右边界等于操作轨道左边界：通过；
- 操作轨道右边界等于 panel 右边界：通过；
- 操作轨道宽度始终为 `112px`：通过；
- 动态缩放后恢复原边界：通过；
- 多种内容高度逐行同步：通过。

### macOS App

- Tauri release 构建：通过；
- app 签名校验：通过；
- 架构：macOS arm64；
- 版本：`0.5.2`；
- bundle id：`com.codexmanager.desktop`；
- ZIP 完整性校验：通过。

## 风险与影响范围

- 影响范围限定为账号池表格布局及状态文本边界。
- 其他管理页面继续使用原有通用表格样式。
- 账号加载、筛选、排序、状态切换、代理、额度、RPC 和持久化逻辑保持原状。
- `ResizeObserver` 仅观察当前页主表的可见行，并在组件更新或卸载时断开。

## Review Checklist

- [x] 操作列为独立 DOM 轨道。
- [x] 操作轨道固定在 panel 最右侧。
- [x] 主表滚动视口终止于操作轨道左侧。
- [x] 状态列在滚动终点完整显示。
- [x] 表头、加载行、空状态行和数据行均能同步高度。
- [x] 动态窗口缩放验证通过。
