### PR TITLE
docs: 优化 AIXiamo 国内 Plus / Pro 赞助入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,15 @@
   </tr>
   <tr>
     <td align="center" valign="middle" width="180">
-      <a href="https://www.aixiamo.com/chatgpt-pro?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=logo_pro_price_20260808">
+      <a href="https://www.aixiamo.com/?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=logo_brand_home_v3">
         <img src="assets/images/sponsors/aixiamo.jpg" alt="AI夏末 AIXiamo" width="120" />
       </a>
     </td>
     <td valign="top">
-      <strong><a href="https://www.aixiamo.com/chatgpt-pro?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_owner_price_20260808">AIXiamo（独立 AI 订阅服务，赞助展示）</a></strong>：截至 2026-08-08，ChatGPT Pro 5x（100 美元档）公开价 ¥719，20x（200 美元档）公开价 ¥1269；支持支付宝、USDT-BEP20（BSC）和 USDT-TRC20（TRON），无需海外银行卡。Pro 由人工按订单处理，顺利时通常约 2–5 分钟；不索取登录密码、验证码或恢复码，付款后订单与处理状态可查。可使用<a href="https://www.aixiamo.com/tools/chatgpt-pro-plan-calculator?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_calculator_price_20260808">用量选择器比较 Pro 5x / 20x</a>。价格、库存及支付方式可能调整，以实时页面为准。
+      <strong><a href="https://www.aixiamo.com/?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=brand_home_v3">AIXiamo 官网｜国内 ChatGPT Plus / Pro 本人账号正规充值</a></strong><br />
+      <strong>Codex 额度不够，Plus 还是 Pro？</strong> 日常使用和普通 Codex 选 <a href="https://www.aixiamo.com/chatgpt-plus-domestic-recharge?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=plus_owner_v3">Plus</a>；经常触顶或高频长任务，再比较 <a href="https://www.aixiamo.com/chatgpt-pro?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=pro_owner_v3">Pro 5x / 20x</a>。<br />
+      支持支付宝、无需海外银行卡；不索取密码、验证码或恢复码，订单可查、中文售后，充值不成功经核验后全额退款。持续运营三年多，线上线下累计服务数万名用户；另有 Claude Pro / Max、Gemini（Google AI Pro）、Grok / SuperGrok 等主流 AI 会员。<br />
+      欢迎企业采购对接；<a href="https://www.aixiamo.com/articles/aixiamo-invoice-application-notice-2026?utm_source=github&utm_medium=sponsor&utm_campaign=codex_manager&utm_content=invoice_notice_v3">已完成订单支持申请开具发票，请先联系售后确认</a>。
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## 变更摘要
- 将 AIXiamo 赞助文案调整为四行结构，便于 GitHub 桌面端和移动端扫读。
- 首行明确“国内 ChatGPT Plus / Pro 本人账号正规充值”。
- 为品牌首页、Plus、Pro 和企业开票说明设置独立可追踪链接。
- 移除易过期的固定价格快照和用量计算器入口。

## 改动范围
- [ ] Frontend
- [ ] Desktop / Tauri
- [ ] Service
- [ ] Gateway / Protocol Adapter
- [x] Docs / Governance
- [ ] Workflow / Release

## 主要文件
- `README.md`

## 验证
- [ ] `pnpm -C apps run test`
- [ ] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`
- [ ] `cargo test --workspace`
- [x] 其他本地验证已说明

已执行的实际验证：

```text
- GitHub README Preview 正常渲染赞助表格、粗体、换行和全部链接。
- 仅 README.md 的 AIXiamo 赞助行发生变化。
- 保持现有 Logo 文件和 width=120 展示尺寸不变。
```

未执行的验证与原因：

```text
纯文档变更，不涉及应用代码、构建、支付或运行逻辑。
```

## 风险与影响面
- 仅影响 README 赞助区的 AIXiamo 文案和出站链接。
- UTM campaign 保持 codex_manager，使用不同 utm_content 区分入口。
- 未修改其他赞助商、项目代码或图片资产。

## 备注
- 未包含 token、cookie、API key 或客户数据。
- 允许维护者编辑。
