### PR TITLE
fix(startup): fix main window initialization logic for hidden state / 修复主窗口初始化逻辑

### DIFF
--- a/apps/src-tauri/src/app_shell/lifecycle.rs
+++ b/apps/src-tauri/src/app_shell/lifecycle.rs
@@ -158,7 +158,10 @@ pub(crate) fn handle_main_window_event(window: &tauri::Window, event: &tauri::Wi
             return;
         }
 
-        if let Err(err) = window.app_handle().save_window_state(tauri_plugin_window_state::StateFlags::all()) {
+        if let Err(err) = window
+            .app_handle()
+            .save_window_state(crate::desktop_window_state_flags())
+        {
             log::warn!("save window state before close failed: {}", err);
         }
 

--- a/apps/src-tauri/src/app_shell/startup.rs
+++ b/apps/src-tauri/src/app_shell/startup.rs
@@ -1,7 +1,9 @@
 use crate::commands::settings::sync_window_runtime_state_from_settings;
 
 use super::state::TRAY_AVAILABLE;
-use super::window::{navigate_main_window_to_startup_app, request_show_main_window};
+use super::window::{
+    initialize_main_window, navigate_main_window_to_startup_app, request_show_main_window,
+};
 
 #[cfg(debug_assertions)]
 const DEV_SERVER_STARTUP_URL: &str = "http://127.0.0.1:3005/startup.html";
@@ -36,8 +38,13 @@ pub(crate) fn sync_startup_window_state() {
 pub(crate) fn schedule_startup_main_window(app: &tauri::AppHandle) {
     let tray_available = TRAY_AVAILABLE.load(std::sync::atomic::Ordering::Relaxed);
     let configured = codexmanager_service::current_show_main_window_on_startup_setting();
-    if !should_show_main_window_on_startup(configured, tray_available) {
-        log::info!("startup main window remains hidden by app setting");
+    if startup_main_window_action(configured, tray_available)
+        == StartupMainWindowAction::InitializeHidden
+    {
+        log::info!("startup main window remains hidden by app setting while initializing");
+        if !initialize_main_window(app) {
+            log::warn!("startup main window failed to initialize in the background");
+        }
         return;
     }
 
@@ -52,8 +59,18 @@ pub(crate) fn schedule_startup_main_window(app: &tauri::AppHandle) {
     });
 }
 
-fn should_show_main_window_on_startup(configured: bool, tray_available: bool) -> bool {
-    configured || !tray_available
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StartupMainWindowAction {
+    InitializeHidden,
+    Show,
+}
+
+fn startup_main_window_action(configured: bool, tray_available: bool) -> StartupMainWindowAction {
+    if configured || !tray_available {
+        StartupMainWindowAction::Show
+    } else {
+        StartupMainWindowAction::InitializeHidden
+    }
 }
 
 fn navigate_main_window_to_startup_app_when_ready(app: &tauri::AppHandle) {
@@ -117,16 +134,25 @@ fn wait_for_startup_webview_content() {}
 
 #[cfg(test)]
 mod tests {
-    use super::should_show_main_window_on_startup;
+    use super::{startup_main_window_action, StartupMainWindowAction};
 
     #[test]
     fn startup_window_respects_setting_when_tray_is_available() {
-        assert!(should_show_main_window_on_startup(true, true));
-        assert!(!should_show_main_window_on_startup(false, true));
+        assert_eq!(
+            startup_main_window_action(true, true),
+            StartupMainWindowAction::Show
+        );
+        assert_eq!(
+            startup_main_window_action(false, true),
+            StartupMainWindowAction::InitializeHidden
+        );
     }
 
     #[test]
     fn startup_window_is_shown_when_tray_is_unavailable() {
-        assert!(should_show_main_window_on_startup(false, false));
+        assert_eq!(
+            startup_main_window_action(false, false),
+            StartupMainWindowAction::Show
+        );
     }
 }

--- a/apps/src-tauri/src/app_shell/startup.rs
+++ b/apps/src-tauri/src/app_shell/startup.rs
@@ -44,7 +44,9 @@ pub(crate) fn schedule_startup_main_window(app: &tauri::AppHandle) {
         log::info!("startup main window remains hidden by app setting while initializing");
         if !initialize_main_window(app) {
             log::warn!("startup main window failed to initialize in the background");
+            return;
         }
+        schedule_startup_app_navigation(app.clone());
         return;
     }
 
@@ -54,9 +56,17 @@ pub(crate) fn schedule_startup_main_window(app: &tauri::AppHandle) {
             log::warn!("startup show main window request failed: {}", err);
             return;
         }
-        wait_for_startup_webview_content();
-        navigate_main_window_to_startup_app_when_ready(&app);
+        wait_for_startup_app_navigation(&app);
     });
+}
+
+fn schedule_startup_app_navigation(app: tauri::AppHandle) {
+    std::thread::spawn(move || wait_for_startup_app_navigation(&app));
+}
+
+fn wait_for_startup_app_navigation(app: &tauri::AppHandle) {
+    wait_for_startup_webview_content();
+    navigate_main_window_to_startup_app_when_ready(app);
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/apps/src-tauri/src/app_shell/window.rs
+++ b/apps/src-tauri/src/app_shell/window.rs
@@ -58,6 +58,19 @@ fn show_main_window(app: &tauri::AppHandle) -> bool {
     reveal_main_window(&main_window.window)
 }
 
+pub(crate) fn initialize_main_window(app: &tauri::AppHandle) -> bool {
+    if APP_EXIT_REQUESTED.load(Ordering::Relaxed) {
+        log::info!("initialize main window skipped because app exit is already requested");
+        return false;
+    }
+
+    let initialized = ensure_main_window(app).is_some();
+    if initialized {
+        log::info!("main window initialized in the background");
+    }
+    initialized
+}
+
 fn reveal_main_window(window: &tauri::WebviewWindow) -> bool {
     if let Err(err) = window.unminimize() {
         log::debug!("unminimize main window before show skipped: {}", err);

--- a/apps/src-tauri/src/lib.rs
+++ b/apps/src-tauri/src/lib.rs
@@ -35,6 +35,11 @@ struct UsageRefreshCompletedPayload {
     completed_at: i64,
 }
 
+fn desktop_window_state_flags() -> tauri_plugin_window_state::StateFlags {
+    tauri_plugin_window_state::StateFlags::all()
+        .difference(tauri_plugin_window_state::StateFlags::VISIBLE)
+}
+
 #[cfg(target_os = "linux")]
 fn is_known_ayatana_deprecation_notice(domain: Option<&str>, message: &str) -> bool {
     domain == Some(AYATANA_APPINDICATOR_LOG_DOMAIN)
@@ -80,7 +85,7 @@ pub fn run() {
     let app = tauri::Builder::default()
         .plugin(
             tauri_plugin_window_state::Builder::new()
-                .with_state_flags(tauri_plugin_window_state::StateFlags::all())
+                .with_state_flags(desktop_window_state_flags())
                 .build(),
         )
         .plugin(

--- a/apps/src-tauri/src/tests/lib_tests.rs
+++ b/apps/src-tauri/src/tests/lib_tests.rs
@@ -4,6 +4,7 @@ use crate::app_storage::{
 };
 use crate::commands::service::ensure_bind_target_available;
 use crate::commands::settings::effective_lightweight_mode_on_close_to_tray;
+use crate::desktop_window_state_flags;
 use crate::rpc_client::{normalize_addr, resolve_socket_addrs, rpc_call, rpc_call_with_sockets};
 use std::fs;
 use std::io::{Read, Write};
@@ -53,6 +54,17 @@ fn lightweight_close_to_tray_requires_close_to_tray_mode() {
     assert!(!effective_lightweight_mode_on_close_to_tray(false, true));
     assert!(!effective_lightweight_mode_on_close_to_tray(true, false));
     assert!(effective_lightweight_mode_on_close_to_tray(true, true));
+}
+
+#[test]
+fn startup_visibility_is_not_restored_from_window_state() {
+    let flags = desktop_window_state_flags();
+
+    assert!(!flags.contains(tauri_plugin_window_state::StateFlags::VISIBLE));
+    assert!(flags.contains(tauri_plugin_window_state::StateFlags::POSITION));
+    assert!(flags.contains(tauri_plugin_window_state::StateFlags::SIZE));
+    assert!(flags.contains(tauri_plugin_window_state::StateFlags::MAXIMIZED));
+    assert!(flags.contains(tauri_plugin_window_state::StateFlags::FULLSCREEN));
 }
 
 /// 函数 `rpc_call_tolerates_slow_response`


### PR DESCRIPTION
## 变更摘要

- 修复主窗口初始化逻辑，确保禁用了 启动时显示主界面 后，程序服务自动启用，窗口正常刷新

Follow on with #383

Fix #426, Fix #427

## 改动范围

- [x] Frontend
- [x] Desktop / Tauri
- [x] Service
- [ ] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- 

## 验证

- [x] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [x] `pnpm -C apps run test:ui`
- [x] `cargo test --workspace`
- [ ] 其他本地验证已说明

已执行的实际验证：

```text

```

未执行的验证与原因：

```text

```

## 风险与影响面

- 

## 备注

- 提交前请确认未包含敏感 token、cookie、API key
