### PR TITLE
fix(service):  WebSocket 模式下模型 Fast 策略不生效的问题

### DIFF
--- a/crates/service/src/http/responses_websocket.rs
+++ b/crates/service/src/http/responses_websocket.rs
@@ -288,13 +288,15 @@ async fn run_responses_websocket_session(mut socket: WebSocket, context: WsReque
         }
     };
 
-    let prepared_first = match rewrite_client_frame(first_text.as_str(), &context) {
-        Ok(prepared) => prepared,
-        Err(err) => {
-            send_ws_error_and_close(&mut socket, err, context.prefer_raw_errors).await;
-            return;
-        }
-    };
+    let prepared_first =
+        match rewrite_client_frame_with_model_fast_policy(first_text.as_str(), &context).await {
+            Ok(prepared) => prepared,
+            Err(err) => {
+                record_rejected_ws_request(&context, &err);
+                send_ws_error_and_close(&mut socket, err, context.prefer_raw_errors).await;
+                return;
+            }
+        };
 
     let mut first_log = begin_ws_request_log(
         &context,
@@ -383,7 +385,7 @@ async fn run_responses_websocket_session(mut socket: WebSocket, context: WsReque
                 };
                 match client_result {
                     Ok(Message::Text(text)) => {
-                        match rewrite_client_frame(text.as_str(), &context) {
+                        match rewrite_client_frame_with_model_fast_policy(text.as_str(), &context).await {
                             Ok(prepared) => {
                                 if let Some(previous_pending) = pending_request.take() {
                                     finalize_ws_request_log(
@@ -474,6 +476,21 @@ async fn run_responses_websocket_session(mut socket: WebSocket, context: WsReque
                                 pending_request = Some(current_pending);
                             }
                             Err(err) => {
+                                if let Some(previous_pending) = pending_request.take() {
+                                    finalize_ws_request_log(
+                                        &context,
+                                        &previous_pending.log,
+                                        Some(upstream.account_id.as_str()),
+                                        Some(upstream.upstream_url.as_str()),
+                                        499,
+                                        crate::gateway::RequestLogUsage::default(),
+                                        Some(crate::gateway::bilingual_error(
+                                            "WebSocket 请求因后续请求被拒绝而中止",
+                                            "websocket request aborted because the follow-up request was rejected",
+                                        )),
+                                    );
+                                }
+                                record_rejected_ws_request(&context, &err);
                                 send_ws_error_and_close(&mut socket, err, context.prefer_raw_errors).await;
                                 let _ = upstream.stream.close(None).await;
                                 break;
@@ -1022,6 +1039,105 @@ async fn receive_initial_request(socket: &mut WebSocket) -> Result<Option<String
     }
 }
 
+async fn rewrite_client_frame_with_model_fast_policy(
+    text: &str,
+    context: &WsRequestContext,
+) -> Result<PreparedClientFrame, WsSessionError> {
+    let text = text.to_string();
+    let context = context.clone();
+    tokio::task::spawn_blocking(move || {
+        let storage = open_storage().ok_or_else(|| {
+            WsSessionError::new(
+                500,
+                RESPONSES_WS_ERROR_CODE,
+                crate::gateway::bilingual_error("存储不可用", "storage unavailable"),
+            )
+        })?;
+        rewrite_client_frame_with_storage(text.as_str(), &context, &storage)
+    })
+    .await
+    .map_err(|err| {
+        WsSessionError::new(
+            500,
+            RESPONSES_WS_ERROR_CODE,
+            crate::gateway::bilingual_error(
+                "处理 WebSocket 模型策略任务失败",
+                format!("websocket model policy task failed: {err}"),
+            ),
+        )
+    })?
+}
+
+fn rewrite_client_frame_with_storage(
+    text: &str,
+    context: &WsRequestContext,
+    storage: &codexmanager_core::storage::Storage,
+) -> Result<PreparedClientFrame, WsSessionError> {
+    let mut prepared = rewrite_client_frame(text, context)?;
+    let Some(model_slug) = prepared
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(prepared);
+    };
+    let model = storage
+        .get_enabled_model_v2(model_slug)
+        .map_err(|err| {
+            WsSessionError::new(
+                500,
+                RESPONSES_WS_ERROR_CODE,
+                format!("model_catalog_v2_read_failed: {err}"),
+            )
+        })?
+        .ok_or_else(|| {
+            WsSessionError::new(
+                404,
+                "model_not_found",
+                format!("model_not_found: {model_slug}"),
+            )
+        })?;
+    let (body, applied) = crate::models_v2::fast_policy::apply(
+        prepared.text.as_bytes().to_vec(),
+        model.fast_policy,
+        prepared.has_service_tier_field,
+    )
+    .map_err(|_| {
+        WsSessionError::new(
+            400,
+            crate::models_v2::fast_policy::FAST_REQUEST_BLOCKED,
+            crate::gateway::bilingual_error(
+                format!("模型 {model_slug} 不允许 Fast 请求"),
+                format!("model {model_slug} does not allow Fast requests"),
+            ),
+        )
+    })?;
+    if !applied {
+        return Ok(prepared);
+    }
+
+    let value = serde_json::from_slice::<Value>(&body).map_err(|err| {
+        WsSessionError::bad_gateway_bilingual(
+            "读取模型 Fast 策略结果失败",
+            format!("parse model fast policy result failed: {err}"),
+        )
+    })?;
+    prepared.effective_service_tier = value
+        .get("service_tier")
+        .and_then(Value::as_str)
+        .and_then(crate::apikey::service_tier::normalize_service_tier_for_log)
+        .map(str::to_string);
+    prepared.service_tier_source = Some("model_policy".to_string());
+    prepared.text = String::from_utf8(body).map_err(|err| {
+        WsSessionError::bad_gateway_bilingual(
+            "序列化模型 Fast 策略结果失败",
+            format!("serialize model fast policy result failed: {err}"),
+        )
+    })?;
+    Ok(prepared)
+}
+
 fn rewrite_client_frame(
     text: &str,
     context: &WsRequestContext,
@@ -1455,7 +1571,13 @@ async fn wait_for_client_request_and_reconnect_upstream(
     let Some(text) = receive_initial_request(socket).await? else {
         return Ok(None);
     };
-    let prepared = rewrite_client_frame(text.as_str(), context)?;
+    let prepared = match rewrite_client_frame_with_model_fast_policy(text.as_str(), context).await {
+        Ok(prepared) => prepared,
+        Err(err) => {
+            record_rejected_ws_request(context, &err);
+            return Err(err);
+        }
+    };
     let mut pending = PendingWsRequestState {
         log: begin_ws_request_log(context, &prepared, "unresolved", "upstream_reconnect"),
         prepared,
@@ -2237,6 +2359,60 @@ fn begin_ws_request_log(
             prepared.text.as_bytes(),
         ),
     }
+}
+
+fn record_rejected_ws_request(context: &WsRequestContext, err: &WsSessionError) {
+    let trace_id = crate::gateway::next_trace_id();
+    let effective_protocol_type = crate::apikey_profile::resolve_gateway_protocol_type(
+        context.api_key.protocol_type.as_str(),
+        RESPONSES_ENDPOINT,
+    );
+    crate::gateway::log_request_start(
+        trace_id.as_str(),
+        context.api_key.id.as_str(),
+        "GET",
+        RESPONSES_ENDPOINT,
+        None,
+        None,
+        None,
+        true,
+        "ws",
+        effective_protocol_type,
+    );
+    let started_at = Instant::now();
+    if let Some(storage) = open_storage() {
+        crate::gateway::write_request_log(
+            &storage,
+            crate::gateway::RequestLogTraceContext {
+                trace_id: Some(trace_id.as_str()),
+                original_path: Some(RESPONSES_ENDPOINT),
+                adapted_path: Some(RESPONSES_ENDPOINT),
+                request_type: Some("ws"),
+                route_strategy: Some("unresolved"),
+                route_source: Some("local_validation"),
+                ..Default::default()
+            },
+            Some(context.api_key.id.as_str()),
+            None,
+            RESPONSES_ENDPOINT,
+            "GET",
+            None,
+            None,
+            None,
+            Some(err.status),
+            crate::gateway::RequestLogUsage::default(),
+            Some(err.message.as_str()),
+            Some(started_at.elapsed().as_millis()),
+        );
+    }
+    crate::gateway::log_request_final(
+        trace_id.as_str(),
+        err.status,
+        None,
+        None,
+        Some(err.message.as_str()),
+        started_at.elapsed().as_millis(),
+    );
 }
 
 fn should_buffer_ws_upstream_preamble(text: &str, buffered_count: usize) -> bool {

--- a/crates/service/src/http/responses_websocket_tests.rs
+++ b/crates/service/src/http/responses_websocket_tests.rs
@@ -3,12 +3,15 @@ use super::{
     inspect_ws_terminal_event, is_previous_response_not_found_terminal, merge_client_metadata,
     missing_ws_tool_call_from_terminal, parse_websocket_target, parse_ws_usage,
     prepare_missing_ws_tool_call_retry, proxy_basic_auth_header,
-    rebase_ws_request_for_account_change, rewrite_client_frame, should_buffer_ws_upstream_preamble,
-    strip_previous_response_id_from_ws_text, ws_request_has_tool_call_output,
-    CompletedWsToolCallCache, WsRequestContext, WsToolCallKind, WsUpstreamAuthorization,
+    rebase_ws_request_for_account_change, rewrite_client_frame, rewrite_client_frame_with_storage,
+    should_buffer_ws_upstream_preamble, strip_previous_response_id_from_ws_text,
+    ws_request_has_tool_call_output, CompletedWsToolCallCache, WsRequestContext, WsToolCallKind,
+    WsUpstreamAuthorization,
 };
 use axum::http::{HeaderMap, HeaderValue};
-use codexmanager_core::storage::{now_ts, Account, ApiKey, Storage, Token};
+use codexmanager_core::storage::{
+    now_ts, Account, ApiKey, ManagedModelV2Upsert, ModelFastPolicyV2, Storage, Token,
+};
 use serde_json::{json, Value};
 
 fn sample_api_key() -> ApiKey {
@@ -32,6 +35,139 @@ fn sample_api_key() -> ApiKey {
         aggregate_api_url: None,
         account_plan_filter: None,
     }
+}
+
+#[test]
+fn websocket_frame_applies_model_fast_policy() {
+    let storage = Storage::open_in_memory().expect("open storage");
+    storage.init().expect("init storage");
+    let context = WsRequestContext {
+        api_key: sample_api_key(),
+        incoming_headers: sample_incoming_headers(None, None),
+        prompt_cache_key: None,
+        effective_upstream_base: "https://chatgpt.com/backend-api/codex".to_string(),
+        prefer_raw_errors: false,
+    };
+
+    for (policy, client_tier, expected_upstream_tier, expected_source) in [
+        (
+            ModelFastPolicyV2::Passthrough,
+            Some("fast"),
+            Some("priority"),
+            Some("client_request"),
+        ),
+        (
+            ModelFastPolicyV2::Filter,
+            Some("fast"),
+            None,
+            Some("model_policy"),
+        ),
+        (
+            ModelFastPolicyV2::Force,
+            None,
+            Some("priority"),
+            Some("model_policy"),
+        ),
+        (ModelFastPolicyV2::Block, None, None, Some("unset")),
+    ] {
+        let mut model = storage
+            .get_managed_model_v2("gpt-5.4")
+            .expect("read managed model")
+            .expect("managed model");
+        model.fast_policy = policy;
+        storage
+            .upsert_managed_model_v2(&ManagedModelV2Upsert {
+                previous_slug: Some("gpt-5.4".to_string()),
+                model,
+            })
+            .expect("update model fast policy");
+
+        let mut frame = json!({
+            "type": "response.create",
+            "model": "gpt-5.4",
+            "input": "hello"
+        });
+        if let Some(client_tier) = client_tier {
+            frame["service_tier"] = Value::String(client_tier.to_string());
+        }
+        let prepared =
+            rewrite_client_frame_with_storage(frame.to_string().as_str(), &context, &storage)
+                .expect("rewrite websocket frame");
+        let value: Value = serde_json::from_str(&prepared.text).expect("parse rewritten frame");
+
+        assert_eq!(
+            value.get("service_tier").and_then(Value::as_str),
+            expected_upstream_tier,
+            "unexpected upstream service tier for {policy:?}"
+        );
+        assert_eq!(
+            prepared.service_tier_source.as_deref(),
+            expected_source,
+            "unexpected service tier source for {policy:?}"
+        );
+    }
+
+    let mut model = storage
+        .get_managed_model_v2("gpt-5.4")
+        .expect("read managed model")
+        .expect("managed model");
+    model.fast_policy = ModelFastPolicyV2::Block;
+    storage
+        .upsert_managed_model_v2(&ManagedModelV2Upsert {
+            previous_slug: Some("gpt-5.4".to_string()),
+            model,
+        })
+        .expect("update block policy");
+    let err = match rewrite_client_frame_with_storage(
+        r#"{"type":"response.create","model":"gpt-5.4","input":"hello","service_tier":"fast"}"#,
+        &context,
+        &storage,
+    ) {
+        Ok(_) => panic!("block policy must reject explicit fast request"),
+        Err(err) => err,
+    };
+    assert_eq!(err.status, 400);
+    assert_eq!(
+        err.code,
+        crate::models_v2::fast_policy::FAST_REQUEST_BLOCKED
+    );
+
+    let mut api_key_fast_context = context.clone();
+    api_key_fast_context.api_key.service_tier = Some("fast".to_string());
+    let prepared = rewrite_client_frame_with_storage(
+        r#"{"type":"response.create","model":"gpt-5.4","input":"hello"}"#,
+        &api_key_fast_context,
+        &storage,
+    )
+    .expect("block policy must allow API key injected fast tier");
+    let value: Value = serde_json::from_str(&prepared.text).expect("parse API key fast frame");
+    assert_eq!(
+        value.get("service_tier").and_then(Value::as_str),
+        Some("priority")
+    );
+
+    let mut overridden_model = storage
+        .get_managed_model_v2("gpt-5.4-mini")
+        .expect("read overridden managed model")
+        .expect("overridden managed model");
+    overridden_model.fast_policy = ModelFastPolicyV2::Filter;
+    storage
+        .upsert_managed_model_v2(&ManagedModelV2Upsert {
+            previous_slug: Some("gpt-5.4-mini".to_string()),
+            model: overridden_model,
+        })
+        .expect("update overridden model fast policy");
+    let mut model_override_context = context;
+    model_override_context.api_key.model_slug = Some("gpt-5.4-mini".to_string());
+    let prepared = rewrite_client_frame_with_storage(
+        r#"{"type":"response.create","model":"gpt-5.4","input":"hello","service_tier":"fast"}"#,
+        &model_override_context,
+        &storage,
+    )
+    .expect("apply final model fast policy");
+    let value: Value = serde_json::from_str(&prepared.text).expect("parse overridden model frame");
+    assert_eq!(prepared.model.as_deref(), Some("gpt-5.4-mini"));
+    assert!(value.get("service_tier").is_none());
 }
 
 fn sample_account() -> Account {

--- a/crates/service/src/http/tests/proxy_runtime_tests.rs
+++ b/crates/service/src/http/tests/proxy_runtime_tests.rs
@@ -7,7 +7,9 @@ use axum::body::{to_bytes, Body};
 use axum::extract::State;
 use axum::http::{header, HeaderMap, HeaderValue, Request as HttpRequest, StatusCode};
 use bytes::Bytes;
-use codexmanager_core::storage::{Account, ApiKey, Storage, Token, UsageSnapshotRecord};
+use codexmanager_core::storage::{
+    Account, ApiKey, ManagedModelV2Upsert, ModelFastPolicyV2, Storage, Token, UsageSnapshotRecord,
+};
 use futures_util::{SinkExt, StreamExt};
 use reqwest::Client;
 use std::collections::HashMap;
@@ -1121,6 +1123,95 @@ async fn hybrid_responses_websocket_returns_426() {
     server_handle.await.expect("join front proxy");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn official_responses_websocket_block_policy_rejects_initial_frame() {
+    let _guard = crate::test_env_guard();
+    let db_path = new_test_db_path("codexmanager-proxy-runtime-ws-block-initial");
+    let storage = init_test_storage(&db_path);
+    let _db_guard = EnvGuard::set("CODEXMANAGER_DB_PATH", db_path.to_string_lossy().as_ref());
+    insert_api_key_record(
+        &storage,
+        "platform_key_ws_block_initial",
+        crate::apikey_profile::ROTATION_ACCOUNT,
+        Some("http://127.0.0.1:1/chatgpt.com/backend-api/codex".to_string()),
+    );
+    let mut model = storage
+        .get_managed_model_v2("gpt-5.4-mini")
+        .expect("read websocket block model")
+        .expect("websocket block model");
+    model.fast_policy = ModelFastPolicyV2::Block;
+    storage
+        .upsert_managed_model_v2(&ManagedModelV2Upsert {
+            previous_slug: Some("gpt-5.4-mini".to_string()),
+            model,
+        })
+        .expect("update websocket initial block policy");
+    tokio::task::spawn_blocking(|| {
+        crate::gateway::reload_runtime_config_from_env();
+        let _ = crate::gateway::front_proxy_max_body_bytes();
+    })
+    .await
+    .expect("reload runtime config");
+
+    let state = ProxyState {
+        backend_base_url: "http://127.0.0.1:1".to_string(),
+        client: Client::new(),
+    };
+    let (front_addr, shutdown_tx, server_handle) = start_front_proxy_test_server(state).await;
+    let request = build_ws_request(
+        &format!("ws://{front_addr}/v1/responses"),
+        "platform_key_ws_block_initial",
+        &[("OpenAI-Beta", "responses_websockets=2026-02-06")],
+    );
+    let (mut client_ws, response) = connect_async(request).await.expect("websocket connects");
+    assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+
+    client_ws
+        .send(Message::Text(
+            serde_json::json!({
+                "type": "response.create",
+                "model": "gpt-4.1",
+                "input": "blocked initial request",
+                "service_tier": "fast"
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send blocked initial frame");
+    let event = tokio::time::timeout(Duration::from_secs(5), client_ws.next())
+        .await
+        .expect("blocked initial event timeout")
+        .expect("blocked initial event")
+        .expect("blocked initial event result");
+    let Message::Text(text) = event else {
+        panic!("expected blocked initial websocket error text frame");
+    };
+    let payload: serde_json::Value =
+        serde_json::from_str(text.as_str()).expect("parse blocked initial event");
+    assert_eq!(payload["type"], "error");
+    assert_eq!(payload["status"], 400);
+    assert_eq!(payload["error"]["code"], "fast_request_blocked");
+
+    let request_logs = storage
+        .list_request_logs(None, 10)
+        .expect("list blocked initial request logs");
+    let blocked_logs = request_logs
+        .iter()
+        .filter(|item| item.request_type.as_deref() == Some("ws"))
+        .collect::<Vec<_>>();
+    assert_eq!(blocked_logs.len(), 1);
+    assert_eq!(blocked_logs[0].status_code, Some(400));
+    assert!(blocked_logs[0]
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("does not allow Fast requests")));
+
+    let _ = client_ws.close(None).await;
+    let _ = shutdown_tx.send(());
+    server_handle.await.expect("join front proxy");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn official_responses_websocket_proxies_frames_and_headers() {
     let _guard = crate::test_env_guard();
@@ -1216,6 +1307,19 @@ async fn official_responses_websocket_proxies_frames_and_headers() {
         }
         other => panic!("unexpected first client event: {other:?}"),
     }
+
+    let mut model = storage
+        .get_managed_model_v2("gpt-5.4-mini")
+        .expect("read websocket model")
+        .expect("websocket model");
+    model.fast_policy = ModelFastPolicyV2::Filter;
+    storage
+        .upsert_managed_model_v2(&ManagedModelV2Upsert {
+            previous_slug: Some("gpt-5.4-mini".to_string()),
+            model,
+        })
+        .expect("update websocket model fast policy");
+
     client_ws
         .send(Message::Text(
             serde_json::json!({
@@ -1249,6 +1353,7 @@ async fn official_responses_websocket_proxies_frames_and_headers() {
         second_payload["client_metadata"]["x-codex-turn-metadata"],
         "turn_meta_ws_1"
     );
+    assert!(second_payload.get("service_tier").is_none());
     assert!(second_payload.get("prompt_cache_key").is_none());
 
     let second_client_event = tokio::time::timeout(Duration::from_secs(5), client_ws.next())
@@ -1354,6 +1459,44 @@ async fn official_responses_websocket_proxies_frames_and_headers() {
     );
     assert_eq!(capture.frames.len(), 2);
 
+    let mut model = storage
+        .get_managed_model_v2("gpt-5.4-mini")
+        .expect("read websocket model for block policy")
+        .expect("websocket model for block policy");
+    model.fast_policy = ModelFastPolicyV2::Block;
+    storage
+        .upsert_managed_model_v2(&ManagedModelV2Upsert {
+            previous_slug: Some("gpt-5.4-mini".to_string()),
+            model,
+        })
+        .expect("update websocket model block policy");
+
+    client_ws
+        .send(Message::Text(
+            serde_json::json!({
+                "type": "response.create",
+                "input": "blocked follow up",
+                "service_tier": "fast"
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send blocked websocket frame");
+    let blocked_client_event = tokio::time::timeout(Duration::from_secs(5), client_ws.next())
+        .await
+        .expect("blocked client event timeout")
+        .expect("blocked client event")
+        .expect("blocked client event result");
+    let Message::Text(blocked_text) = blocked_client_event else {
+        panic!("expected blocked websocket error text frame");
+    };
+    let blocked_payload: serde_json::Value =
+        serde_json::from_str(blocked_text.as_str()).expect("parse blocked websocket event");
+    assert_eq!(blocked_payload["type"], "error");
+    assert_eq!(blocked_payload["status"], 400);
+    assert_eq!(blocked_payload["error"]["code"], "fast_request_blocked");
+
     let request_logs = storage
         .list_request_logs(None, 10)
         .expect("list request logs");
@@ -1363,8 +1506,8 @@ async fn official_responses_websocket_proxies_frames_and_headers() {
         .collect();
     assert_eq!(
         ws_logs.len(),
-        2,
-        "expected two websocket request log entries"
+        3,
+        "expected two forwarded requests and one blocked request log entry"
     );
     assert!(
         ws_logs
@@ -1383,14 +1526,25 @@ async fn official_responses_websocket_proxies_frames_and_headers() {
         "expected follow-up websocket request without explicit service tier to stay empty"
     );
     assert!(
-        ws_logs
-            .iter()
-            .filter(|item| item.service_tier.is_none())
-            .any(|item| item.effective_service_tier.as_deref() == Some("fast")),
-        "expected follow-up websocket request to keep effective fast service tier"
+        ws_logs.iter().any(|item| {
+            item.service_tier.is_none()
+                && item.effective_service_tier.is_none()
+                && item.service_tier_source.as_deref() == Some("model_policy")
+        }),
+        "expected follow-up websocket request to apply the model filter policy"
+    );
+    assert!(
+        ws_logs.iter().any(|item| {
+            item.status_code == Some(400)
+                && item
+                    .error
+                    .as_deref()
+                    .is_some_and(|error| error.contains("does not allow Fast requests"))
+        }),
+        "expected blocked websocket request to be logged"
     );
 
-    client_ws.close(None).await.expect("close client websocket");
+    let _ = client_ws.close(None).await;
     let _ = shutdown_tx.send(());
     tokio::time::timeout(Duration::from_secs(5), server_handle)
         .await


### PR DESCRIPTION
## 变更摘要

- 修复 `/v1/responses` WebSocket 模式下模型 Fast 策略不生效的问题。
- 让 WebSocket 与 HTTP 路径保持一致，支持 `passthrough`、`filter`、`force` 和 `block`。
- 策略应用覆盖首次请求、同一连接的后续请求以及上游重连后的请求。
- 补充拒绝日志及对应的单元测试和真实 WebSocket 代理回归测试。

## 改动范围

- [ ] Frontend
- [ ] Desktop / Tauri
- [x] Service
- [x] Gateway / Protocol Adapter
- [ ] Docs / Governance
- [ ] Workflow / Release

## 主要文件

- `crates/service/src/http/responses_websocket.rs`
  - 在每次 `response.create` 中按最终模型应用 Fast 策略。
  - 使用阻塞任务读取 SQLite，避免阻塞 Tokio worker。
  - `block` 拒绝时返回结构化 WebSocket 错误并写入请求日志。
  - 后续请求被拒绝时，将尚未完成的前一请求记录为 499。
- `crates/service/src/http/responses_websocket_tests.rs`
  - 覆盖四种 Fast 策略、API Key 注入 Fast 和模型覆盖后的最终策略。
- `crates/service/src/http/tests/proxy_runtime_tests.rs`
  - 覆盖初始帧 `block`、同连接后续帧 `filter` 和 `block`，并验证请求日志。

## 验证

- [x] `pnpm -C apps run test`
- [x] `pnpm -C apps run build`
- [ ] `pnpm -C apps run test:ui`（已执行，34/36 通过）
- [ ] `cargo test --workspace`（已执行，1 条并行测试失败；隔离复跑通过）
- [x] 其他本地验证已说明

已执行的实际验证：

```text
WebSocket 相关测试：57/57 通过
HTTP Fast 策略集成测试：1/1 通过
codexmanager-service library：1383 通过，3 忽略
App settings：33/33 通过
Default address：10/10 通过
E2E：1/1 通过
cargo fmt --all -- --check：通过
git diff --check：通过

真实本地 API 验证：
- HTTP /v1/responses：成功
- WebSocket /v1/responses：成功
- passthrough：成功
- filter：成功，日志确认 Fast tier 被移除，来源为 model_policy
- force：成功，日志确认 Fast tier 由 model_policy 注入
- block：返回 400 / fast_request_blocked，并写入拒绝日志