### PR TITLE
fix: 修复两个测试时出现的异常/fix two issues during debuging

### DIFF
--- a/apps/src-tauri/scripts/before-build.mjs
+++ b/apps/src-tauri/scripts/before-build.mjs
@@ -169,6 +169,10 @@ function warmupDesktopHomePageInBackground() {
   }, 0);
 }
 
+function isExpectedDesktopDevProxyDisconnect(error) {
+  return ["ECONNABORTED", "ECONNRESET", "EPIPE", "ERR_STREAM_DESTROYED"].includes(error?.code);
+}
+
 function createDesktopDevProxy() {
   const server = http.createServer((request, response) => {
     const proxyRequest = http.request(
@@ -183,17 +187,63 @@ function createDesktopDevProxy() {
         },
       },
       (proxyResponse) => {
+        if (response.destroyed) {
+          proxyResponse.destroy();
+          return;
+        }
         response.writeHead(proxyResponse.statusCode ?? 502, proxyResponse.headers);
+        proxyResponse.on("error", (error) => {
+          response.destroy();
+          if (!isExpectedDesktopDevProxyDisconnect(error)) {
+            console.warn(`Next dev proxy response failed: ${error.message}`);
+          }
+        });
         proxyResponse.pipe(response);
       },
     );
 
     proxyRequest.on("error", (error) => {
+      if (response.destroyed || isExpectedDesktopDevProxyDisconnect(error)) {
+        response.destroy();
+        return;
+      }
+      if (response.headersSent) {
+        console.warn(`Next dev proxy failed after sending headers: ${error.message}`);
+        response.destroy();
+        return;
+      }
       response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
       response.end(`Next dev proxy error: ${error.message}`);
     });
 
+    request.on("aborted", () => {
+      proxyRequest.destroy();
+    });
+    request.on("error", (error) => {
+      proxyRequest.destroy();
+      if (!isExpectedDesktopDevProxyDisconnect(error)) {
+        console.warn(`Desktop dev proxy request failed: ${error.message}`);
+      }
+    });
+    response.on("error", (error) => {
+      proxyRequest.destroy();
+      if (!isExpectedDesktopDevProxyDisconnect(error)) {
+        console.warn(`Desktop dev proxy client response failed: ${error.message}`);
+      }
+    });
+
     request.pipe(proxyRequest);
+  });
+
+  // Reloading a WebView closes its HTTP/HMR sockets immediately. On Windows
+  // this commonly surfaces as ECONNABORTED on the raw client socket; consume
+  // that expected disconnect so it does not terminate beforeDevCommand.
+  server.on("connection", (socket) => {
+    socket.on("error", (error) => {
+      if (!isExpectedDesktopDevProxyDisconnect(error)) {
+        console.warn(`Desktop dev proxy client socket failed: ${error.message}`);
+      }
+    });
   });
 
   server.on("upgrade", (request, socket, head) => {
@@ -218,6 +268,9 @@ function createDesktopDevProxy() {
 
     upstream.on("error", () => {
       socket.destroy();
+    });
+    socket.on("close", () => {
+      upstream.destroy();
     });
   });
 

--- a/apps/src-tauri/src/app_shell/window.rs
+++ b/apps/src-tauri/src/app_shell/window.rs
@@ -11,9 +11,7 @@ use tauri::{
 #[cfg(debug_assertions)]
 use tauri::Url;
 
-use super::state::{
-    APP_EXIT_REQUESTED, KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE, KEEP_WINDOW_UI_MOUNTED,
-};
+use super::state::{APP_EXIT_REQUESTED, KEEP_ALIVE_FOR_LIGHTWEIGHT_CLOSE, KEEP_WINDOW_UI_MOUNTED};
 
 pub(crate) const MAIN_WINDOW_LABEL: &str = "main";
 pub(crate) const TRAY_PREVIEW_WINDOW_LABEL: &str = "tray-preview";
@@ -60,7 +58,7 @@ fn show_main_window(app: &tauri::AppHandle) -> bool {
         main_window.created,
         main_window.created_after_initial,
     ) {
-        navigate_created_main_window_to_app(&main_window.window);
+        navigate_main_window_to_app(&main_window.window);
     }
     reveal_main_window(&main_window.window)
 }
@@ -253,7 +251,10 @@ fn ensure_main_window(app: &tauri::AppHandle) -> Option<MainWindowHandle> {
             if window.label() != MAIN_WINDOW_LABEL {
                 return;
             }
-            log::info!("main window page loaded");
+            log::info!("main window page loaded: {}", payload.url());
+            if should_navigate_loaded_main_window_to_app(payload.url().path()) {
+                navigate_main_window_to_app(&window);
+            }
         })
         .build()
     {
@@ -284,10 +285,14 @@ fn should_navigate_created_main_window_to_app(created: bool, created_after_initi
     cfg!(debug_assertions) && created && created_after_initial
 }
 
-fn navigate_created_main_window_to_app(window: &tauri::WebviewWindow) {
+fn should_navigate_loaded_main_window_to_app(path: &str) -> bool {
+    cfg!(debug_assertions) && path == "/startup.html"
+}
+
+fn navigate_main_window_to_app(window: &tauri::WebviewWindow) {
     if let Err(err) = navigate_window_to_app_url(window) {
         log::warn!(
-            "navigate recreated main window from startup page to app failed: {}",
+            "navigate main window from startup page to app failed: {}",
             err
         );
     }
@@ -459,7 +464,7 @@ fn resolve_tray_preview_position(
 mod tests {
     use super::{
         resolve_tray_preview_position, should_navigate_created_main_window_to_app,
-        should_reload_tray_preview_window,
+        should_navigate_loaded_main_window_to_app, should_reload_tray_preview_window,
     };
     use tauri::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalRect, PhysicalSize, Rect};
 
@@ -505,6 +510,18 @@ mod tests {
         assert!(should_navigate_created_main_window_to_app(true, true));
         #[cfg(not(debug_assertions))]
         assert!(!should_navigate_created_main_window_to_app(true, true));
+    }
+
+    #[test]
+    fn loaded_startup_page_navigates_to_the_dev_app() {
+        #[cfg(debug_assertions)]
+        {
+            assert!(should_navigate_loaded_main_window_to_app("/startup.html"));
+            assert!(!should_navigate_loaded_main_window_to_app("/"));
+            assert!(!should_navigate_loaded_main_window_to_app("/tray-preview/"));
+        }
+        #[cfg(not(debug_assertions))]
+        assert!(!should_navigate_loaded_main_window_to_app("/startup.html"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更摘要

- 修复使用`cargo tauri dev`进行测试情况下的两个问题
    1. 界面卡在Loading Codex Manager处
    2. 多次打开窗口可能出现的异常：
```
node:events:486
throw er; // Unhandled 'error' event
^
Error: write ECONNABORTED
at afterWriteDispatched (node:internal/stream_base_commons:159:15)
at writeGeneric (node:internal/stream_base_commons:150:3)
at Socket._writeGeneric (node:net:966:11)
at Socket._write (node:net:978:8)
at writeOrBuffer (node:internal/streams/writable:570:12)
at _write (node:internal/streams/writable:499:10)
at Writable.write (node:internal/streams/writable:508:10)
at Socket.ondata (node:internal/streams/readable:1008:24)
at Socket.emit (node:events:508:28)
at addChunk (node:internal/streams/readable:559:12)
Emitted 'error' event on Socket instance at:
at Socket.onerror (node:internal/streams/readable:1031:14)
at Socket.emit (node:events:508:28)
at emitErrorNT (node:internal/streams/destroy:170:8)
at emitErrorCloseNT (node:internal/streams/destroy:129:3)
at process.processTicksAndRejections (node:internal/process/task_queues:89:21) {
errno: -4079,
code: 'ECONNABORTED',
syscall: 'write'
}
Node.js v24.12.0
Error The "beforeDevCommand" terminated with a non-zero status **code.**
 ```

## 改动范围

- [ ] Frontend
- [x] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- 

## 验证

- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [ ] 其他本地验证已说明

已执行的实际验证：

```text

```

未执行的验证与原因：

```text

```

## 风险与影响面

- 

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
