### PR TITLE
docs: 同步 AIXiamo Pro 价格与支付事实

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@
   </tr>
   <tr>
     <td align="center" valign="middle" width="180">
-      <a href="https://www.aixiamo.com/?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager">
+      <a href="https://www.aixiamo.com/chatgpt-pro?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=logo_pro_price_20260808">
         <img src="assets/images/sponsors/aixiamo.jpg" alt="AI夏末 AIXiamo" width="120" />
       </a>
     </td>
     <td valign="top">
-      <strong><a href="https://www.aixiamo.com/chatgpt-pro?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_owner">AIXiamo（独立 AI 订阅服务）</a></strong>：提供 ChatGPT Plus / Pro 国内充值；高频 Codex、深度研究和长任务用户可先<a href="https://www.aixiamo.com/tools/chatgpt-pro-plan-calculator?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_calculator">比较 Pro 5x / 20x 并用用量选择器判断档位</a>。也覆盖 Claude Max、Google AI Pro（Gemini）和 SuperGrok；支持支付宝，无需海外银行卡，订单状态可查询。
+      <strong><a href="https://www.aixiamo.com/chatgpt-pro?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_owner_price_20260808">AIXiamo（独立 AI 订阅服务，赞助展示）</a></strong>：截至 2026-08-08，ChatGPT Pro 5x（100 美元档）公开价 ¥719，20x（200 美元档）公开价 ¥1269；支持支付宝、USDT-BEP20（BSC）和 USDT-TRC20（TRON），无需海外银行卡。Pro 由人工按订单处理，顺利时通常约 2–5 分钟；不索取登录密码、验证码或恢复码，付款后订单与处理状态可查。可使用<a href="https://www.aixiamo.com/tools/chatgpt-pro-plan-calculator?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_calculator_price_20260808">用量选择器比较 Pro 5x / 20x</a>。价格、库存及支付方式可能调整，以实时页面为准。
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## 变更摘要
- 同步 AIXiamo 赞助展示中的 ChatGPT Pro 5x / 20x 公开价格与档位。
- 将支付方式修正为支付宝、USDT-BEP20（BSC）和 USDT-TRC20（TRON）。
- 补充 2–5 分钟人工处理、不索取密码/验证码/恢复码、订单可查等公开事实。
- 明确“赞助展示”、核对日期与“以实时页面为准”的边界。

## 改动范围
- [ ] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [x] Docs / Governance
- [ ] Workflow / Release

## 主要文件
- README.md

## 验证
- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：
```text
GitHub Markdown 预览正常；仅 README 一处赞助行变化；三个 UTM 链接可解析；价格、支付与交付口径已和 2026-08-08 公开页面核对。
```

未执行的验证与原因：
```text
未运行代码测试或构建：本次仅修改 README 文案与链接，不影响应用代码。
```

## 风险与影响面
- 低风险，仅 README；价格带核对日期，并明确以实时页面为准。
- 未修改商品、支付、交付或应用内赞助卡配置。

## 备注
- 当前公开赞助 API 中的应用内 AIXiamo 卡片仍含“微信”旧口径；该配置不在此仓库 README 中，需维护者在远端赞助配置中另行同步。
- 未包含敏感 token、cookie 或 API key。