### PR TITLE
Update AIXiamo Pro decision links

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
       </a>
     </td>
     <td valign="top">
-      <strong><a href="https://www.aixiamo.com/?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=sponsor_text">AIXiamo（独立 AI 订阅服务）</a></strong>：提供 <a href="https://www.aixiamo.com/articles/codex-quota-not-enough-plus-pro-api-2026?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=developer_codex_quota">ChatGPT Plus / Pro 国内充值与 Codex 额度选择</a>，也覆盖 Claude Max 5x / 20x、Google AI Pro（Gemini）和 SuperGrok；支持支付宝，无需海外银行卡，订单状态可查询。
+      <strong><a href="https://www.aixiamo.com/chatgpt-pro?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_owner">AIXiamo（独立 AI 订阅服务）</a></strong>：提供 ChatGPT Plus / Pro 国内充值；高频 Codex、深度研究和长任务用户可先<a href="https://www.aixiamo.com/tools/chatgpt-pro-plan-calculator?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_calculator">比较 Pro 5x / 20x 并用用量选择器判断档位</a>。也覆盖 Claude Max、Google AI Pro（Gemini）和 SuperGrok；支持支付宝，无需海外银行卡，订单状态可查询。
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## 变更摘要

- 将现有 AIXiamo 赞助入口从旧 Codex 额度文章调整为 ChatGPT Pro 权威说明页。
- 增加公开的 Pro 5x / 20x 使用强度与成本计算器，帮助高频 Codex、深度研究和长任务用户先判断档位。
- 保留原赞助关系、第三方身份说明与支付宝/订单可查事实。

## 改动范围

- [x] Docs / Governance

## 主要文件

- `README.md`

## 验证

- [x] 两个目标 URL 均返回 HTTP 200。
- [x] 差异仅包含赞助说明的一行替换。
- [x] 未修改应用代码、赞助配置、支付或项目功能。

未执行应用构建与测试：本次为 README 文案和链接更新，不涉及可执行代码。

## 风险与影响面

低风险；最终是否合并由项目维护者审核决定。